### PR TITLE
docs: finalize agent documentation system (canonical, GitHub, Claude layers)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,18 +1,18 @@
 # Claude-Specific Operational Guidance
 
-This file provides operational guidance for Claude agents working on \skdr-eval\.
+This file provides operational guidance for Claude agents working on `skdr-eval`.
 
 ## 1. Canonical Guidance
-- **Primary Reference**: The canonical shared guidance for all agents is in [\AGENTS.md\](../../AGENTS.md).
-- **Deep Context**: For architectural, workflow, and invariant rules, see [\docs/agent-context/\](../../docs/agent-context/).
+- **Primary Reference**: The canonical shared guidance for all agents is in [`AGENTS.md`](../AGENTS.md).
+- **Deep Context**: For architectural, workflow, and invariant rules, see [`docs/agent-context/`](../docs/agent-context/).
 
 ## 2. Claude-Specific Rules
-- **Statistical Integrity**: Claude agents must enforce all statistical invariants listed in [\docs/agent-context/invariants.md\](../../docs/agent-context/invariants.md).
+- **Statistical Integrity**: Claude agents must enforce all statistical invariants listed in [`docs/agent-context/invariants.md`](../docs/agent-context/invariants.md).
 - **Simulation Proofs**: Any change to statistical evaluation logic must include a simulation that proves the code recovers a known ground-truth parameter.
 
 ## 3. Workflow Integration
-- **Makefile Authority**: Always use \Makefile\ targets for workflows. Do not run ad-hoc commands.
-- **Validation**: Run \make validate\ before finalizing any PR.
+- **Makefile Authority**: Always use `Makefile` targets for workflows. Do not run ad-hoc commands.
+- **Validation**: Run `make validate` before finalizing any PR.
 
 ## 4. Documentation Governance
-- **Update Policy**: If code behavior changes, update the \examples/\ scripts first and the \README.md\ second to ensure they match.
+- **Update Policy**: If code behavior changes, update the `examples/` scripts first and the `README.md` second to ensure they match.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,19 +1,19 @@
 # Code Review Instructions for skdr-eval
 
-This file governs code review behavior, especially for GitHub Copilot and AI agents. For broader context and deeper guidance, see [\AGENTS.md\](../../AGENTS.md) and [\docs/agent-context/\](../../docs/agent-context/).
+This file governs code review behavior, especially for GitHub Copilot and AI agents. For broader context and deeper guidance, see [`AGENTS.md`](../AGENTS.md) and [`docs/agent-context/`](../docs/agent-context/).
 
 ## Review-Critical Rules
 
 ### 1. Statistical Integrity is Non-Negotiable
 - **Never accept PRs that remove or bypass cross-fitting, propensity stabilization, or other statistical safeguards**, even if justified by performance or simplification claims.
 - **Any change to statistical evaluation logic MUST include a simulation that proves the code recovers a known ground-truth parameter.** This is the definition of done.
-- See [\.github/instructions/src.instructions.md\](./instructions/src.instructions.md) for specific guardrails.
+- See [`.github/instructions/src.instructions.md`](./instructions/src.instructions.md) for specific guardrails.
 
 ### 2. Code and Documentation Must Be Reviewed Together
 - If a PR modifies a public API or function signature, verify that:
-  - The \examples/\ scripts are updated to match.
-  - The \README.md\ quick-start example is current.
-  - See [\docs/agent-context/review-checklist.md\](../../docs/agent-context/review-checklist.md).
+  - The `examples/` scripts are updated to match.
+  - The `README.md` quick-start example is current.
+  - See [`docs/agent-context/review-checklist.md`](../docs/agent-context/review-checklist.md).
 
 ### 3. Workflow, Invariant, and Architecture Changes Trigger Documentation Review
-- If a PR modifies CI/CD (\.github/workflows/\, \pyproject.toml\), the \Makefile\ and \scripts/validate_contribution.py\ must stay in sync.
+- If a PR modifies CI/CD (`.github/workflows/`, `pyproject.toml`), the `Makefile` and `scripts/validate_contribution.py` must stay in sync.

--- a/.github/instructions/src.instructions.md
+++ b/.github/instructions/src.instructions.md
@@ -1,15 +1,15 @@
 # Source-Specific Instructions for skdr-eval
 
-This file provides scoped instructions for AI agents working specifically on \src/skdr_eval/\.
+This file provides scoped instructions for AI agents working specifically on `src/skdr_eval/`.
 
 ## 1. Statistical Invariants
 - **Cross-fitting**: Never remove or bypass cross-fitting loops. Without cross-fitting, evaluating a model on the same data used to fit its nuisance parameters introduces severe bias.
