### PR TITLE
Release v0.3.1: Fix CI build dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2025-08-13
+
+### Fixed
+- **CI Build Failure**: Added missing `setuptools_scm` dependency to release workflow
+- **Release Pipeline**: Fixed ModuleNotFoundError that prevented v0.3.0 from building successfully
+- **Package Publication**: Ensured dynamic versioning works correctly in GitHub Actions
+
+### Infrastructure
+- **Release Workflow**: Enhanced build dependencies to include all required packages for successful builds
+
 ## [0.3.0] - 2025-08-13
 
 ### Added


### PR DESCRIPTION
# Release v0.3.1: CI Build Dependencies Fix

This patch release fixes the CI build failure that prevented v0.3.0 from being published successfully.

## 🐛 Bug Fix

### CI Build Failure Resolution
- **Fixed**: Missing `setuptools_scm` dependency in release workflow
- **Added**: `setuptools_scm` to build dependencies in [.github/workflows/release.yml](cci:7://file:///c:/Users/dandrsantos/Documents/Profissional/skdr-eval/.github/workflows/release.yml:0:0-0:0)
- **Resolved**: ModuleNotFoundError that prevented package building

## 📋 Changes
- Updated release workflow to include all required build dependencies
- Ensures dynamic versioning works correctly in GitHub Actions
- Fixes the build-and-publish job that was failing for v0.3.0

## 🎯 Impact
- Enables successful package publication to PyPI
- Fixes the release pipeline for current and future releases
- Ensures setuptools-scm dynamic versioning works in CI

## 📋 Release Checklist
- [x] Changelog updated with patch release notes
- [x] CI build dependencies fixed
- [x] Ready for tagging and publication

This is a critical patch to fix the release infrastructure.