### PR TITLE
Hotfix: Fix setuptools_scm missing dependency in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install build dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build twine
+        pip install build twine setuptools_scm
 
     - name: Verify git state for clean versioning
       run: |


### PR DESCRIPTION
# Hotfix: Fix v0.3.0 Release CI Failure

## Problem
The v0.3.0 release failed in the build-and-publish workflow with:
ModuleNotFoundError: No module named 'setuptools_scm'


## Root Cause
The release workflow was trying to determine the version using setuptools_scm before installing it as a dependency.

## Solution
- Added `setuptools_scm` to build dependencies in [.github/workflows/release.yml](cci:7://file:///c:/Users/dandrsantos/Documents/Profissional/skdr-eval/.github/workflows/release.yml:0:0-0:0)
- This ensures dynamic versioning works correctly in CI

## Impact
- Fixes the v0.3.0 release build failure
- Enables successful package publication to PyPI
- Ensures future releases work correctly

## Testing
This fix will be validated when the release workflow runs again after merging.