-- **Propensity Clipping**: Do not remove or "simplify" the propensity score clipping logic. Reciprocals of near-zero propensities will cause variance to explode or result in \NaN\s.
+- **Propensity Clipping**: Do not remove or "simplify" the propensity score clipping logic. Reciprocals of near-zero propensities will cause variance to explode or result in `NaN`s.
 
 ## 2. Code Review Guardrails
 - **Simulation Proofs**: Any change to statistical evaluation logic must include a simulation that proves the code recovers a known ground-truth parameter.
-- **Invariant Checks**: Ensure that cross-fitting and propensity stabilization are not bypassed. See [\docs/agent-context/invariants.md\](../../docs/agent-context/invariants.md).
+- **Invariant Checks**: Ensure that cross-fitting and propensity stabilization are not bypassed. See [`docs/agent-context/invariants.md`](../../docs/agent-context/invariants.md).
 
 ## 3. Documentation Governance
-- **API Sync**: If a public function signature changes, update the \examples/\ scripts and \README.md\ quick-start example to match.
-- **Workflow Sync**: If CI/CD or toolchains change, ensure the \Makefile\ and \scripts/validate_contribution.py\ are updated to match.
+- **API Sync**: If a public function signature changes, update the `examples/` scripts and `README.md` quick-start example to match.
+- **Workflow Sync**: If CI/CD or toolchains change, ensure the `Makefile` and `scripts/validate_contribution.py` are updated to match.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,41 +1,41 @@
 # Agent Instructions: skdr-eval
 
-This is the primary routing and canonical guidance file for AI/coding agents interacting with \skdr-eval\.
+This is the primary routing and canonical guidance file for AI/coding agents interacting with `skdr-eval`.
 
 ## 1. Purpose and Architectural Intent
-\skdr-eval\ is a library for doubly robust (DR) and stabilized doubly robust (SNDR) evaluation of machine learning models.
-**Core Intent:** Statistical Correctness > Performance/Simplicity. Never compromise the math for execution speed. See [\docs/agent-context/architecture.md\](docs/agent-context/architecture.md).
+`skdr-eval` is a library for doubly robust (DR) and stabilized doubly robust (SNDR) evaluation of machine learning models.
+**Core Intent:** Statistical Correctness > Performance/Simplicity. Never compromise the math for execution speed. See [`docs/agent-context/architecture.md`](docs/agent-context/architecture.md).
 
 ## 2. Practical Repo Map
-- \src/skdr_eval/\: Core evaluation logic. Contains path-specific statistical invariants.
-- \examples/\: **Most trustworthy usage guide.** Script examples here are more reliable than markdown docs.
-- \scripts/\: Internal tools, notably \validate_contribution.py\.
-- \tests/\: Source of truth for edge cases and feature support.
-- \docs/agent-context/\: Deep context and architectural rules for agents.
+- `src/skdr_eval/`: Core evaluation logic. Contains path-specific statistical invariants.
+- `examples/`: **Most trustworthy usage guide.** Script examples here are more reliable than markdown docs.
+- `scripts/`: Internal tools, notably `validate_contribution.py`.
+- `tests/`: Source of truth for edge cases and feature support.
+- `docs/agent-context/`: Deep context and architectural rules for agents.
 
 ## 3. Domain Vocabulary
-- **\treatment\**: The action taken in the *historical* data logs.
-- **\policy\**: The action recommended by the *model* currently being evaluated.
+- **treatment**: The action taken in the *historical* data logs.
+- **policy**: The action recommended by the *model* currently being evaluated.
 *Warning: Confusing these will invert or invalidate evaluation results.*
 
 ## 4. Invariants & Pitfalls
-- **Trust Code > Docs**: Markdown files (like \README.md\ or \DEVELOPMENT.md\) are often aspirational and drift from reality. Always verify APIs against \src/\ type signatures and \examples/\.
-- Do not "simplify" complex logic without mathematical proof. See [\docs/agent-context/invariants.md\](docs/agent-context/invariants.md).
+- **Trust Code > Docs**: Markdown files (like `README.md` or `DEVELOPMENT.md`) are often aspirational and drift from reality. Always verify APIs against `src/` type signatures and `examples/`.
+- Do not "simplify" complex logic without mathematical proof. See [`docs/agent-context/invariants.md`](docs/agent-context/invariants.md).
 
 ## 5. Preferred Workflows & Commands
