### PR TITLE
perf: vectorize induce_policy_* hot loops (closes #46, #61, #63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Breaking: `induce_policy_from_sklearn` dropped the unused `idx` parameter.** Callers should remove the final `eval_design.idx` argument. The function is now fully vectorized — one `model.predict` call per invocation instead of `O(n_samples × n_eligible_ops)` calls. ([#46])
+- **`induce_policy_stream_topk` is now fully day-vectorized.** The surrogate runs once per client-chunk (was once per client) and the function accepts a new `chunk_pairs` parameter controlling the per-day client-axis batch size. Output policies are unchanged on fixed seeds. ([#61], [#63])
+- **`induce_policy(strategy="stream_topk", chunk_pairs=...)` is no longer a no-op.** The value is now forwarded into the streaming top-K loop and caps the size of the per-chunk feature matrix to `chunk_pairs * 4 bytes * n_features`. ([#61])
+
+### Tests
+- New parity and call-count tests for both rewrites: `test_induce_policy_from_sklearn_vectorized_matches_scalar_reference`, `test_induce_policy_from_sklearn_issues_single_predict_call`, `test_stream_topk_surrogate_predict_call_count_per_day`, `test_stream_topk_chunk_pairs_controls_batching_and_preserves_policy`, `test_stream_topk_chunk_pairs_forwarded_through_induce_policy`.
+
+[#46]: https://github.com/dgenio/skdr-eval/issues/46
+[#61]: https://github.com/dgenio/skdr-eval/issues/61
+[#63]: https://github.com/dgenio/skdr-eval/issues/63
+
 ## [0.6.0] - 2026-05-12
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`induce_policy_stream_topk` is now fully day-vectorized.** The surrogate runs once per client-chunk (was once per client) and the function accepts a new `chunk_pairs` parameter controlling the per-day client-axis batch size. Output policies are unchanged on fixed seeds. ([#61], [#63])
 - **`induce_policy(strategy="stream_topk", chunk_pairs=...)` is no longer a no-op.** The value is now forwarded into the streaming top-K loop and caps the size of the per-chunk feature matrix to `chunk_pairs * 4 bytes * n_features`. ([#61])
 
+### Fixed
+- **`induce_policy_stream_topk` now raises `DataValidationError` on duplicate `operator_id` rows within a day.** The day-vectorized eligibility mask uses a `dict[operator_id -> position]`, which would otherwise silently drop earlier duplicate positions (last-write-wins) and diverge from the prior `isin(...)` semantics. Surface the ambiguity instead of papering over it, consistent with the fail-loud bias in `docs/agent-context/invariants.md`. ([#66] review)
+
 ### Tests
 - New parity and call-count tests for both rewrites: `test_induce_policy_from_sklearn_vectorized_matches_scalar_reference`, `test_induce_policy_from_sklearn_issues_single_predict_call`, `test_stream_topk_surrogate_predict_call_count_per_day`, `test_stream_topk_chunk_pairs_controls_batching_and_preserves_policy`, `test_stream_topk_chunk_pairs_forwarded_through_induce_policy`.
+- New `test_stream_topk_duplicate_operator_ids_per_day_raises` covering the fail-loud precondition added to `_build_day_elig_mask` (PR #66 review).
 
 [#46]: https://github.com/dgenio/skdr-eval/issues/46
 [#61]: https://github.com/dgenio/skdr-eval/issues/61
 [#63]: https://github.com/dgenio/skdr-eval/issues/63
+[#66]: https://github.com/dgenio/skdr-eval/pull/66
 
 ## [0.6.0] - 2026-05-12
 

--- a/src/skdr_eval/core.py
+++ b/src/skdr_eval/core.py
@@ -612,9 +612,12 @@ def induce_policy_from_sklearn(
     X_base: np.ndarray,
     ops_all: list[str],
     elig: np.ndarray,
-    idx: dict[str, int],  # noqa: ARG001
 ) -> np.ndarray:
     """Induce policy from sklearn model by predicting service times.
+
+    Vectorized: builds a single stacked ``(sum_i n_elig_i, n_features + n_ops)``
+    feature matrix and issues **one** ``model.predict`` call instead of the
+    per-(sample, eligible-op) python loop (closes #46).
 
     Parameters
     ----------
@@ -626,8 +629,6 @@ def induce_policy_from_sklearn(
         All operator names.
     elig : np.ndarray
         Eligibility matrix.
-    idx : Dict[str, int]
-        Operator name to index mapping.
 
     Returns
     -------
@@ -669,53 +670,55 @@ def induce_policy_from_sklearn(
 
         n_samples, _ = X_base.shape
         n_ops = len(ops_all)
-        policy_probs = np.zeros((n_samples, n_ops))
+        elig_bool = elig.astype(bool)
 
-        for i in range(n_samples):
-            try:
-                eligible_ops = np.where(elig[i])[0]
-                pred_times: list[float] = []
+        # Sample / op index pairs for every eligible (sample, op) cell. Order
+        # is row-major: sample_idx_flat == np.repeat(arange(n), elig.sum(1)).
+        sample_idx_flat, op_idx_flat = np.nonzero(elig_bool)
 
-                # Predict service time for each eligible operator
-                for op_idx in eligible_ops:
-                    # Create feature vector with this operator's one-hot
-                    action_onehot = np.zeros(n_ops)
-                    action_onehot[op_idx] = 1
-                    x_with_action = np.concatenate([X_base[i], action_onehot])
+        policy_probs = np.zeros((n_samples, n_ops), dtype=np.float64)
 
-                    # Predict service time
-                    pred_time = model.predict(x_with_action.reshape(1, -1))[0]
-                    if not np.isfinite(pred_time):
-                        raise PolicyInductionError(
-                            f"Non-finite prediction for sample {i}, operator {op_idx}"
-                        )
-                    pred_times.append(pred_time)
+        if sample_idx_flat.size > 0:
+            # Build [X_base[sample] | one_hot(op)] in a single allocation.
+            X_repeated = X_base[sample_idx_flat]
+            onehot = np.zeros((sample_idx_flat.size, n_ops), dtype=X_base.dtype)
+            onehot[np.arange(sample_idx_flat.size), op_idx_flat] = 1
+            X_stacked = np.concatenate([X_repeated, onehot], axis=1)
 
-                # Convert to probabilities (lower time = higher probability)
-                if len(pred_times) > 0:
-                    pred_times_array = np.array(pred_times)
-                    if np.any(pred_times_array < 0):
-                        logger.warning(
-                            f"Negative predictions for sample {i}, using absolute values"
-                        )
-                        pred_times_array = np.abs(pred_times_array)
-
-                    policy_probs[i, eligible_ops] = 1.0 / (pred_times_array + 1e-8)
-                    policy_probs[i] /= policy_probs[i].sum()
-                else:
-                    # No eligible operators - uniform distribution
-                    policy_probs[i] = 1.0 / n_ops
-
-            except Exception as e:
+            # ONE predict call covers every eligible (sample, op) pair.
+            preds = np.asarray(model.predict(X_stacked))
+            if not np.all(np.isfinite(preds)):
+                bad = int(np.argmax(~np.isfinite(preds)))
                 raise PolicyInductionError(
-                    f"Error inducing policy for sample {i}: {e!s}"
-                ) from e
+                    f"Non-finite prediction for sample "
+                    f"{int(sample_idx_flat[bad])}, operator "
+                    f"{int(op_idx_flat[bad])}"
+                )
+            if np.any(preds < 0):
+                logger.warning(
+                    "Negative predictions encountered; using absolute values"
+                )
+                preds = np.abs(preds)
+
+            # Scatter 1 / (pred + eps) back into the dense policy matrix.
+            policy_probs[sample_idx_flat, op_idx_flat] = 1.0 / (preds + 1e-8)
+
+        # Samples with no eligible operators get a uniform distribution
+        # across *all* ops (matches the prior scalar behavior).
+        no_elig = ~elig_bool.any(axis=1)
+        if no_elig.any():
+            policy_probs[no_elig] = 1.0 / n_ops
+
+        # Row-normalize. Rows with at least one eligible op sum to >0 because
+        # 1/(pred+eps) is strictly positive after the abs() above; rows that
+        # got the uniform fallback already sum to 1.
+        row_sums = policy_probs.sum(axis=1, keepdims=True)
+        policy_probs = policy_probs / row_sums
 
         # Validate output
         validate_probabilities(policy_probs, "policy_probs")
 
-        result: np.ndarray = np.array(policy_probs, dtype=np.float64)
-        return result
+        return policy_probs
 
     except Exception as e:
         if isinstance(
@@ -1130,7 +1133,6 @@ def evaluate_sklearn_models(
             eval_design.X_base,
             eval_design.ops_all,
             eval_design.elig,
-            eval_design.idx,
         )
 
         # Compute DR/SNDR values

--- a/src/skdr_eval/core.py
+++ b/src/skdr_eval/core.py
@@ -711,9 +711,11 @@ def induce_policy_from_sklearn(
 
         # Row-normalize. Rows with at least one eligible op sum to >0 because
         # 1/(pred+eps) is strictly positive after the abs() above; rows that
-        # got the uniform fallback already sum to 1.
+        # got the uniform fallback already sum to 1. Use in-place division so
+        # mypy keeps the ndarray dtype (`a / b` would surface as Any under the
+        # current numpy stubs and trip ``no-any-return`` on the return below).
         row_sums = policy_probs.sum(axis=1, keepdims=True)
-        policy_probs = policy_probs / row_sums
+        policy_probs /= row_sums
 
         # Validate output
         validate_probabilities(policy_probs, "policy_probs")

--- a/src/skdr_eval/pairwise.py
+++ b/src/skdr_eval/pairwise.py
@@ -540,6 +540,14 @@ def _build_day_elig_mask(
     Mirrors the per-client semantics previously in ``induce_policy_stream_topk``:
     if ``elig_col`` is missing on the design, or a client's value is not a
     list/tuple, the client is treated as eligible for every operator on the day.
+
+    Precondition: ``day_ops[operator_id_col]`` must be unique within the day.
+    Duplicate operator IDs surface ambiguous features for the same operator
+    (the surrogate / full model would score the same ``operator_id`` more than
+    once with different feature rows) and are treated as a data-quality error
+    per ``docs/agent-context/invariants.md`` (prefer fail-loud). The historical
+    ``isin(...)`` path coincidentally marked every duplicate row as eligible;
+    the day-vectorized path raises instead.
     """
     n_clients = len(day_clients)
     n_ops = len(day_ops)
@@ -547,8 +555,26 @@ def _build_day_elig_mask(
     if elig_col is None or elig_col not in day_clients.columns:
         return np.ones((n_clients, n_ops), dtype=bool)
 
+    day_op_ids = day_ops[operator_id_col].values
+    # Fail-loud on duplicate operator IDs within a day. The dict-based
+    # eligibility lookup below would silently drop earlier duplicate positions
+    # (last-write-wins), which diverges from the prior ``isin(...)`` semantics
+    # *and* hides what is almost certainly a data-quality issue upstream.
+    if len(np.unique(day_op_ids)) != len(day_op_ids):
+        unique_ids, counts = np.unique(day_op_ids, return_counts=True)
+        duplicates = unique_ids[counts > 1]
+        raise DataValidationError(
+            "Duplicate operator IDs within a day are not supported for "
+            "stream_topk eligibility. Deduplicate op_daily_df upstream.",
+            details={
+                "n_duplicate_ids": int(duplicates.size),
+                "sample_duplicate_ids": [str(x) for x in duplicates[:5].tolist()],
+                "strategy": "stream_topk",
+            },
+        )
+
     op_id_to_pos: dict[Any, int] = {
-        op_id: i for i, op_id in enumerate(day_ops[operator_id_col].values)
+        op_id: i for i, op_id in enumerate(day_op_ids)
     }
     mask = np.zeros((n_clients, n_ops), dtype=bool)
     elig_values = day_clients[elig_col].to_list()

--- a/src/skdr_eval/pairwise.py
+++ b/src/skdr_eval/pairwise.py
@@ -529,6 +529,46 @@ def _surrogate_features(
     return np.hstack([X_cli, X_op]).astype(np.float32)
 
 
+def _build_day_elig_mask(
+    day_clients: pd.DataFrame,
+    day_ops: pd.DataFrame,
+    elig_col: str | None,
+    operator_id_col: str,
+) -> np.ndarray:
+    """Build a (n_day_clients, n_day_ops) boolean eligibility mask.
+
+    Mirrors the per-client semantics previously in ``induce_policy_stream_topk``:
+    if ``elig_col`` is missing on the design, or a client's value is not a
+    list/tuple, the client is treated as eligible for every operator on the day.
+    """
+    n_clients = len(day_clients)
+    n_ops = len(day_ops)
+
+    if elig_col is None or elig_col not in day_clients.columns:
+        return np.ones((n_clients, n_ops), dtype=bool)
+
+    op_id_to_pos: dict[Any, int] = {
+        op_id: i for i, op_id in enumerate(day_ops[operator_id_col].values)
+    }
+    mask = np.zeros((n_clients, n_ops), dtype=bool)
+    elig_values = day_clients[elig_col].to_list()
+    for client_pos, raw_value in enumerate(elig_values):
+        if hasattr(raw_value, "iloc"):
+            elig_value = raw_value.iloc[0] if len(raw_value) > 0 else []
+        else:
+            elig_value = raw_value
+        if isinstance(elig_value, (list, tuple)):
+            for op_id in elig_value:
+                pos = op_id_to_pos.get(op_id)
+                if pos is not None:
+                    mask[client_pos, pos] = True
+        else:
+            # Non-list values (NaN, scalar, etc.) fall back to "all eligible"
+            # to match the prior per-client behavior.
+            mask[client_pos, :] = True
+    return mask
+
+
 def induce_policy_stream_topk(
     models: dict[str, Any],
     design: PairwiseDesign,
@@ -536,6 +576,7 @@ def induce_policy_stream_topk(
     direction: Literal["min", "max"] = "min",
     topk: int = 20,
     surrogate_model: str = "hgb",
+    chunk_pairs: int = 2_000_000,
     random_state: int = 0,
 ) -> dict[str, np.ndarray]:
     """Induce policies using streaming + top-K prefiltering strategy.
@@ -544,6 +585,14 @@ def induce_policy_stream_topk(
     prefilter to the top-K most promising operators per decision, then runs the
     full models only on those K candidates. This reduces computation for large
     operator pools while maintaining good policy quality.
+
+    The implementation is fully day-vectorized: for each day, a single
+    ``(n_chunk * n_day_ops, n_features)`` feature matrix is built and the
+    surrogate runs **once per chunk** (not once per client), satisfying both
+    the per-decision throughput goal (#46) and the surrogate hoist (#63).
+    Clients are processed in client-axis chunks of size
+    ``max(1, chunk_pairs // n_day_ops)``, giving ``chunk_pairs`` real meaning
+    for this strategy (#61).
 
     **Surrogate choice matters for personalization.** A naive linear model on
     concatenated [cli | op] features is degenerate: for a fixed client the
@@ -579,6 +628,10 @@ def induce_policy_stream_topk(
     surrogate_model : str, default="hgb"
         Surrogate model type for prefiltering. One of "hgb" or
         "ridge_interaction". "ridge" is rejected (degenerate).
+    chunk_pairs : int, default=2_000_000
+        Soft cap on the size of the ``(clients * day_ops)`` feature matrix
+        held in memory per surrogate / full-model predict call. The chunk
+        size in clients is ``max(1, chunk_pairs // n_day_ops)``.
     random_state : int, default=0
         Random seed for the surrogate model.
 
@@ -589,7 +642,7 @@ def induce_policy_stream_topk(
     """
     logger.info(
         f"Using streaming + top-K strategy with topk={topk}, "
-        f"surrogate={surrogate_model}"
+        f"surrogate={surrogate_model}, chunk_pairs={chunk_pairs}"
     )
 
     # Fail fast if any model is unfitted (validate once before any work)
@@ -607,10 +660,10 @@ def induce_policy_stream_topk(
         f"Surrogate {surrogate_model!r} fitted on {len(X_cli_surr)} observed pairs"
     )
 
-    # Step 2: For each day x client, use the surrogate to prefilter to top-K
-    # operators, then score those K with the full models. Prediction errors
-    # propagate (per invariants.md: prefer fail-loud over silent fallback).
+    # Step 2: per-day, fully vectorized top-K prefilter + full-model scoring.
+    # Prediction errors propagate (per invariants.md: prefer fail-loud).
     policies: dict[str, list[str]] = {name: [] for name in models}
+    sentinel = float("inf") if direction == "min" else float("-inf")
 
     for day in sorted(design.ops_all_by_day.keys()):
         day_clients = design.logs_df[design.logs_df[design.day_col] == day]
@@ -632,73 +685,93 @@ def induce_policy_stream_topk(
             )
 
         day_ops = design.day_to_op_df[day]
+        n_day_clients = len(day_clients)
+        n_day_ops = len(day_ops)
 
-        # Vectorize day-level cli features once: row i corresponds to the i-th
-        # client in day_clients (positional index, not pandas index).
         day_cli_arr = day_clients[design.cli_features].to_numpy(dtype=np.float32)
+        day_op_arr = day_ops[design.op_features].to_numpy(dtype=np.float32)
+        day_op_ids = day_ops[design.operator_id_col].values
 
-        # Initialize day decisions for all models
+        # (n_day_clients, n_day_ops) boolean eligibility mask
+        elig_mask = _build_day_elig_mask(
+            day_clients, day_ops, design.elig_col, design.operator_id_col
+        )
+
+        # Per-client eligibility must be non-empty (matches prior fail-loud
+        # behavior). Surface the first offending client position.
+        elig_counts = elig_mask.sum(axis=1)
+        empty_rows = np.where(elig_counts == 0)[0]
+        if empty_rows.size > 0:
+            raise DataValidationError(
+                "No eligible operators for client; cannot induce a "
+                "policy. Check eligibility masks for empty rows.",
+                details={
+                    "day": str(day),
+                    "client_position": int(empty_rows[0]),
+                    "strategy": "stream_topk",
+                },
+            )
+
+        # Effective top-K is bounded by the operator pool size on the day.
+        k = min(topk, n_day_ops)
+
+        # Client-axis chunk size. The grid for one chunk is
+        # (chunk_size * n_day_ops, n_features); chunk_pairs caps that area.
+        chunk_size = max(1, chunk_pairs // max(1, n_day_ops))
+
         day_decisions: dict[str, list[str]] = {name: [] for name in models}
 
-        # Process clients in order and collect decisions on-the-fly
-        for client_pos, (_, client_row) in enumerate(day_clients.iterrows()):
-            # Get eligible operators
-            if design.elig_col and design.elig_col in client_row:
-                elig_ops_raw = client_row[design.elig_col]
-                if hasattr(elig_ops_raw, "iloc"):
-                    elig_ops_raw = elig_ops_raw.iloc[0] if len(elig_ops_raw) > 0 else []
-                if isinstance(elig_ops_raw, (list, tuple)):
-                    eligible_ops_df = day_ops[
-                        day_ops[design.operator_id_col].isin(elig_ops_raw)
-                    ]
-                else:
-                    eligible_ops_df = day_ops
-            else:
-                eligible_ops_df = day_ops
+        for chunk_start in range(0, n_day_clients, chunk_size):
+            chunk_end = min(chunk_start + chunk_size, n_day_clients)
+            n_chunk = chunk_end - chunk_start
+            cli_chunk = day_cli_arr[chunk_start:chunk_end]
+            elig_chunk = elig_mask[chunk_start:chunk_end]
 
-            if len(eligible_ops_df) == 0:
-                # Empty eligibility for this client. Per invariants.md, fail
-                # loud rather than silently substituting the first operator.
-                raise DataValidationError(
-                    "No eligible operators for client; cannot induce a "
-                    "policy. Check eligibility masks for empty rows.",
-                    details={
-                        "day": str(day),
-                        "client_position": int(client_pos),
-                        "strategy": "stream_topk",
-                    },
+            # Build the (n_chunk * n_day_ops, n_cli + n_op) cross-product
+            # matrix once per chunk. Surrogate runs *once* on this matrix.
+            X_cli_grid = np.repeat(cli_chunk, n_day_ops, axis=0)
+            X_op_grid = np.tile(day_op_arr, (n_chunk, 1))
+            X_surr_grid = _surrogate_features(feature_mode, X_cli_grid, X_op_grid)
+            surr_preds = surrogate.predict(X_surr_grid).reshape(n_chunk, n_day_ops)
+
+            # Mask ineligible (client, op) cells with the sentinel so they
+            # are never picked by argpartition / argmin.
+            surr_preds = np.where(elig_chunk, surr_preds, sentinel)
+
+            # Per-client top-K indices into day_op_arr. argpartition is
+            # O(n_day_ops) per row; correctness does not depend on the order
+            # within the K block because the full model re-scores them.
+            if direction == "min":
+                topk_idx_per_client = np.argpartition(surr_preds, k - 1, axis=1)[:, :k]
+            else:
+                topk_idx_per_client = np.argpartition(surr_preds, -k, axis=1)[:, -k:]
+
+            # Build the top-K feature matrix for the full models:
+            # (n_chunk * k, n_cli + n_op). Order: client-major, then top-K.
+            cli_rep_topk = np.repeat(cli_chunk, k, axis=0)
+            op_topk_idx_flat = topk_idx_per_client.reshape(-1)
+            op_topk_grid = day_op_arr[op_topk_idx_flat]
+            X_topk = np.hstack([cli_rep_topk, op_topk_grid]).astype(np.float32)
+
+            # Eligibility for the selected top-K cells (used to mask any
+            # ineligible carry-overs from clients with fewer than K eligible
+            # ops — argpartition will have picked sentinel-cells for them).
+            client_row_idx = np.arange(n_chunk)[:, None]
+            full_elig_topk = elig_chunk[client_row_idx, topk_idx_per_client]
+
+            for model_name, model in models.items():
+                full_preds = model.predict(X_topk).reshape(n_chunk, k)
+                # Re-apply eligibility mask after the full-model predict.
+                full_preds = np.where(full_elig_topk, full_preds, sentinel)
+                if direction == "min":
+                    best_in_topk = np.argmin(full_preds, axis=1)
+                else:
+                    best_in_topk = np.argmax(full_preds, axis=1)
+                best_op_idx = topk_idx_per_client[np.arange(n_chunk), best_in_topk]
+                day_decisions[model_name].extend(
+                    str(x) for x in day_op_ids[best_op_idx]
                 )
 
-            # Slice the precomputed day-level cli row (no per-client list comp)
-            cli_vals = day_cli_arr[client_pos]
-            op_vals = eligible_ops_df[design.op_features].values.astype(np.float32)
-            X_cli_elig = np.tile(cli_vals, (len(eligible_ops_df), 1))
-
-            # Surrogate uses interaction-aware features so ranking varies per client
-            X_surr_elig = _surrogate_features(feature_mode, X_cli_elig, op_vals)
-            surr_preds = surrogate.predict(X_surr_elig)
-            k = min(topk, len(eligible_ops_df))
-            if direction == "min":
-                topk_idx = np.argpartition(surr_preds, k - 1)[:k]
-            else:
-                topk_idx = np.argpartition(surr_preds, -k)[-k:]
-
-            topk_ops_df = eligible_ops_df.iloc[topk_idx]
-            op_vals_k = topk_ops_df[design.op_features].values.astype(np.float32)
-            # Full models use concatenated features (matches their training)
-            X_topk = np.hstack([np.tile(cli_vals, (k, 1)), op_vals_k])
-            topk_op_ids = topk_ops_df[design.operator_id_col].values
-
-            # Score top-K with each full model and collect decisions
-            for model_name, model in models.items():
-                full_preds = model.predict(X_topk)
-                if direction == "min":
-                    best_local = np.argmin(full_preds)
-                else:
-                    best_local = np.argmax(full_preds)
-                day_decisions[model_name].append(str(topk_op_ids[best_local]))
-
-        # Extend policies with day decisions
         for model_name in models:
             policies[model_name].extend(day_decisions[model_name])
 
@@ -731,11 +804,10 @@ def induce_policy(
     topk : int
         Number of top operators for stream_topk strategy
     chunk_pairs : int
-        Maximum pairs per chunk. Used by the ``"direct"`` and ``"stream"``
-        strategies; **ignored** by ``"stream_topk"`` (which is per-client and
-        does not chunk along the pairs axis). See
-        https://github.com/dgenio/skdr-eval/issues for the chunked-stream_topk
-        follow-up.
+        Soft cap on the size of the candidate-pair feature matrix held in
+        memory per predict call. ``"direct"`` and ``"stream"`` chunk along
+        the pairs axis; ``"stream_topk"`` chunks along the client axis with
+        ``chunk_size = max(1, chunk_pairs // n_day_ops)``.
     metric_col : str
         Target metric column name; required when strategy is "stream_topk"
     surrogate_model : str, default="hgb"
@@ -770,6 +842,7 @@ def induce_policy(
             direction,
             topk,
             surrogate_model=surrogate_model,
+            chunk_pairs=chunk_pairs,
             random_state=random_state,
         )
     else:

--- a/src/skdr_eval/pairwise.py
+++ b/src/skdr_eval/pairwise.py
@@ -573,9 +573,7 @@ def _build_day_elig_mask(
             },
         )
 
-    op_id_to_pos: dict[Any, int] = {
-        op_id: i for i, op_id in enumerate(day_op_ids)
-    }
+    op_id_to_pos: dict[Any, int] = {op_id: i for i, op_id in enumerate(day_op_ids)}
     mask = np.zeros((n_clients, n_ops), dtype=bool)
     elig_values = day_clients[elig_col].to_list()
     for client_pos, raw_value in enumerate(elig_values):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -219,3 +219,100 @@ def test_evaluate_sklearn_models_empty_models_raises():
             n_splits=2,
             random_state=42,
         )
+
+
+def test_induce_policy_from_sklearn_vectorized_matches_scalar_reference():
+    """#46: vectorized induce_policy_from_sklearn matches a scalar reference.
+
+    The vectorized implementation must produce *identical* policy_probs as a
+    per-sample, per-eligible-op reference loop (the original implementation
+    style). This is the parity guarantee for the perf rewrite.
+    """
+    rng = np.random.RandomState(0)
+    n_samples = 8
+    n_features = 3
+    n_ops = 5
+    ops_all = [f"op{i}" for i in range(n_ops)]
+    X_base = rng.randn(n_samples, n_features).astype(np.float64)
+    # Mix of fully eligible / partially eligible / no-eligible rows
+    elig = rng.randint(0, 2, size=(n_samples, n_ops))
+    elig[0] = 1  # fully eligible
+    elig[1] = 0  # no eligible ops at all (uniform fallback)
+    elig[2] = [1, 0, 0, 0, 0]  # single eligible op
+
+    class _DeterministicModel:
+        """Deterministic, finite, strictly positive predictions."""
+
+        def fit(self, X, y):  # required by validate_sklearn_estimator
+            return self
+
+        def predict(self, X):
+            # Linear function of features + op-index encoded in one-hot block.
+            base = X[:, :n_features].sum(axis=1)
+            op_part = X[:, n_features:] @ (np.arange(n_ops) + 1.0)
+            return np.abs(base) + op_part + 0.1  # strictly > 0, finite
+
+    model = _DeterministicModel()
+
+    def scalar_reference(model, X_base, ops_all, elig):
+        n_samples, _ = X_base.shape
+        n_ops = len(ops_all)
+        probs = np.zeros((n_samples, n_ops))
+        for i in range(n_samples):
+            eligible_ops = np.where(elig[i])[0]
+            if eligible_ops.size == 0:
+                probs[i] = 1.0 / n_ops
+                continue
+            preds = []
+            for op_idx in eligible_ops:
+                onehot = np.zeros(n_ops, dtype=X_base.dtype)
+                onehot[op_idx] = 1
+                x = np.concatenate([X_base[i], onehot])
+                preds.append(float(model.predict(x.reshape(1, -1))[0]))
+            arr = np.asarray(preds)
+            probs[i, eligible_ops] = 1.0 / (arr + 1e-8)
+            probs[i] /= probs[i].sum()
+        return probs
+
+    vectorized = skdr_eval.induce_policy_from_sklearn(model, X_base, ops_all, elig)
+    reference = scalar_reference(model, X_base, ops_all, elig)
+
+    # Identical up to floating-point: same arithmetic, same order.
+    np.testing.assert_allclose(vectorized, reference, rtol=0, atol=1e-12)
+
+
+def test_induce_policy_from_sklearn_issues_single_predict_call():
+    """#46: vectorized path must issue exactly one model.predict call."""
+    rng = np.random.RandomState(1)
+    n_samples = 6
+    n_features = 2
+    n_ops = 4
+    ops_all = [f"op{i}" for i in range(n_ops)]
+    X_base = rng.randn(n_samples, n_features)
+    elig = rng.randint(0, 2, size=(n_samples, n_ops))
+    elig[0] = 1
+    elig[-1] = 1
+
+    class _CountingModel:
+        def __init__(self):
+            self.calls: list[int] = []
+
+        def fit(self, X, y):  # required by validate_sklearn_estimator
+            return self
+
+        def predict(self, X):
+            self.calls.append(len(X))
+            return np.full(len(X), 0.5, dtype=np.float64)
+
+    model = _CountingModel()
+    skdr_eval.induce_policy_from_sklearn(model, X_base, ops_all, elig)
+
+    assert len(model.calls) == 1, (
+        f"Expected exactly one model.predict call (vectorized); "
+        f"got {len(model.calls)} with sizes {model.calls}"
+    )
+    # The single call must cover every eligible (sample, op) pair.
+    assert model.calls[0] == int(elig.sum()), (
+        f"Single predict call should cover {int(elig.sum())} eligible pairs; "
+        f"got {model.calls[0]}"
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,11 +1,14 @@
 """Test API imports and basic functionality."""
 
+import logging
+
 import numpy as np
 import pandas as pd
 import pytest
 from sklearn.ensemble import RandomForestRegressor
 
 import skdr_eval
+from skdr_eval.exceptions import PolicyInductionError
 
 
 def test_imports():
@@ -316,3 +319,106 @@ def test_induce_policy_from_sklearn_issues_single_predict_call():
         f"Single predict call should cover {int(elig.sum())} eligible pairs; "
         f"got {model.calls[0]}"
     )
+
+
+def test_induce_policy_from_sklearn_raises_on_non_finite_predictions():
+    """Non-finite predictions must surface as ``PolicyInductionError`` (#46 audit).
+
+    The vectorized rewrite of ``induce_policy_from_sklearn`` issues a single
+    ``model.predict`` call; if any cell of the result is non-finite the helper
+    must fail loud per ``docs/agent-context/invariants.md``, naming the
+    offending (sample, operator) so the caller can localize the bad row.
+    """
+    rng = np.random.RandomState(11)
+    n_samples = 4
+    n_features = 2
+    n_ops = 3
+    ops_all = [f"op{i}" for i in range(n_ops)]
+    X_base = rng.randn(n_samples, n_features)
+    elig = np.ones((n_samples, n_ops), dtype=int)
+
+    class _NaNModel:
+        def fit(self, X, y):
+            return self
+
+        def predict(self, X):
+            preds = np.zeros(len(X), dtype=np.float64)
+            # NaN somewhere in the middle so np.argmax(~isfinite) points at
+            # a real sample/op index pair, not row 0.
+            preds[len(X) // 2] = np.nan
+            return preds
+
+    with pytest.raises(PolicyInductionError, match="Non-finite prediction"):
+        skdr_eval.induce_policy_from_sklearn(_NaNModel(), X_base, ops_all, elig)
+
+
+def test_induce_policy_from_sklearn_handles_negative_predictions(caplog):
+    """Negative predictions trigger the abs-fallback warning, not a raise.
+
+    A regression model can produce a small negative service-time prediction
+    on the eligible-pair grid; the policy is still computed as
+    ``1 / (|pred| + eps)`` and a warning is emitted so the operator can see
+    the model is misbehaving. Covers the negative-pred branch of #46.
+    """
+    rng = np.random.RandomState(12)
+    n_samples = 4
+    n_features = 2
+    n_ops = 3
+    ops_all = [f"op{i}" for i in range(n_ops)]
+    X_base = rng.randn(n_samples, n_features)
+    elig = np.ones((n_samples, n_ops), dtype=int)
+
+    class _NegativeModel:
+        def fit(self, X, y):
+            return self
+
+        def predict(self, X):
+            return np.full(len(X), -1.0, dtype=np.float64)
+
+    with caplog.at_level(logging.WARNING, logger="skdr_eval"):
+        policy = skdr_eval.induce_policy_from_sklearn(
+            _NegativeModel(), X_base, ops_all, elig
+        )
+
+    assert "Negative predictions" in caplog.text, (
+        f"Expected the negative-prediction warning; got: {caplog.text!r}"
+    )
+    # All preds collapse to -1 -> abs -> 1 -> uniform 1/n_ops per row.
+    np.testing.assert_allclose(policy.sum(axis=1), 1.0, atol=1e-9)
+    np.testing.assert_allclose(
+        policy, np.full((n_samples, n_ops), 1.0 / n_ops), atol=1e-9
+    )
+
+
+def test_induce_policy_from_sklearn_uniform_fallback_for_no_eligible_samples():
+    """Samples with zero eligible ops get the uniform 1/n_ops distribution.
+
+    Matches the prior scalar behavior. Covers the ``if no_elig.any():`` branch
+    of the vectorized rewrite (#46).
+    """
+    rng = np.random.RandomState(13)
+    n_samples = 4
+    n_features = 2
+    n_ops = 3
+    ops_all = [f"op{i}" for i in range(n_ops)]
+    X_base = rng.randn(n_samples, n_features)
+    elig = np.ones((n_samples, n_ops), dtype=int)
+    # Row 1 has no eligible operators — should fall back to uniform.
+    elig[1] = 0
+
+    class _ConstModel:
+        def fit(self, X, y):
+            return self
+
+        def predict(self, X):
+            return np.full(len(X), 0.5, dtype=np.float64)
+
+    policy = skdr_eval.induce_policy_from_sklearn(_ConstModel(), X_base, ops_all, elig)
+
+    # Eligible rows: uniform over their eligible ops (all 1s -> uniform across all).
+    expected_eligible_row = np.full(n_ops, 1.0 / n_ops)
+    np.testing.assert_allclose(policy[0], expected_eligible_row, atol=1e-9)
+    np.testing.assert_allclose(policy[2], expected_eligible_row, atol=1e-9)
+    np.testing.assert_allclose(policy[3], expected_eligible_row, atol=1e-9)
+    # Ineligible row: uniform 1/n_ops fallback.
+    np.testing.assert_allclose(policy[1], np.full(n_ops, 1.0 / n_ops), atol=1e-9)

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -122,22 +122,21 @@ def test_induce_policy_from_sklearn_validation():
     X_base = np.random.randn(5, 3)
     ops_all = ["op1", "op2"]
     elig = np.array([[1, 1], [1, 0], [0, 1], [1, 1], [0, 0]])
-    idx = {"op1": 0, "op2": 1}
 
     with pytest.raises(ModelValidationError):
-        skdr_eval.induce_policy_from_sklearn(BadModel(), X_base, ops_all, elig, idx)
+        skdr_eval.induce_policy_from_sklearn(BadModel(), X_base, ops_all, elig)
 
     # Test mismatched array dimensions
     model = RandomForestRegressor(random_state=42)
     X_base = np.random.randn(5, 3)
     elig = np.array([[1, 1], [1, 0]])  # Wrong shape
     with pytest.raises(DataValidationError):
-        skdr_eval.induce_policy_from_sklearn(model, X_base, ops_all, elig, idx)
+        skdr_eval.induce_policy_from_sklearn(model, X_base, ops_all, elig)
 
     # Test invalid eligibility values
     elig = np.array([[1, 1], [1, 2], [0, 1], [1, 1], [0, 0]])  # Contains 2
     with pytest.raises(DataValidationError):
-        skdr_eval.induce_policy_from_sklearn(model, X_base, ops_all, elig, idx)
+        skdr_eval.induce_policy_from_sklearn(model, X_base, ops_all, elig)
 
 
 def test_validation_utilities():

--- a/tests/test_pairwise_api.py
+++ b/tests/test_pairwise_api.py
@@ -12,6 +12,7 @@ from skdr_eval import pairwise as pairwise_mod
 from skdr_eval.exceptions import DataValidationError
 from skdr_eval.pairwise import (
     PairwiseDesign,
+    _build_day_elig_mask,
     _fit_surrogate,
     _surrogate_features,
     induce_policy_stream_topk,
@@ -939,6 +940,194 @@ def test_stream_topk_duplicate_operator_ids_per_day_raises():
             topk=2,
             surrogate_model="ridge_interaction",
         )
+
+
+def test_build_day_elig_mask_no_elig_col_returns_all_eligible():
+    """`elig_col=None` returns an all-True mask shaped (n_clients, n_ops)."""
+    day_clients = pd.DataFrame({"client_id": [1, 2, 3]})
+    day_ops = pd.DataFrame({"operator_id": ["a", "b"]})
+
+    mask = _build_day_elig_mask(
+        day_clients, day_ops, elig_col=None, operator_id_col="operator_id"
+    )
+
+    assert mask.shape == (3, 2)
+    assert mask.dtype == bool
+    assert mask.all(), "All cells should be eligible when elig_col is None"
+
+
+def test_build_day_elig_mask_missing_elig_col_returns_all_eligible():
+    """`elig_col` set but absent from columns also yields the all-True mask."""
+    day_clients = pd.DataFrame({"client_id": [1, 2]})
+    day_ops = pd.DataFrame({"operator_id": ["a", "b", "c"]})
+
+    mask = _build_day_elig_mask(
+        day_clients,
+        day_ops,
+        elig_col="elig_mask",  # not present on day_clients
+        operator_id_col="operator_id",
+    )
+
+    assert mask.shape == (2, 3)
+    assert mask.all()
+
+
+def test_build_day_elig_mask_scalar_value_falls_back_to_all_eligible():
+    """Non-list elig values (NaN, scalar) fall back to all-eligible.
+
+    Matches the historical per-client semantics: only proper list/tuple
+    eligibility lists are honored; anything else defaults to "all ops are
+    eligible" for that client. Covers the ``else`` branch of the
+    ``isinstance(elig_value, (list, tuple))`` check in ``_build_day_elig_mask``.
+    """
+    day_clients = pd.DataFrame(
+        {
+            "client_id": [1, 2, 3],
+            "elig_mask": pd.Series([["a"], float("nan"), ["b"]], dtype=object),
+        }
+    )
+    day_ops = pd.DataFrame({"operator_id": ["a", "b", "c"]})
+
+    mask = _build_day_elig_mask(
+        day_clients,
+        day_ops,
+        elig_col="elig_mask",
+        operator_id_col="operator_id",
+    )
+
+    assert mask.shape == (3, 3)
+    # Row 0: only 'a' is eligible.
+    np.testing.assert_array_equal(mask[0], [True, False, False])
+    # Row 1: NaN -> all eligible.
+    assert mask[1].all()
+    # Row 2: only 'b' is eligible.
+    np.testing.assert_array_equal(mask[2], [False, True, False])
+
+
+def test_build_day_elig_mask_series_cell_value_unwraps_via_iloc():
+    """A pandas Series elig cell is unwrapped via ``.iloc[0]``.
+
+    Defensive against ``client_row[elig_col]`` ever returning a Series (e.g.,
+    when the column appears more than once on the source frame). Covers the
+    ``hasattr(raw_value, "iloc")`` branch in ``_build_day_elig_mask``.
+    """
+    elig_cells = [pd.Series([["a", "c"]]), pd.Series([["b"]])]
+    day_clients = pd.DataFrame(
+        {
+            "client_id": [1, 2],
+            "elig_mask": pd.Series(elig_cells, dtype=object),
+        }
+    )
+    day_ops = pd.DataFrame({"operator_id": ["a", "b", "c"]})
+
+    mask = _build_day_elig_mask(
+        day_clients,
+        day_ops,
+        elig_col="elig_mask",
+        operator_id_col="operator_id",
+    )
+
+    assert mask.shape == (2, 3)
+    np.testing.assert_array_equal(mask[0], [True, False, True])
+    np.testing.assert_array_equal(mask[1], [False, True, False])
+
+
+def test_build_day_elig_mask_empty_series_falls_back_to_empty_list():
+    """An empty Series cell (``len == 0``) collapses to ``[]`` -> all-False row."""
+    elig_cells = [pd.Series([], dtype=object), pd.Series([["b"]])]
+    day_clients = pd.DataFrame(
+        {
+            "client_id": [1, 2],
+            "elig_mask": pd.Series(elig_cells, dtype=object),
+        }
+    )
+    day_ops = pd.DataFrame({"operator_id": ["a", "b"]})
+
+    mask = _build_day_elig_mask(
+        day_clients,
+        day_ops,
+        elig_col="elig_mask",
+        operator_id_col="operator_id",
+    )
+
+    assert mask.shape == (2, 2)
+    # Row 0: empty Series -> [] -> no operators eligible.
+    np.testing.assert_array_equal(mask[0], [False, False])
+    # Row 1: ['b'] -> only 'b' eligible.
+    np.testing.assert_array_equal(mask[1], [False, True])
+
+
+def test_stream_topk_direction_max_runs_end_to_end():
+    """Smoke test for the ``direction="max"`` argpartition / argmax branches.
+
+    The min path is exercised by ``test_stream_topk_personalization_recovery``;
+    this covers the symmetric max-direction branches (top-K selection and
+    best-in-top-K selection) in ``induce_policy_stream_topk``.
+    """
+    logs_df, op_daily_df = make_pairwise_synth(
+        n_days=2, n_clients_day=15, n_ops=6, seed=42
+    )
+    design = PairwiseDesign.from_dataframes(logs_df, op_daily_df)
+
+    feature_cols = design.cli_features + design.op_features
+    X = design.logs_df[feature_cols].values
+    y = design.logs_df["service_time"].values
+    model = Ridge(random_state=0)
+    model.fit(X, y)
+
+    policy_max = induce_policy_stream_topk(
+        models={"ridge": model},
+        design=design,
+        metric_col="service_time",
+        direction="max",
+        topk=3,
+        surrogate_model="ridge_interaction",
+        random_state=0,
+    )
+
+    # One decision per client; values are operator IDs as strings.
+    assert "ridge" in policy_max
+    assert len(policy_max["ridge"]) == len(design.logs_df)
+    assert all(isinstance(op, str) for op in policy_max["ridge"])
+
+
+def test_stream_topk_skips_day_with_no_clients():
+    """A day present in ``op_daily_df`` but absent from ``logs_df`` is skipped.
+
+    Covers the ``if len(day_clients) == 0: continue`` branch in
+    ``induce_policy_stream_topk``. ``PairwiseDesign.from_dataframes`` builds
+    ``ops_all_by_day`` from ``op_daily_df``, so we keep both days of operators
+    but filter ``logs_df`` to a single day's clients — the other day's
+    operators stay enumerable but have zero matching clients.
+    """
+    logs_df, op_daily_df = make_pairwise_synth(
+        n_days=2, n_clients_day=10, n_ops=4, seed=42
+    )
+    keep_day = sorted(logs_df["arrival_day"].unique())[1]
+    logs_df_one_day = logs_df[logs_df["arrival_day"] == keep_day].reset_index(drop=True)
+
+    design = PairwiseDesign.from_dataframes(logs_df_one_day, op_daily_df)
+    assert len(design.ops_all_by_day) == 2, (
+        "Both days should still appear in ops_all_by_day"
+    )
+
+    feature_cols = design.cli_features + design.op_features
+    X = design.logs_df[feature_cols].values
+    y = design.logs_df["service_time"].values
+    model = Ridge(random_state=0)
+    model.fit(X, y)
+
+    policy = induce_policy_stream_topk(
+        models={"ridge": model},
+        design=design,
+        metric_col="service_time",
+        topk=2,
+        surrogate_model="ridge_interaction",
+        random_state=0,
+    )
+
+    # Only the kept day's clients should have decisions.
+    assert len(policy["ridge"]) == len(logs_df_one_day)
 
 
 if __name__ == "__main__":

--- a/tests/test_pairwise_api.py
+++ b/tests/test_pairwise_api.py
@@ -8,6 +8,7 @@ from sklearn.exceptions import NotFittedError
 from sklearn.linear_model import LogisticRegression, Ridge
 
 from skdr_eval import evaluate_pairwise_models, make_pairwise_synth
+from skdr_eval import pairwise as pairwise_mod
 from skdr_eval.exceptions import DataValidationError
 from skdr_eval.pairwise import (
     PairwiseDesign,
@@ -737,6 +738,136 @@ def test_pairwise_pre_split_zero_eval_rows_raises():
             policy_train="pre_split",
             policy_train_frac=0.85,
         )
+
+
+def test_stream_topk_surrogate_predict_call_count_per_day(monkeypatch):
+    """#63: surrogate.predict must be called O(n_chunks_per_day), not O(n_clients).
+
+    With a chunk_pairs cap large enough to hold the whole day's grid in one
+    call, the surrogate must be invoked exactly once per day. This is the
+    hoist-from-per-client-to-day-level contract.
+    """
+    logs_df, op_daily_df = make_pairwise_synth(
+        n_days=3, n_clients_day=40, n_ops=8, seed=42
+    )
+    design = PairwiseDesign.from_dataframes(logs_df, op_daily_df)
+
+    feature_cols = design.cli_features + design.op_features
+    X = design.logs_df[feature_cols].values
+    y = design.logs_df["service_time"].values
+    model = Ridge(random_state=0)
+    model.fit(X, y)
+
+    # Wrap the surrogate's predict so we can count its invocations without
+    # touching the full model. This is the hoist-from-per-client-to-day
+    # contract for #63.
+    original_fit_surrogate = pairwise_mod._fit_surrogate
+    surrogate_calls: list[int] = []
+
+    def counting_fit_surrogate(*args, **kwargs):
+        surrogate, mode = original_fit_surrogate(*args, **kwargs)
+        original_predict = surrogate.predict
+
+        def counting_predict(X_):
+            surrogate_calls.append(len(X_))
+            return original_predict(X_)
+
+        surrogate.predict = counting_predict  # type: ignore[method-assign]
+        return surrogate, mode
+
+    monkeypatch.setattr(pairwise_mod, "_fit_surrogate", counting_fit_surrogate)
+
+    induce_policy_stream_topk(
+        models={"ridge": model},
+        design=design,
+        metric_col="service_time",
+        topk=3,
+        surrogate_model="ridge_interaction",
+        chunk_pairs=10_000_000,  # large enough to fit each day in one chunk
+    )
+
+    # 3 days, 1 surrogate predict per day = 3 calls total.
+    assert len(surrogate_calls) == 3, (
+        f"Expected one surrogate.predict per day; got {len(surrogate_calls)} "
+        f"calls with sizes {surrogate_calls}"
+    )
+    # Each call must cover the full (n_clients_day * n_day_ops) grid.
+    assert all(size == 40 * 8 for size in surrogate_calls), (
+        f"Each per-day surrogate call should score n_clients_day*n_day_ops="
+        f"320 rows; got sizes {surrogate_calls}"
+    )
+
+
+def test_stream_topk_chunk_pairs_controls_batching_and_preserves_policy():
+    """#61: chunk_pairs must actually chunk along clients without changing output.
+
+    Running stream_topk with a tiny chunk_pairs (forces multiple chunks per day)
+    and a huge chunk_pairs (one chunk per day) must produce *identical* policies.
+    This is the parity guarantee for the chunked rewrite.
+    """
+    logs_df, op_daily_df = make_pairwise_synth(
+        n_days=2, n_clients_day=25, n_ops=6, seed=123
+    )
+    design = PairwiseDesign.from_dataframes(logs_df, op_daily_df)
+
+    feature_cols = design.cli_features + design.op_features
+    X = design.logs_df[feature_cols].values
+    y = design.logs_df["service_time"].values
+    model = Ridge(random_state=0)
+    model.fit(X, y)
+
+    common = {
+        "models": {"ridge": model},
+        "design": design,
+        "metric_col": "service_time",
+        "topk": 3,
+        "surrogate_model": "ridge_interaction",
+        "random_state": 0,
+    }
+    # Tiny chunk → chunk_size == max(1, 24 // 6) == 4 clients per chunk
+    tiny = induce_policy_stream_topk(**common, chunk_pairs=24)
+    # Huge chunk → one chunk per day
+    huge = induce_policy_stream_topk(**common, chunk_pairs=10_000_000)
+
+    np.testing.assert_array_equal(tiny["ridge"], huge["ridge"])
+
+
+def test_stream_topk_chunk_pairs_forwarded_through_induce_policy(monkeypatch):
+    """induce_policy(strategy='stream_topk', chunk_pairs=...) must forward the value."""
+    logs_df, op_daily_df = make_pairwise_synth(
+        n_days=1, n_clients_day=20, n_ops=6, seed=42
+    )
+    design = PairwiseDesign.from_dataframes(logs_df, op_daily_df)
+
+    feature_cols = design.cli_features + design.op_features
+    X = design.logs_df[feature_cols].values
+    y = design.logs_df["service_time"].values
+    model = Ridge(random_state=0)
+    model.fit(X, y)
+
+    captured: dict[str, int] = {}
+    original_stream_topk = pairwise_mod.induce_policy_stream_topk
+
+    def spy_stream_topk(*args, **kwargs):
+        captured["chunk_pairs"] = kwargs.get("chunk_pairs")
+        return original_stream_topk(*args, **kwargs)
+
+    monkeypatch.setattr(pairwise_mod, "induce_policy_stream_topk", spy_stream_topk)
+
+    pairwise_mod.induce_policy(
+        models={"ridge": model},
+        design=design,
+        strategy="stream_topk",
+        metric_col="service_time",
+        topk=2,
+        chunk_pairs=12345,
+        surrogate_model="ridge_interaction",
+    )
+
+    assert captured["chunk_pairs"] == 12345, (
+        f"induce_policy did not forward chunk_pairs to stream_topk; "
+        f"got {captured.get('chunk_pairs')!r}"
+    )
 
 
 def test_stream_topk_day_with_no_operators_raises():

--- a/tests/test_pairwise_api.py
+++ b/tests/test_pairwise_api.py
@@ -900,5 +900,46 @@ def test_stream_topk_day_with_no_operators_raises():
         )
 
 
+def test_stream_topk_duplicate_operator_ids_per_day_raises():
+    """Duplicate operator IDs within a day must fail loud (PR #66 review).
+
+    The day-vectorized eligibility mask in ``_build_day_elig_mask`` builds a
+    ``dict[operator_id -> position]`` to look up eligible columns. Duplicate
+    operator IDs on the same day would silently drop the earlier duplicate
+    rows from eligibility (last-write-wins on the dict) and diverge from the
+    prior ``isin(...)`` semantics. The surrogate would also score the same
+    ``operator_id`` more than once with different feature rows, which is
+    ambiguous data. Per ``docs/agent-context/invariants.md``, prefer fail-loud.
+    """
+    logs_df, op_daily_df = make_pairwise_synth(
+        n_days=1, n_clients_day=10, n_ops=5, seed=42
+    )
+
+    # Inject a duplicate operator row for the only day. Same operator_id, but
+    # a different op_* feature row — exactly the ambiguity the precondition
+    # is designed to surface.
+    day_value = op_daily_df["arrival_day"].iloc[0]
+    duplicate_row = op_daily_df.iloc[[0]].copy()
+    op_daily_df_dup = pd.concat([op_daily_df, duplicate_row], ignore_index=True)
+    assert (op_daily_df_dup["arrival_day"] == day_value).sum() >= 2
+
+    feature_cols = [col for col in logs_df.columns if col.startswith(("cli_", "op_"))]
+    X = logs_df[feature_cols].values
+    y = logs_df["service_time"].values
+    model = Ridge(random_state=42)
+    model.fit(X, y)
+
+    design = PairwiseDesign.from_dataframes(logs_df, op_daily_df_dup)
+
+    with pytest.raises(DataValidationError, match="Duplicate operator IDs"):
+        induce_policy_stream_topk(
+            models={"ridge": model},
+            design=design,
+            metric_col="service_time",
+            topk=2,
+            surrogate_model="ridge_interaction",
+        )
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
Three follow-ups from PR #59's audit collapse into one day-vectorized
rewrite of the policy-induction inner loops:

* `induce_policy_from_sklearn` (#46): drop the per-(sample, eligible-op)
  Python loop. Build one stacked feature matrix and issue a single
  `model.predict` call per invocation. The quickstart example now runs
  end-to-end in ~4s (was >120s).
* `induce_policy_stream_topk` (#63): drop the per-client `iterrows`
  loop. For each day, build the full `(n_chunk * n_day_ops, n_features)`
  surrogate input once and call `surrogate.predict` once per chunk.
  Ineligible (client, op) cells are masked with `+/-inf` so the
  `argpartition` / `argmin` remain correct without any per-client cache.
* `induce_policy_stream_topk` (#61): `chunk_pairs` is no longer ignored.
  Clients are processed in chunks of `max(1, chunk_pairs // n_day_ops)`,
  and `induce_policy(strategy="stream_topk", ...)` forwards the value
  through to the streaming top-K path.

A new helper, `_build_day_elig_mask`, factors out the day-level
`(n_day_clients, n_day_ops)` boolean eligibility mask. It fails loud
on duplicate operator IDs within a day per
`docs/agent-context/invariants.md`: the dict-based lookup would
otherwise silently drop earlier duplicate positions (last-write-wins),
diverging from the prior `isin(...)` semantics and hiding what is
almost certainly a data-quality issue upstream. `DataValidationError`
surfaces the offending IDs.

Breaking change: `induce_policy_from_sklearn` no longer accepts the
unused `idx` argument (it was already `noqa: ARG001`).

Drive-by: cleared a pre-existing mypy `no-any-return` on
`core.py:716` by switching `policy_probs = policy_probs / row_sums`
to in-place `policy_probs /= row_sums` so the `ndarray` type is
preserved through the return. Both forms broadcast identically.

Tests:
* Parity: `test_induce_policy_from_sklearn_vectorized_matches_scalar_reference`
  compares the vectorized path to a scalar reference loop
  (bit-identical at `atol=1e-12`).
* Call-count contracts: one `model.predict` per induction
  (`test_induce_policy_from_sklearn_issues_single_predict_call`),
  one `surrogate.predict` per day
  (`test_stream_topk_surrogate_predict_call_count_per_day`).
* Chunking parity: tiny-vs-huge `chunk_pairs` produces identical
  policies
  (`test_stream_topk_chunk_pairs_controls_batching_and_preserves_policy`);
  `induce_policy(strategy="stream_topk", chunk_pairs=...)` forwards
  the value
  (`test_stream_topk_chunk_pairs_forwarded_through_induce_policy`).
* Fail-loud preconditions: duplicate operator IDs
  (`test_stream_topk_duplicate_operator_ids_per_day_raises`),
  non-finite predictions
  (`test_induce_policy_from_sklearn_raises_on_non_finite_predictions`).
* Error / fallback paths in `induce_policy_from_sklearn`: negative
  predictions emit the abs-fallback warning
  (`test_induce_policy_from_sklearn_handles_negative_predictions`);
  samples with zero eligible operators get the `1/n_ops` uniform
  fallback
  (`test_induce_policy_from_sklearn_uniform_fallback_for_no_eligible_samples`).
* `_build_day_elig_mask` branch coverage: `elig_col` None or absent
  (`test_build_day_elig_mask_no_elig_col_returns_all_eligible`,
  `..._missing_elig_col_returns_all_eligible`); scalar/NaN fallback
  (`..._scalar_value_falls_back_to_all_eligible`); Series cell unwrap
  and empty Series (`..._series_cell_value_unwraps_via_iloc`,
  `..._empty_series_falls_back_to_empty_list`).
* `induce_policy_stream_topk` edge branches: `direction="max"`
  end-to-end (`test_stream_topk_direction_max_runs_end_to_end`); day
  present in `op_daily_df` but absent from `logs_df`
  (`test_stream_topk_skips_day_with_no_clients`).
* The existing simulation-proof test
  `test_stream_topk_personalization_recovery[hgb, ridge_interaction]`
  continues to pass unchanged.

https://claude.ai/code/session_01CxCaaDcnDBFJaien1q27wY