-- The \Makefile\ is the absolute authority for workflows. Do not run ad-hoc tool commands.
-- Run \make validate\ before finalizing any PR.
-- See [\docs/agent-context/workflows.md\](docs/agent-context/workflows.md).
+- The `Makefile` is the absolute authority for workflows. Do not run ad-hoc tool commands.
+- Run `make validate` before finalizing any PR.
+- See [`docs/agent-context/workflows.md`](docs/agent-context/workflows.md).
 
 ## 6. Definition of Done
 - Any change to statistical logic REQUIRES a simulation-based proof recovering a ground-truth parameter.
-- See [\docs/agent-context/review-checklist.md\](docs/agent-context/review-checklist.md).
+- See [`docs/agent-context/review-checklist.md`](docs/agent-context/review-checklist.md).
 
 ## 7. Documentation Governance & Map
-- **Update Policy**: If code behavior changes, update the \examples/\ scripts first and the \README.md\ second to ensure they match. 
+- **Update Policy**: If code behavior changes, update the `examples/` scripts first and the `README.md` second to ensure they match. 
 - For specific topic rules, consult the canonical files:
-  - Architecture: [\docs/agent-context/architecture.md\](docs/agent-context/architecture.md)
-  - Workflows: [\docs/agent-context/workflows.md\](docs/agent-context/workflows.md)
-  - Constraints: [\docs/agent-context/invariants.md\](docs/agent-context/invariants.md)
-  - Pattern Capture: [\docs/agent-context/lessons-learned.md\](docs/agent-context/lessons-learned.md)
-  - PR/Review: [\docs/agent-context/review-checklist.md\](docs/agent-context/review-checklist.md)
+  - Architecture: [`docs/agent-context/architecture.md`](docs/agent-context/architecture.md)
+  - Workflows: [`docs/agent-context/workflows.md`](docs/agent-context/workflows.md)
+  - Constraints: [`docs/agent-context/invariants.md`](docs/agent-context/invariants.md)
+  - Pattern Capture: [`docs/agent-context/lessons-learned.md`](docs/agent-context/lessons-learned.md)
+  - PR/Review: [`docs/agent-context/review-checklist.md`](docs/agent-context/review-checklist.md)

--- a/docs/agent-context/architecture.md
+++ b/docs/agent-context/architecture.md
@@ -5,9 +5,9 @@ Doubly robust (DR) and stabilized doubly robust (SNDR) estimation are inherently
 
 ## Why the Library Has Chosen This Boundary
 - **Input Layer**: Standard data structures (Pandas DataFrames, NumPy arrays). This follows scikit-learn conventions and reduces friction for users.
-- **Core Logic**: The cross-fitting and propensity-stabilization patterns are statistically necessary, not organizational preferences. See [\docs/agent-context/invariants.md\](docs/agent-context/invariants.md) for what must not be altered.
+- **Core Logic**: The cross-fitting and propensity-stabilization patterns are statistically necessary, not organizational preferences. See [`docs/agent-context/invariants.md`](./invariants.md) for what must not be altered.
 
 ## Why Complex-Looking Code Exists
-Functions like propensity score clipping (e.g., \_clip_propensities\) may look like arbitrary heuristics. They are required for variance stabilization in DR/SNDR and are grounded in statistical theory, not in ad-hoc tuning.
+Functions like propensity score clipping (e.g., the clipping logic in `dr_value_with_clip` in `src/skdr_eval/core.py`) may look like arbitrary heuristics. They are required for variance stabilization in DR/SNDR and are grounded in statistical theory, not in ad-hoc tuning.
 
-*(For specific implementation constraints that enforce this design, consult [\docs/agent-context/invariants.md\](docs/agent-context/invariants.md).)*
+*(For specific implementation constraints that enforce this design, consult [`docs/agent-context/invariants.md`](./invariants.md).)*

--- a/docs/agent-context/invariants.md
+++ b/docs/agent-context/invariants.md
@@ -2,15 +2,15 @@
 
 ## Mathematical Invariants (Do Not "Simplify")
 1. **Cross-fitting is Sacred**: Never remove or bypass cross-fitting loops to improve execution speed. Without cross-fitting, evaluating a model on the same data used to fit its nuisance parameters introduces severe bias.
-2. **Propensity Clipping / Stabilization**: Do not remove the propensity score clipping/bounding logic (e.g., \_clip_propensities\). Reciprocals of near-zero propensities will cause variance to explode or result in \NaN\s. It may look like arbitrary data manipulation, but it is mathematically required.
+2. **Propensity Clipping / Stabilization**: Do not remove the propensity score clipping/bounding logic (e.g., the `dr_value_with_clip` function and `w_clip` computation in `src/skdr_eval/core.py`). Reciprocals of near-zero propensities will cause variance to explode or result in `NaN`s. It may look like arbitrary data manipulation, but it is mathematically required.
 
 ## Implementation Guardrails
-- **Thresholds**: Constants like \DIRECT_STRATEGY_THRESHOLD\ exist to prevent Out-Of-Memory (OOM) errors during heavy dataframe operations. Do not blindly increase these limits or remove fallback strategies without explicit memory profiling.
+- **Thresholds**: Constants like `DIRECT_STRATEGY_THRESHOLD` exist to prevent Out-Of-Memory (OOM) errors during heavy dataframe operations. Do not blindly increase these limits or remove fallback strategies without explicit memory profiling.
 
 ## Domain Vocabulary (Hard Separation)
-- **\treatment\**: The action taken in the *historical* data (actual logs).
-- **\policy\**: The action recommended by the *model* currently being evaluated.
+- **treatment**: The action taken in the *historical* data (actual logs).
+- **policy**: The action recommended by the *model* currently being evaluated.
 - Confusing these in variable names, parameter names, or logic will invert or completely invalidate evaluation results.
 
 ## Governance
-- **Update Triggers**: If a new statistical stabilization method (e.g., a new clipping heuristic or bounds check) is added anywhere in \src/skdr_eval/\, it must be abstracted and listed here as a forbidden shortcut and rationale noted.
+- **Update Triggers**: If a new statistical stabilization method (e.g., a new clipping heuristic or bounds check) is added anywhere in `src/skdr_eval/`, it must be abstracted and listed here as a forbidden shortcut and rationale noted.

--- a/docs/agent-context/lessons-learned.md
+++ b/docs/agent-context/lessons-learned.md
@@ -3,7 +3,7 @@
 *(This file captures reusable patterns and traps to avoid, not a timeline of one-off incidents.)*
 
 ## Workflow: Promoting Lessons
-When agents or maintainers identify a recurring trap or misunderstanding in reviews/implementation, extract the underlying rule and record it here. If the rule is a hard operational boundary, move it directly to [\docs/agent-context/invariants.md\](docs/agent-context/invariants.md).
+When agents or maintainers identify a recurring trap or misunderstanding in reviews/implementation, extract the underlying rule and record it here. If the rule is a hard operational boundary, move it directly to [`docs/agent-context/invariants.md`](./invariants.md).
 
 ## Promotion Criteria
 A lesson is promoted here only when:
@@ -15,8 +15,8 @@ One-off incidents do not belong in durable guidance.
 ## Durable Patterns
 
 ### Pattern 1: Aspirational Documentation
-Markdown-based documentation in this repository (such as \README.md\ and \DEVELOPMENT.md\) sometimes describes planned features or unverified processes, rather than facts grounded in code and CI.
+Markdown-based documentation in this repository (such as `README.md` and `DEVELOPMENT.md`) sometimes describes planned features or unverified processes, rather than facts grounded in code and CI.
 
-**The Lesson**: When in doubt about an API call, workflow step, or process, verify against the source code (\src/\), the Makefile, the CI configuration, and the working scripts in \examples/\. Do not assume that a README example is correct or that a workflow described in narrative form is currently used.
+**The Lesson**: When in doubt about an API call, workflow step, or process, verify against the source code (`src/`), the Makefile, the CI configuration, and the working scripts in `examples/`. Do not assume that a README example is correct or that a workflow described in narrative form is currently used.
 
-**Implication for Docs**: After each code change, review whether \examples/\ scripts and readme examples still match the current API.
+**Implication for Docs**: After each code change, review whether `examples/` scripts and readme examples still match the current API.

--- a/docs/agent-context/review-checklist.md
+++ b/docs/agent-context/review-checklist.md
@@ -4,15 +4,15 @@ Use this checklist for self-validation before proposing changes, and for reviewi
 
 ## Statistical & Logic Changes
 - [ ] **Simulation Proof**: Does the PR modify, add, or "optimize" any statistical evaluation logic? **REQUIREMENT**: The PR must include a simulation or test that mathematically proves the new logic accurately recovers a known ground-truth parameter.
-- [ ] **Invariant Check**: Did this change bypass cross-fitting or propensity stabilization? (If yes, reject. See [\docs/agent-context/invariants.md\](docs/agent-context/invariants.md).)
+- [ ] **Invariant Check**: Did this change bypass cross-fitting or propensity stabilization? (If yes, reject. See [`docs/agent-context/invariants.md`](./invariants.md).)
 
 ## Code Quality & CI Readiness
-- [ ] **Validation**: Does \make validate\ pass locally with zero errors?
+- [ ] **Validation**: Does `make validate` pass locally with zero errors?
 
 ## Documentation Freshness & Governance
-- [ ] **API Sync**: If a public function signature in \src/\ changed, are the scripts in \examples/\ updated?
-- [ ] **README Sync**: If a public API changed, is the quickstart example in \README.md\ updated to match the working examples?
-- [ ] **Workflow Sync**: If CI or toolchains changed, is the \Makefile\ updated?
+- [ ] **API Sync**: If a public function signature in `src/` changed, are the scripts in `examples/` updated?
+- [ ] **README Sync**: If a public API changed, is the quickstart example in `README.md` updated to match the working examples?
+- [ ] **Workflow Sync**: If CI or toolchains changed, is the `Makefile` updated?
 
 ## Governance
 - **Update Triggers**: This checklist must be updated whenever the project adopts a new mandatory tool (e.g., an architectural linter) or experiences a severe regression that a new checklist item would have caught.

--- a/docs/agent-context/workflows.md
+++ b/docs/agent-context/workflows.md
@@ -1,17 +1,17 @@
 # Workflows and Authoritative Commands
 
 ## Single Source of Truth
-The \Makefile\ is the canonical source for all developer commands. Do not run ad-hoc \pytest\, \ruff\, or \mypy\ commands in isolation when a \Make\ target exists. Do not trust descriptive markdown text (\DEVELOPMENT.md\) if it contradicts the \Makefile\.
+The `Makefile` is the canonical source for all developer commands. Do not run ad-hoc `pytest`, `ruff`, or `mypy` commands in isolation when a `make` target exists. Do not trust descriptive markdown text (`DEVELOPMENT.md`) if it contradicts the `Makefile`.
 
 ## Core Commands
-- **Full PR Check**: \make validate\ (runs \scripts/validate_contribution.py\). This is the authoritative pre-submission check.
-- **Install (Dev)**: \make install-dev\
-- **Test with Coverage**: \make test-cov\
+- **Full PR Check**: `make validate` (runs `scripts/validate_contribution.py`). This is the authoritative pre-submission check.
+- **Install (Dev)**: `make install-dev`
+- **Test with Coverage**: `make test-cov`
 
 ## Standard Tasks
 ### Adding a Dependency
-1. Add the package to \pyproject.toml\ (under \dependencies\ or \optional-dependencies.dev\ as appropriate).
-2. Run \make install-dev\ to rebuild the environment.
+1. Add the package to `pyproject.toml` (under `dependencies` or `optional-dependencies.dev` as appropriate).
+2. Run `make install-dev` to rebuild the environment.
 
 ## Documentation Governance for Workflows
-- **Update Triggers**: If CI/CD steps in \.github/workflows/ci.yml\ change, you MUST update the corresponding \Makefile\ targets and/or \scripts/validate_contribution.py\ to match. The local \Make\ experience must mirror CI.
+- **Update Triggers**: If CI/CD steps in `.github/workflows/ci.yml` change, you MUST update the corresponding `Makefile` targets and/or `scripts/validate_contribution.py` to match. The local `make` experience must mirror CI.


### PR DESCRIPTION
### Summary

This PR finalizes the new documentation system for agent and developer workflows, as approved in the harmonization review. It implements the canonical, GitHub, and Claude layers:

- Canonical: AGENTS.md, docs/agent-context/* (architecture, invariants, workflows, lessons-learned, review-checklist)
- GitHub: .github/copilot-instructions.md, .github/instructions/src.instructions.md
- Claude: .claude/CLAUDE.md

#### What/Why
- Ensures one canonical home per durable fact
- Removes obsolete duplication (Claude rules/statistical-logic.md)
- Keeps GitHub and Claude layers thin and operational
- All internal references and governance rules are up to date

#### Testing
- All files verified present and correct
- Lint, format, and typecheck run (see below)
- Tests not run due to missing dependencies (see below)

#### Docs/AI Agent Instructions
- All agent instruction files updated as per plan
- No changes to README.md or examples/ required

#### Risks/Notes
- No code or API changes
- Typecheck and lint run; tests not run due to missing dependencies (sklearn, etc.)

---

- [x] Branch from develop
- [x] All doc/agent files updated
- [x] Lint/format/typecheck run
- [x] PR template used
