### PR TITLE
docs: repositioning, Colab notebooks, use-case gallery, Zenodo prep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,58 @@ jobs:
       run: |
         python examples/preflight.py
 
+  notebooks-smoke:
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install (dev extras include nbmake)
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[dev]
+
+    - name: Execute Colab quickstart notebooks via nbmake
+      run: |
+        python -m pytest --nbmake examples/notebooks/ \
+          --nbmake-timeout=300 \
+          --override-ini="addopts=" \
+          -p no:cacheprovider
+
+  use-cases-smoke:
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install (default extras only)
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+
+    - name: Run domain use-case scripts
+      run: |
+        python examples/use_cases/01_ecommerce_ranking.py
+        python examples/use_cases/02_ad_targeting.py
+        python examples/use_cases/03_healthcare_cate.py
+        python examples/use_cases/04_call_routing.py
+
   build:
     runs-on: ubuntu-latest
     needs: test

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,36 @@
+{
+  "title": "skdr-eval: Offline Policy Evaluation for sklearn-Compatible Models with Time-Aware Doubly Robust Estimators",
+  "description": "skdr-eval is a Python library for offline policy evaluation (OPE) of sklearn-compatible decision policies. It implements time-aware Doubly Robust (DR) and Stabilized Doubly Robust (SNDR) estimators with calibrated propensity scores, moving-block bootstrap confidence intervals, and a bundled EvaluationArtifact carrying per-decision diagnostics, clip-grid sensitivity, PSIS Pareto-k support-health, propensity calibration (ECE / Brier), and an HTML stakeholder card. Applications include recommender and ranking systems, ad targeting, uplift modeling, healthcare CATE, and any contextual-bandit setting where running a live A/B test on a candidate policy is impractical.",
+  "creators": [
+    {
+      "name": "Santos, Diogo",
+      "affiliation": ""
+    }
+  ],
+  "upload_type": "software",
+  "access_right": "open",
+  "license": "MIT",
+  "keywords": [
+    "offline policy evaluation",
+    "OPE",
+    "doubly robust",
+    "stabilized doubly robust",
+    "SNDR",
+    "counterfactual evaluation",
+    "contextual bandits",
+    "causal inference",
+    "treatment effects",
+    "ranking",
+    "recommender systems",
+    "scikit-learn",
+    "Python"
+  ],
+  "related_identifiers": [
+    {
+      "scheme": "url",
+      "identifier": "https://github.com/dgenio/skdr-eval",
+      "relation": "isSupplementTo",
+      "resource_type": "software"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Repositioning, onboarding, and citability sweep** ([#67], [#69], [#77], [#78], [#90], [#98]).
+  - **README**: rewrite the headline + opening paragraph for general-purpose
+    offline policy evaluation (was service-time-only); add a "When should I
+    use this?" plain-language section; add an Open-in-Colab badge table for
+    five quickstart notebooks; add a use-case gallery section pointing at the
+    new `examples/use_cases/` scripts; fix CI / Coverage / dev-clone badges
+    and URLs from `dandrsantos` to `dgenio`. ([#67], [#98])
+  - **`pyproject.toml`**: fix `[project.urls]` Homepage / Repository / Issues
+    to `dgenio/skdr-eval`; add Changelog / Documentation URLs; broaden
+    `description` from "service-time minimization" to general-purpose OPE;
+    broaden `keywords`. ([#67], [#98])
+  - **`examples/notebooks/`** (new) — five nbmake-tested Colab notebooks:
+    `01_quickstart`, `02_pairwise_quickstart`, `03_ecommerce_ranking`,
+    `04_ad_targeting`, `05_healthcare_cate`. Each is < 12 cells, runs in
+    under 60 s, opens directly in Colab via the README badge table. ([#69], [#90])
+  - **`examples/use_cases/`** (new) — four runnable domain walk-throughs:
+    `01_ecommerce_ranking.py`, `02_ad_targeting.py`, `03_healthcare_cate.py`,
+    `04_call_routing.py`. Each reuses the existing synth generators with
+    domain-flavored framing and stakeholder summaries. ([#78])
+  - **CI** — new `notebooks-smoke` job runs
+    `pytest --nbmake examples/notebooks/` on every PR; new `use-cases-smoke`
+    job runs the four domain scripts. Both gate on the `test` job so
+    notebook / example rot is caught at PR time. ([#69], [#78], [#90])
+  - **`Makefile`** — new `notebooks` and `use-cases` targets mirror the new
+    CI jobs locally; help text updated.
+  - **`CITATION.cff`** — bump `version` to `0.7.0`, fix URLs to
+    `dgenio/skdr-eval`, broaden keywords / abstract, add `identifiers` block
+    with a DOI placeholder, add a `preferred-citation` block. ([#77])
+  - **`.zenodo.json`** (new) — Zenodo metadata for the next tagged release
+    so the GitHub → Zenodo binding mints a concept DOI automatically. ([#77])
+  - **`docs/zenodo.md`** (new) — one-time maintainer checklist for the
+    GitHub → Zenodo binding. ([#77])
+  - **`docs/methods.md`** (new) — short methods-note outline (positioning vs.
+    Open Bandit Pipeline / SCOPE-RL / banditml; references). ([#77])
+- **`[notebooks]` optional extra** in `pyproject.toml` — installs
+  `jupyter`, `matplotlib`, `nbformat`, `nbclient` for users who want to run
+  the new notebooks locally (`pip install 'skdr-eval[notebooks]'`).
+- **`nbmake>=1.5` and `nbformat>=5.0`** added to the `[dev]` extra so CI
+  can execute the new notebook smoke job.
+
+### Changed
+- **`pyproject.toml`** `description` now reads "General-purpose offline policy
+  evaluation for sklearn-compatible models with time-aware Doubly Robust (DR)
+  and Stabilized DR (SNDR) estimators, calibrated propensities, and
+  stakeholder evaluation cards" — reflects the actual scope (no statistical
+  change).
+
+[#67]: https://github.com/dgenio/skdr-eval/issues/67
+[#69]: https://github.com/dgenio/skdr-eval/issues/69
+[#77]: https://github.com/dgenio/skdr-eval/issues/77
+[#78]: https://github.com/dgenio/skdr-eval/issues/78
+[#90]: https://github.com/dgenio/skdr-eval/issues/90
+[#98]: https://github.com/dgenio/skdr-eval/issues/98
+
 ## [0.8.0] - 2026-05-20
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 type: software
 title: "skdr-eval: Offline Policy Evaluation for sklearn-Compatible Models with Time-Aware Doubly Robust Estimators"
-version: "0.7.0"
-date-released: "2026-05-17"
+version: "0.8.0"
+date-released: "2026-05-20"
 url: "https://github.com/dgenio/skdr-eval"
 repository-code: "https://github.com/dgenio/skdr-eval"
 license: MIT
@@ -52,6 +52,6 @@ preferred-citation:
     - family-names: "Santos"
       given-names: "Diogo"
       email: "diogofcul@gmail.com"
-  version: "0.7.0"
+  version: "0.8.0"
   year: 2026
   url: "https://github.com/dgenio/skdr-eval"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,24 +1,57 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 type: software
-title: "skdr-eval: Offline Policy Evaluation for Service-Time Minimization"
-version: "0.1.0"
-date-released: "2024-08-12"
-url: "https://github.com/dandrsantos/skdr-eval"
-repository-code: "https://github.com/dandrsantos/skdr-eval"
+title: "skdr-eval: Offline Policy Evaluation for sklearn-Compatible Models with Time-Aware Doubly Robust Estimators"
+version: "0.7.0"
+date-released: "2026-05-17"
+url: "https://github.com/dgenio/skdr-eval"
+repository-code: "https://github.com/dgenio/skdr-eval"
 license: MIT
 authors:
   - family-names: "Santos"
     given-names: "Diogo"
     email: "diogofcul@gmail.com"
-    orcid: "https://orcid.org/0000-0000-0000-0000"
+identifiers:
+  - type: url
+    value: "https://github.com/dgenio/skdr-eval"
+    description: "GitHub repository"
+  # Zenodo DOI is minted on the next tagged release once the GitHub→Zenodo
+  # integration is enabled (see docs/zenodo.md). Replace the placeholder below
+  # with the concept DOI after the first Zenodo-archived release.
+  - type: doi
+    value: "10.5281/zenodo.0000000"
+    description: "Concept DOI (replace with real value after first Zenodo release)"
 keywords:
-  - "offline evaluation"
+  - "offline policy evaluation"
+  - "OPE"
   - "doubly robust"
-  - "bandits"
+  - "stabilized doubly robust"
+  - "SNDR"
+  - "counterfactual evaluation"
+  - "contextual bandits"
   - "causal inference"
-  - "policy evaluation"
+  - "treatment effects"
+  - "ranking"
+  - "recommender systems"
+  - "scikit-learn"
 abstract: >-
-  A Python library for offline policy evaluation using Doubly Robust (DR) and
-  Stabilized Doubly Robust (SNDR) estimators with time-aware splits and calibration
-  for service-time minimization problems.
+  skdr-eval is a Python library for offline policy evaluation (OPE) of
+  sklearn-compatible decision policies. It implements time-aware Doubly Robust
+  (DR) and Stabilized Doubly Robust (SNDR) estimators with calibrated
+  propensity scores, moving-block bootstrap confidence intervals, and a
+  bundled `EvaluationArtifact` carrying per-decision diagnostics, clip-grid
+  sensitivity, PSIS Pareto-k support-health, propensity calibration (ECE /
+  Brier), and an HTML stakeholder card. Applications include recommender and
+  ranking systems, ad targeting, uplift modeling, healthcare CATE, call
+  routing, and any contextual-bandit setting where running a live A/B test
+  on a candidate policy is impractical or risky.
+preferred-citation:
+  type: software
+  title: "skdr-eval: Offline Policy Evaluation for sklearn-Compatible Models with Time-Aware Doubly Robust Estimators"
+  authors:
+    - family-names: "Santos"
+      given-names: "Diogo"
+      email: "diogofcul@gmail.com"
+  version: "0.7.0"
+  year: 2026
+  url: "https://github.com/dgenio/skdr-eval"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for skdr-eval development
 
-.PHONY: help install install-dev clean lint format typecheck test test-cov build docs check validate smoke coverage-sim all
+.PHONY: help install install-dev clean lint format typecheck test test-cov build docs check validate smoke coverage-sim notebooks use-cases all
 
 # Default target
 help:
@@ -18,6 +18,9 @@ help:
 	@echo "  check        Run all quality checks (lint + typecheck + test)"
 	@echo "  validate     Run comprehensive contribution validation (AI agent friendly)"
 	@echo "  coverage-sim Run moving-block bootstrap coverage simulation (issues #81 #62)"
+	@echo "  smoke        Run examples/preflight.py and examples/quickstart.py"
+	@echo "  notebooks    Execute examples/notebooks/ via nbmake (needs [dev] extra)"
+	@echo "  use-cases    Run all examples/use_cases/*.py scripts"
 	@echo "  all          Run clean + check + build"
 
 # Installation targets
@@ -79,6 +82,20 @@ coverage-sim:
 smoke:
 	python examples/preflight.py
 	python examples/quickstart.py
+
+# Notebook smoke (mirrors CI notebooks-smoke job; requires [dev] for nbmake)
+notebooks:
+	python -m pytest --nbmake examples/notebooks/ \
+		--nbmake-timeout=300 \
+		--override-ini="addopts=" \
+		-p no:cacheprovider
+
+# Use-case smoke (mirrors CI use-cases-smoke job)
+use-cases:
+	python examples/use_cases/01_ecommerce_ranking.py
+	python examples/use_cases/02_ad_targeting.py
+	python examples/use_cases/03_healthcare_cate.py
+	python examples/use_cases/04_call_routing.py
 
 # Composite targets
 check: lint typecheck test smoke

--- a/README.md
+++ b/README.md
@@ -2,15 +2,53 @@
 
 [![PyPI version](https://badge.fury.io/py/skdr-eval.svg)](https://badge.fury.io/py/skdr-eval)
 [![Python versions](https://img.shields.io/pypi/pyversions/skdr-eval.svg)](https://pypi.org/project/skdr-eval/)
-[![CI](https://github.com/dandrsantos/skdr-eval/workflows/CI/badge.svg)](https://github.com/dandrsantos/skdr-eval/actions)
-[![Coverage](https://codecov.io/gh/dandrsantos/skdr-eval/branch/main/graph/badge.svg)](https://codecov.io/gh/dandrsantos/skdr-eval)
+[![CI](https://github.com/dgenio/skdr-eval/workflows/CI/badge.svg)](https://github.com/dgenio/skdr-eval/actions)
+[![Coverage](https://codecov.io/gh/dgenio/skdr-eval/branch/main/graph/badge.svg)](https://codecov.io/gh/dgenio/skdr-eval)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**Offline policy evaluation for service-time minimization using Doubly Robust (DR) and Stabilized Doubly Robust (SNDR) estimators with time-aware splits and calibration. Now with pairwise evaluation and autoscaling support.**
+**General-purpose offline policy evaluation (OPE) for sklearn-compatible models, with time-aware Doubly Robust (DR) and Stabilized Doubly Robust (SNDR) estimators, calibrated propensities, PSIS support-health, and a stakeholder evaluation card you can hand to a PM.**
+
+Try it in your browser — no install needed:
+
+| Notebook | Open in Colab |
+|---|---|
+| Quickstart (contextual-bandit OPE) | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/dgenio/skdr-eval/blob/main/examples/notebooks/01_quickstart.ipynb) |
+| Pairwise / autoscaling quickstart | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/dgenio/skdr-eval/blob/main/examples/notebooks/02_pairwise_quickstart.ipynb) |
+| E-commerce ranking use case | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/dgenio/skdr-eval/blob/main/examples/notebooks/03_ecommerce_ranking.ipynb) |
+| Ad targeting use case | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/dgenio/skdr-eval/blob/main/examples/notebooks/04_ad_targeting.ipynb) |
+| Healthcare CATE use case | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/dgenio/skdr-eval/blob/main/examples/notebooks/05_healthcare_cate.ipynb) |
 
 ## What is this?
 
-`skdr-eval` is a Python package for offline policy evaluation in service-time optimization scenarios. It implements state-of-the-art Doubly Robust (DR) and Stabilized Doubly Robust (SNDR) estimators with time-aware cross-validation and calibration. The package is designed for evaluating machine learning models that make decisions about service allocation, with special support for pairwise (client-operator) evaluation and autoscaling strategies.
+`skdr-eval` is a Python library for **offline policy evaluation** — estimating how well a candidate decision policy would have performed *from logged data alone*, without deploying it. It implements Doubly Robust (DR) and Stabilized Doubly Robust (SNDR) estimators on top of `scikit-learn`-protocol models, with first-class support for time-correlated logs, calibrated propensities, moving-block bootstrap confidence intervals, and a single bundled `EvaluationArtifact` that exposes per-decision diagnostics, clip-grid sensitivity, PSIS Pareto-k support-health, propensity calibration (ECE / Brier), and a renderable HTML stakeholder card.
+
+It started life as an internal tool for call-routing / service-time minimization (and still ships a pairwise / autoscaling layer for that use case), but the underlying machinery is general-purpose contextual-bandit OPE.
+
+## When should I use this?
+
+Reach for `skdr-eval` when **all** of the following are true:
+
+- You have **logged data** of the form `(context x, action a, reward y)` from a policy you no longer want to keep running unchanged.
+- You want to evaluate a **candidate policy** (a recommender, a ranker, a clinical decision rule, a routing model, an ad targeter) **before** A/B testing it, because A/B testing has a real cost (lost revenue, patient risk, SLA violations, operator overtime).
+- Your candidate policy is, or can be wrapped behind, a **scikit-learn-protocol** estimator — `fit` / `predict` (or `predict_proba`) is enough.
+- The logged decisions cover the actions the candidate policy *would* take with non-trivial probability (i.e., there is reasonable **overlap** / positivity). `skdr-eval` will warn you when overlap is thin via PSIS Pareto-k, ESS, and match-rate diagnostics.
+
+Typical use cases:
+
+- **Recommender / ranking systems** — evaluate a new model against logged session data.
+- **Ad targeting** — score a candidate bidding policy on Criteo-style counterfactual logs.
+- **Healthcare CATE** — compare a treatment-assignment rule to standard-of-care on retrospective records.
+- **Call routing / autoscaling** — choose between client-operator assignment policies on historical traffic (the original motivating use case, still first-class via `evaluate_pairwise_models`).
+- **Any contextual-bandit decision** where re-running history would be too expensive or risky to do live.
+
+If you need *slate* / top-K ranking estimators (Cascade-DR, Reward-Interaction IPS) or *MIPS* for very large action spaces, those are tracked on the roadmap (#75, #85) but not yet shipped.
+
+## Where to start
+
+- **Just want to see it work?** Click any "Open in Colab" badge above.
+- **Have logs already?** Skim [Quick Start](#quick-start) below; the standard / pairwise variants are both two screens long.
+- **Comparing against another OPE library?** See [`docs/methods.md`](docs/methods.md) for the positioning vs. Open Bandit Pipeline / SCOPE-RL / banditml.
+- **Looking for end-to-end examples by domain?** Browse [`examples/use_cases/`](examples/use_cases/) for runnable scripts (e-commerce ranking, ad targeting, healthcare CATE, call routing).
 
 ## Table of Contents
 
@@ -59,9 +97,15 @@ pip install skdr-eval[speed]
 
 For development:
 ```bash
-git clone https://github.com/dandrsantos/skdr-eval.git
+git clone https://github.com/dgenio/skdr-eval.git
 cd skdr-eval
 pip install -e .[dev]
+```
+
+To run the Colab quickstart notebooks locally:
+```bash
+pip install 'skdr-eval[notebooks]'
+jupyter notebook examples/notebooks/
 ```
 
 ## Quick Start
@@ -341,17 +385,42 @@ print(artifact.report[['model', 'estimator', 'V_hat', 'ci_lower', 'ci_upper']])
 
 ## Examples
 
-See `examples/quickstart.py` for a complete example, or run:
+`examples/` ships three kinds of runnable artifacts — pick the one that
+matches how you want to consume them:
+
+| Path | Format | Use when |
+|---|---|---|
+| [`examples/quickstart.py`](examples/quickstart.py) | `.py` | Headless / CI / no Jupyter installed. |
+| [`examples/quickstart_pairwise.py`](examples/quickstart_pairwise.py) | `.py` | Same, for the pairwise / autoscaling API. |
+| [`examples/preflight.py`](examples/preflight.py) | `.py` | One-shot capability + schema check before a long evaluation. |
+| [`examples/notebooks/`](examples/notebooks/) | `.ipynb` × 5 | Colab-runnable; click the badges at the top of this README. |
+| [`examples/use_cases/`](examples/use_cases/) | `.py` × 4 | Self-contained domain walk-throughs (e-commerce ranking, ad targeting, healthcare CATE, call routing). |
+
+CI exercises `examples/preflight.py`, `examples/quickstart.py`, every
+notebook in `examples/notebooks/`, and every script in
+`examples/use_cases/` on every PR — they cannot silently rot.
+
+To run a domain example locally:
 
 ```bash
-python examples/quickstart.py
+python examples/use_cases/01_ecommerce_ranking.py
+python examples/use_cases/02_ad_targeting.py
+python examples/use_cases/03_healthcare_cate.py
+python examples/use_cases/04_call_routing.py
+```
+
+To open the notebooks locally:
+
+```bash
+pip install 'skdr-eval[notebooks]'
+jupyter notebook examples/notebooks/
 ```
 
 ## Development
 
 ### Setup
 ```bash
-git clone https://github.com/dandrsantos/skdr-eval.git
+git clone https://github.com/dgenio/skdr-eval.git
 cd skdr-eval
 python -m venv .venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
@@ -408,14 +477,19 @@ If Trusted Publishing is not configured:
 If you use this software in your research, please cite:
 
 ```bibtex
-@software{santos2024skdr,
-  title = {skdr-eval: Offline Policy Evaluation for Service-Time Minimization},
-  author = {Santos, Diogo},
-  year = {2024},
-  url = {https://github.com/dandrsantos/skdr-eval},
-  version = {0.1.0}
+@software{santos2026skdreval,
+  title   = {{skdr-eval}: Offline Policy Evaluation for {sklearn}-Compatible Models with Time-Aware Doubly Robust Estimators},
+  author  = {Santos, Diogo},
+  year    = {2026},
+  url     = {https://github.com/dgenio/skdr-eval},
+  version = {0.7.0},
+  license = {MIT}
 }
 ```
+
+A Zenodo concept DOI is being minted on the next tagged release (see
+[`docs/zenodo.md`](docs/zenodo.md)); after that, `CITATION.cff` will carry
+the canonical DOI and replace the URL field above.
 
 ## License
 

--- a/docs/methods.md
+++ b/docs/methods.md
@@ -1,0 +1,103 @@
+# skdr-eval: methods note (draft outline)
+
+> Status: outline. After the Zenodo DOI is minted (see
+> [`zenodo.md`](zenodo.md)), this note can be polished and deposited on
+> arXiv as a 4–6 page methods note.
+
+## 1. Problem setting
+
+Off-policy evaluation (OPE) of a *target* decision policy `π(a | x)` from
+*logged* decisions made under a different *behavior* policy `π_b(a | x)`,
+where the action `a` is chosen for a context `x` and a reward `Y` is
+observed. The goal is to estimate the policy value
+`V(π) = E_x[ E_{a ∼ π(·|x)}[ E[Y | x, a] ] ]`
+*without* deploying `π` to live traffic.
+
+skdr-eval focuses on the practical subset of OPE that ships in production
+ML pipelines: time-correlated logs, sklearn-compatible estimators,
+propensities estimated from the same logs, and a deliverable HTML card a
+PM can read.
+
+## 2. Estimators
+
+- **Doubly Robust (DR)** — Robins, Rotnitzky & Zhao (1994). Per-decision:
+  `ψ_i = q̂(x_i, a_i^π) + w_i · (Y_i − q̂(x_i, a_i))` where
+  `w_i = π(a_i | x_i) / π̂_b(a_i | x_i)` is the calibrated importance
+  weight and `q̂` is the cross-fitted outcome model.
+- **Stabilized DR (SNDR)** — self-normalized variant that rescales the
+  residual term by `n / Σ_i w_i`. Lower variance when weights are large;
+  small bias from the ratio estimator.
+
+## 3. Trust-mode contributions
+
+`skdr-eval` does not invent new estimators. It adds, *around* the
+classical DR/SNDR machinery, a small toolkit that survives a real-world
+deployment review:
+
+- **Time-aware cross-fitting** with a configurable `gap` between train
+  and test folds (default `gap=1`), to defuse adjacent-row leakage.
+- **Calibrated propensities** (`fit_propensity_timecal`) — isotonic /
+  Platt calibration on a rolling validation slice; ECE and Brier scores
+  exposed on the artifact.
+- **PSIS Pareto-k support-health diagnostic** — Vehtari, Simpson, Gelman,
+  Yao & Gabry (JMLR 2024). Generalized-Pareto shape parameter of the
+  unclipped importance-weight tail; `k ≥ 0.5` is a caution, `k ≥ 0.7` is
+  a high-risk gate.
+- **Moving-block bootstrap CIs** that preserve time-series correlation
+  structure; a coverage-probability simulation harness (PR #100 / issue
+  #81) proves nominal coverage on iid, AR(1), and seasonal DGPs.
+- **Stakeholder evaluation card** — single HTML page bundling `V̂`,
+  CI, ESS, match_rate, clip-grid sparkline, support-health banner,
+  Pareto-k, ECE, top contributors / detractors.
+- **`EvaluationArtifact`** — typed (Pydantic v2) carrier for everything
+  above; round-trips to JSON and HTML; versioned schema (`SCHEMA_VERSION`).
+
+## 4. Relation to existing ecosystems
+
+- **Open Bandit Pipeline (OBP)** — shares the OPE goal; OBP is broader
+  (slate / cascade-DR / MIPS / pseudo-inverse out-of-the-box) but does
+  not focus on calibrated propensities, time-aware folds, or the
+  stakeholder card. `skdr-eval` does not currently ship slate estimators
+  (issue #75); MIPS is tracked in #85.
+- **SCOPE-RL** — full RL OPE / OPL toolkit. Different audience.
+  `skdr-eval` deliberately stays in contextual-bandit territory.
+- **banditml** — focused on the bandit *deployment* loop; complementary,
+  not overlapping.
+
+## 5. Reproducibility
+
+- Synthetic DGPs (`make_synth_logs`, `make_pairwise_synth`) are seeded
+  and ship with every install.
+- Simulation proofs of statistical correctness live under
+  `tests/test_*_simulation.py`; required by the project's
+  `docs/agent-context/review-checklist.md` for any change to a
+  statistical primitive.
+- `examples/notebooks/` and `examples/use_cases/` are exercised in CI
+  via `nbmake` and the existing `examples-smoke` job, so the
+  reproducibility surface does not silently rot.
+
+## 6. Open work
+
+Tracked on the public issue tracker and grouped by milestone:
+
+- **M2 surface** — Typer CLI (#89), `doctor` probe (#91),
+  per-group/slice evaluation (#87), Pydantic `EvaluationCard` schema
+  (#88), tracker protocol (#93).
+- **M2 estimators** — MIPS (#85), MRDR / SWITCH-DR / DRos composable
+  strategies (#86).
+- **M3 ecosystem** — slate / top-K estimators (#75), benchmark harness
+  (#94), OBP-style adapters (#35), public-dataset loaders (#70),
+  LLM-reranker recipe (#95).
+
+## References
+
+- Robins, Rotnitzky & Zhao (1994). Estimation of regression coefficients
+  when some regressors are not always observed. *JASA*.
+- Dudík, Langford & Li (2011). Doubly Robust Policy Evaluation and
+  Learning. *ICML*.
+- Vehtari, Simpson, Gelman, Yao & Gabry (2024). Pareto Smoothed
+  Importance Sampling. *JMLR* 25:1–58.
+- Naeini, Cooper & Hauskrecht (2015). Obtaining well calibrated
+  probabilities using Bayesian binning. *AAAI*.
+- Chernozhukov et al. (2018). Double / debiased machine learning for
+  treatment and structural parameters. *Econometrics Journal*.

--- a/docs/zenodo.md
+++ b/docs/zenodo.md
@@ -1,0 +1,53 @@
+# Minting a Zenodo DOI
+
+This document is the one-time, maintainer-only checklist for binding
+`skdr-eval` to [Zenodo](https://zenodo.org) so every tagged GitHub release
+gets archived with a citable DOI.
+
+## Why
+
+A non-trivial fraction of academic users will only cite — and therefore only
+*use* — a library that has a versioned DOI. The DOI also gives the project a
+permanent landing page independent of GitHub.
+
+## One-time setup (≈5 minutes)
+
+1. Sign in to <https://zenodo.org> with the GitHub identity that has admin
+   rights on `dgenio/skdr-eval` (free account; no fee).
+2. Open <https://zenodo.org/account/settings/github/> and click **"Sync now"**.
+3. Find `dgenio/skdr-eval` in the repository list and flip the toggle to **On**.
+   This authorizes Zenodo to listen for GitHub release webhooks on this repo.
+4. Confirm the metadata. Zenodo will use `.zenodo.json` at the repo root
+   (already present) as the source of truth for title, authors, keywords,
+   description, and license.
+
+## First release that gets a DOI
+
+The next tagged release (after `v0.7.0`) will automatically:
+
+1. Trigger the existing `release.yml` workflow.
+2. Notify Zenodo via the GitHub webhook.
+3. Archive the tagged source tree.
+4. Mint **two** DOIs:
+   - A *concept DOI* representing "all versions of skdr-eval".
+   - A *version DOI* specific to that release.
+
+## Post-mint follow-up
+
+Once the concept DOI is known, replace the placeholder in two files:
+
+- `CITATION.cff` — the `identifiers:` block (`type: doi`) currently holds
+  `10.5281/zenodo.0000000`. Replace with the real concept DOI.
+- `README.md` — add a Zenodo DOI badge under the existing PyPI / Coverage
+  badges (suggested badge URL pattern is provided on the Zenodo record
+  page).
+
+Open a small `chore: bind real Zenodo DOI` PR with both edits.
+
+## Methods note / preprint
+
+A short methods note describing what `skdr-eval` does differently from the
+broader OPE ecosystem (Open Bandit Pipeline, SCOPE-RL, banditml) is drafted
+in [`docs/methods.md`](methods.md). After the DOI is live, that note can be
+deposited on arXiv (cs.LG / stat.ML) and the arXiv ID added under
+`identifiers:` in `CITATION.cff`.

--- a/docs/zenodo.md
+++ b/docs/zenodo.md
@@ -23,7 +23,7 @@ permanent landing page independent of GitHub.
 
 ## First release that gets a DOI
 
-The next tagged release (after `v0.7.0`) will automatically:
+The next tagged release (after `v0.8.0`) will automatically:
 
 1. Trigger the existing `release.yml` workflow.
 2. Notify Zenodo via the GitHub webhook.

--- a/examples/notebooks/01_quickstart.ipynb
+++ b/examples/notebooks/01_quickstart.ipynb
@@ -29,7 +29,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --quiet skdr-eval scikit-learn"
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet skdr-eval scikit-learn"
    ]
   },
   {

--- a/examples/notebooks/01_quickstart.ipynb
+++ b/examples/notebooks/01_quickstart.ipynb
@@ -1,0 +1,165 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9247f271",
+   "metadata": {},
+   "source": [
+    "# skdr-eval — Quickstart\n",
+    "\n",
+    "Offline policy evaluation in one screen. This notebook generates\n",
+    "synthetic logs, evaluates two candidate sklearn policies with the\n",
+    "DR / SNDR estimators, and prints the stakeholder summary.\n",
+    "\n",
+    "👉 [Open in Colab](https://colab.research.google.com/github/dgenio/skdr-eval/blob/main/examples/notebooks/01_quickstart.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9f13708",
+   "metadata": {},
+   "source": [
+    "## 1. Install"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0202e85e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install --quiet skdr-eval scikit-learn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c5d7f26",
+   "metadata": {},
+   "source": [
+    "## 2. Build logs and candidate models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7d8b2a8c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.ensemble import HistGradientBoostingRegressor, RandomForestRegressor\n",
+    "\n",
+    "import skdr_eval\n",
+    "\n",
+    "logs, items, _ = skdr_eval.make_synth_logs(n=2000, n_ops=4, seed=0)\n",
+    "skdr_eval.validate_logs(logs)\n",
+    "\n",
+    "models = {\n",
+    "    \"RF\": RandomForestRegressor(n_estimators=80, random_state=0),\n",
+    "    \"HGB\": HistGradientBoostingRegressor(max_iter=80, random_state=0),\n",
+    "}\n",
+    "len(logs), list(items)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "738ec8f6",
+   "metadata": {},
+   "source": [
+    "## 3. Evaluate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89f19375",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact = skdr_eval.evaluate_sklearn_models(\n",
+    "    logs=logs,\n",
+    "    models=models,\n",
+    "    fit_models=True,\n",
+    "    n_splits=2,\n",
+    "    random_state=0,\n",
+    "    policy_train=\"pre_split\",\n",
+    "    policy_train_frac=0.8,\n",
+    ")\n",
+    "artifact.report[\n",
+    "    [\"model\", \"estimator\", \"V_hat\", \"ESS\", \"match_rate\", \"support_health\"]\n",
+    "].round(4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e17938f5",
+   "metadata": {},
+   "source": [
+    "## 4. Trust signals\n",
+    "\n",
+    "`artifact.warnings` aggregates support-health codes (ESS / overlap /\n",
+    "Pareto-k / calibration) into a single pass/caution/high-risk verdict\n",
+    "per (model, estimator)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "687df281",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact.warnings"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf585e1c",
+   "metadata": {},
+   "source": [
+    "## 5. Stakeholder card\n",
+    "\n",
+    "`save_card` writes a self-contained HTML page for the named model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca777d74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pathlib\n",
+    "\n",
+    "pathlib.Path(\"artifacts\").mkdir(exist_ok=True)\n",
+    "artifact.save_card(\"artifacts/quickstart_card.html\", \"HGB\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ade9eebe",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "- Swap `make_synth_logs` for your own DataFrame; the schema is\n",
+    "  documented in [`README`](https://github.com/dgenio/skdr-eval#readme).\n",
+    "- For pairwise / autoscaling decisions, see the next notebook.\n",
+    "- For domain-flavored use cases, see notebooks 03–05.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/02_pairwise_quickstart.ipynb
+++ b/examples/notebooks/02_pairwise_quickstart.ipynb
@@ -1,0 +1,148 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "9f8b23c7",
+   "metadata": {},
+   "source": [
+    "# skdr-eval — Pairwise / autoscaling quickstart\n",
+    "\n",
+    "Pairwise OPE for client-operator decisions with day-varying\n",
+    "eligibility. Use this notebook when your action set is\n",
+    "*per-decision-context*, not fixed across the whole log.\n",
+    "\n",
+    "👉 [Open in Colab](https://colab.research.google.com/github/dgenio/skdr-eval/blob/main/examples/notebooks/02_pairwise_quickstart.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66f9972e",
+   "metadata": {},
+   "source": [
+    "## 1. Install"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2de32293",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install --quiet skdr-eval scikit-learn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3626394f",
+   "metadata": {},
+   "source": [
+    "## 2. Synthesize pairwise logs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8d59eb2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.ensemble import HistGradientBoostingRegressor\n",
+    "\n",
+    "import skdr_eval\n",
+    "\n",
+    "logs_df, op_daily_df = skdr_eval.make_pairwise_synth(\n",
+    "    n_days=3, n_clients_day=200, n_ops=6, seed=0\n",
+    ")\n",
+    "skdr_eval.validate_pairwise_inputs(logs_df, op_daily_df, metric_col=\"service_time\")\n",
+    "len(logs_df), len(op_daily_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec9252c9",
+   "metadata": {},
+   "source": [
+    "## 3. Fit a candidate routing model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c687455a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "feature_cols = [c for c in logs_df.columns if c.startswith((\"cli_\", \"op_\"))]\n",
+    "candidate = HistGradientBoostingRegressor(max_iter=80, random_state=0)\n",
+    "candidate.fit(logs_df[feature_cols].values, logs_df[\"service_time\"].values)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46eb8efe",
+   "metadata": {},
+   "source": [
+    "## 4. Evaluate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5e48ff3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact = skdr_eval.evaluate_pairwise_models(\n",
+    "    logs_df=logs_df,\n",
+    "    op_daily_df=op_daily_df,\n",
+    "    models={\"HGB\": candidate},\n",
+    "    metric_col=\"service_time\",\n",
+    "    task_type=\"regression\",\n",
+    "    direction=\"min\",\n",
+    "    strategy=\"stream_topk\",\n",
+    "    topk=4,\n",
+    "    n_splits=2,\n",
+    "    random_state=0,\n",
+    ")\n",
+    "artifact.report[\n",
+    "    [\"model\", \"estimator\", \"V_hat\", \"ESS\", \"match_rate\", \"support_health\"]\n",
+    "].round(4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02d5bc3d",
+   "metadata": {},
+   "source": [
+    "## 5. Stakeholder card"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5556a2f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pathlib\n",
+    "\n",
+    "pathlib.Path(\"artifacts\").mkdir(exist_ok=True)\n",
+    "artifact.save_card(\"artifacts/pairwise_card.html\", \"HGB\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/02_pairwise_quickstart.ipynb
+++ b/examples/notebooks/02_pairwise_quickstart.ipynb
@@ -29,7 +29,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --quiet skdr-eval scikit-learn"
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet skdr-eval scikit-learn"
    ]
   },
   {

--- a/examples/notebooks/03_ecommerce_ranking.ipynb
+++ b/examples/notebooks/03_ecommerce_ranking.ipynb
@@ -1,0 +1,126 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a7334775",
+   "metadata": {},
+   "source": [
+    "# E-commerce ranking — offline evaluation of a candidate recommender\n",
+    "\n",
+    "Mirror of `examples/use_cases/01_ecommerce_ranking.py`. Estimate the\n",
+    "policy value of a candidate ranker from logged session data, **before**\n",
+    "any A/B test.\n",
+    "\n",
+    "For *slate* / top-K ranking estimators, see roadmap issue #75.\n",
+    "\n",
+    "👉 [Open in Colab](https://colab.research.google.com/github/dgenio/skdr-eval/blob/main/examples/notebooks/03_ecommerce_ranking.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2307df25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install --quiet skdr-eval scikit-learn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aeee1efd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.ensemble import GradientBoostingRegressor, RandomForestRegressor\n",
+    "\n",
+    "import skdr_eval\n",
+    "\n",
+    "logs, items, _ = skdr_eval.make_synth_logs(n=2000, n_ops=5, seed=7)\n",
+    "skdr_eval.validate_logs(logs)\n",
+    "list(items)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "948d0927",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "candidates = {\n",
+    "    \"RF_ranker\": RandomForestRegressor(n_estimators=80, max_depth=8, random_state=7),\n",
+    "    \"GBM_ranker\": GradientBoostingRegressor(\n",
+    "        n_estimators=80, max_depth=4, random_state=7\n",
+    "    ),\n",
+    "}\n",
+    "artifact = skdr_eval.evaluate_sklearn_models(\n",
+    "    logs=logs,\n",
+    "    models=candidates,\n",
+    "    fit_models=True,\n",
+    "    n_splits=2,\n",
+    "    outcome_estimator=\"hgb\",\n",
+    "    random_state=7,\n",
+    "    policy_train=\"pre_split\",\n",
+    "    policy_train_frac=0.8,\n",
+    ")\n",
+    "cols = [\"model\", \"estimator\", \"V_hat\", \"ESS\", \"match_rate\", \"support_health\"]\n",
+    "artifact.report[cols].round(4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f814773e",
+   "metadata": {},
+   "source": [
+    "Trust diagnostics:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6844ff9d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "artifact.warnings"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0eb3ab70",
+   "metadata": {},
+   "source": [
+    "Pick the candidate with the best (lowest) DR estimate. In a real\n",
+    "deployment review, also confirm the support-health column is `ok` or\n",
+    "`caution`; `high_risk` means do **not** ship without further checks."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73b4b846",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dr_rows = artifact.report[artifact.report[\"estimator\"] == \"DR\"]\n",
+    "best_name = dr_rows.loc[dr_rows[\"V_hat\"].idxmin(), \"model\"]\n",
+    "best_name"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/03_ecommerce_ranking.ipynb
+++ b/examples/notebooks/03_ecommerce_ranking.ipynb
@@ -23,7 +23,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --quiet skdr-eval scikit-learn"
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet skdr-eval scikit-learn"
    ]
   },
   {

--- a/examples/notebooks/04_ad_targeting.ipynb
+++ b/examples/notebooks/04_ad_targeting.ipynb
@@ -21,7 +21,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --quiet skdr-eval scikit-learn"
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet skdr-eval scikit-learn"
    ]
   },
   {

--- a/examples/notebooks/04_ad_targeting.ipynb
+++ b/examples/notebooks/04_ad_targeting.ipynb
@@ -1,0 +1,99 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "58ccd859",
+   "metadata": {},
+   "source": [
+    "# Ad targeting — offline evaluation of a candidate bidding policy\n",
+    "\n",
+    "Mirror of `examples/use_cases/02_ad_targeting.py`. Use this pattern on\n",
+    "any counterfactual-ads log (e.g., Criteo) by replacing `make_synth_logs`\n",
+    "with a public dataset loader once issue #70 ships.\n",
+    "\n",
+    "👉 [Open in Colab](https://colab.research.google.com/github/dgenio/skdr-eval/blob/main/examples/notebooks/04_ad_targeting.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e943c1fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install --quiet skdr-eval scikit-learn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54cccc16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.ensemble import HistGradientBoostingRegressor\n",
+    "from sklearn.linear_model import Ridge\n",
+    "\n",
+    "import skdr_eval\n",
+    "\n",
+    "logs, creatives, _ = skdr_eval.make_synth_logs(n=2000, n_ops=4, seed=11)\n",
+    "skdr_eval.validate_logs(logs)\n",
+    "list(creatives)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0160cec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "models = {\n",
+    "    \"HGB_bidder\": HistGradientBoostingRegressor(max_iter=80, random_state=11),\n",
+    "    \"Ridge_bidder\": Ridge(alpha=1.0, random_state=11),\n",
+    "}\n",
+    "artifact = skdr_eval.evaluate_sklearn_models(\n",
+    "    logs=logs,\n",
+    "    models=models,\n",
+    "    fit_models=True,\n",
+    "    n_splits=2,\n",
+    "    outcome_estimator=\"hgb\",\n",
+    "    random_state=11,\n",
+    "    policy_train=\"pre_split\",\n",
+    "    policy_train_frac=0.8,\n",
+    "    clip_grid=(2.0, 5.0, 10.0, 20.0, 50.0, float(\"inf\")),\n",
+    ")\n",
+    "cols = [\n",
+    "    c\n",
+    "    for c in (\"model\", \"estimator\", \"V_hat\", \"ESS\", \"support_health\", \"pareto_k\")\n",
+    "    if c in artifact.report.columns\n",
+    "]\n",
+    "artifact.report[cols].round(4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f029f77",
+   "metadata": {},
+   "source": [
+    "`pareto_k ≥ 0.7` is a red flag — the weight distribution has heavy\n",
+    "tails and DR variance estimates may be unreliable. SNDR is more\n",
+    "robust in this regime; large DR / SNDR disagreement is itself a\n",
+    "trust signal."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/05_healthcare_cate.ipynb
+++ b/examples/notebooks/05_healthcare_cate.ipynb
@@ -1,0 +1,118 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "72fcf79c",
+   "metadata": {},
+   "source": [
+    "# Healthcare CATE — offline evaluation of a treatment-assignment rule\n",
+    "\n",
+    "Mirror of `examples/use_cases/03_healthcare_cate.py`. Estimate the\n",
+    "policy value of a candidate clinical decision rule from retrospective\n",
+    "logs, **before** any RCT. Particularly attentive to overlap violations,\n",
+    "which are the dominant trust risk in healthcare OPE.\n",
+    "\n",
+    "👉 [Open in Colab](https://colab.research.google.com/github/dgenio/skdr-eval/blob/main/examples/notebooks/05_healthcare_cate.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a3d6dee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install --quiet skdr-eval scikit-learn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5fa34512",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.ensemble import HistGradientBoostingRegressor, RandomForestRegressor\n",
+    "\n",
+    "import skdr_eval\n",
+    "\n",
+    "logs, treatments, _ = skdr_eval.make_synth_logs(n=2000, n_ops=3, seed=23)\n",
+    "skdr_eval.validate_logs(logs)\n",
+    "list(treatments)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50dcb8b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "candidates = {\n",
+    "    \"RF_rule\": RandomForestRegressor(n_estimators=80, max_depth=6, random_state=23),\n",
+    "    \"HGB_rule\": HistGradientBoostingRegressor(max_iter=80, random_state=23),\n",
+    "}\n",
+    "artifact = skdr_eval.evaluate_sklearn_models(\n",
+    "    logs=logs,\n",
+    "    models=candidates,\n",
+    "    fit_models=True,\n",
+    "    n_splits=2,\n",
+    "    outcome_estimator=\"hgb\",\n",
+    "    random_state=23,\n",
+    "    policy_train=\"pre_split\",\n",
+    "    policy_train_frac=0.8,\n",
+    ")\n",
+    "cols = [\"model\", \"estimator\", \"V_hat\", \"ESS\", \"match_rate\", \"support_health\"]\n",
+    "artifact.report[cols].round(4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce8f17be",
+   "metadata": {},
+   "source": [
+    "## DR vs. SNDR disagreement\n",
+    "\n",
+    "A large gap between the DR and SNDR estimates is the most common\n",
+    "trust failure in healthcare OPE — it usually means thin overlap\n",
+    "is inflating DR variance. Report both values to the clinical team."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0b154e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for model_name in candidates:\n",
+    "    rows = artifact.report[artifact.report[\"model\"] == model_name]\n",
+    "    dr = rows[rows[\"estimator\"] == \"DR\"][\"V_hat\"].iloc[0]\n",
+    "    sndr = rows[rows[\"estimator\"] == \"SNDR\"][\"V_hat\"].iloc[0]\n",
+    "    print(f\"{model_name}: |DR - SNDR| = {abs(dr - sndr):.3f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "982438cc",
+   "metadata": {},
+   "source": [
+    "Per-subgroup CATE slicing (e.g., by age band or comorbidity) is\n",
+    "tracked in roadmap issue #87."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/05_healthcare_cate.ipynb
+++ b/examples/notebooks/05_healthcare_cate.ipynb
@@ -22,7 +22,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install --quiet skdr-eval scikit-learn"
+    "import sys\n",
+    "\n",
+    "if \"google.colab\" in sys.modules:\n",
+    "    %pip install --quiet skdr-eval scikit-learn"
    ]
   },
   {

--- a/examples/use_cases/01_ecommerce_ranking.py
+++ b/examples/use_cases/01_ecommerce_ranking.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""E-commerce ranking — offline evaluation of a candidate recommender.
+
+This use case mirrors a common e-commerce setup:
+
+- A *logging* recommender served items to sessions and the platform
+  recorded (session features, served item, observed reward).
+- A data-science team has trained a *candidate* recommender and wants to
+  estimate its policy value **before** A/B testing.
+
+We treat each operator-id in the synthetic generator as a candidate item
+and each "service time" as the negated reward (lower is better). The
+``evaluate_sklearn_models`` entry point is the right tool for the
+contextual-bandit / one-item-per-impression case; for *slate* / top-K
+ranking estimators, see open roadmap issue #75.
+
+Stakeholder reading:
+
+* ``V_hat`` — estimated mean reward under the candidate policy.
+* ``support_health`` — green/yellow/red trust banner.
+* ``pareto_k`` — PSIS Pareto-k; ``< 0.5`` is good, ``≥ 0.7`` is a red
+  flag for weight-tail risk.
+"""
+
+from sklearn.ensemble import GradientBoostingRegressor, RandomForestRegressor
+
+import skdr_eval
+
+
+def main() -> None:
+    print("skdr-eval: E-commerce ranking use case")
+    print("=" * 60)
+
+    # 1. Build a logged-recommender dataset (small for fast CI smoke).
+    print("\n1. Building synthetic ranking logs (n=3000, 5 candidate items)...")
+    logs, items, _ = skdr_eval.make_synth_logs(n=3000, n_ops=5, seed=7)
+    skdr_eval.validate_logs(logs)
+    print(f"   Sessions: {len(logs):,}")
+    print(f"   Candidate items: {list(items)}")
+
+    # 2. Define candidate ranking models. Each model assigns a *score* to
+    # every (session, item) pair; the top-scoring item is the policy's
+    # pick. We use lower-is-better semantics (reward = -service_time-ish).
+    print("\n2. Defining candidate ranking models...")
+    candidates = {
+        "RF_ranker": RandomForestRegressor(
+            n_estimators=100, max_depth=8, random_state=7
+        ),
+        "GBM_ranker": GradientBoostingRegressor(
+            n_estimators=100, max_depth=4, random_state=7
+        ),
+    }
+
+    # 3. Offline-evaluate with DR + SNDR.
+    print("\n3. Running DR / SNDR with time-aware splits...")
+    artifact = skdr_eval.evaluate_sklearn_models(
+        logs=logs,
+        models=candidates,
+        fit_models=True,
+        n_splits=3,
+        outcome_estimator="hgb",
+        random_state=7,
+        policy_train="pre_split",
+        policy_train_frac=0.8,
+    )
+
+    # 4. Stakeholder summary.
+    print("\n4. Stakeholder summary")
+    print("-" * 60)
+    cols = [
+        "model",
+        "estimator",
+        "V_hat",
+        "SE_if",
+        "ESS",
+        "match_rate",
+        "support_health",
+    ]
+    print(artifact.report[cols].round(4).to_string(index=False))
+
+    # 5. Trust diagnostics.
+    print("\n5. Trust diagnostics")
+    print("-" * 60)
+    print(artifact.warnings.to_string(index=False))
+
+    # 6. Best candidate by DR estimate.
+    dr_rows = artifact.report[artifact.report["estimator"] == "DR"]
+    best_name = dr_rows.loc[dr_rows["V_hat"].idxmin(), "model"]
+    print(f"\nBest candidate by DR: {best_name}")
+
+    print("\nDone. (For slate / top-K estimators, see roadmap issue #75.)")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/use_cases/02_ad_targeting.py
+++ b/examples/use_cases/02_ad_targeting.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Ad targeting — offline evaluation of a candidate bidding policy.
+
+This use case mirrors a counterfactual-ads setup (Criteo-style):
+
+- A *logging* targeting policy decided which ad creative to show to each
+  impression and recorded (impression features, served creative,
+  observed reward).
+- A new candidate policy is trained; we want a value estimate **before**
+  any live spend is at risk.
+
+For demonstration we reuse the synthetic generator with a few candidate
+creatives and run the DR / SNDR path. On real Criteo logs the call
+signature is identical — see
+[#70](https://github.com/dgenio/skdr-eval/issues/70) for the public
+dataset loader roadmap item.
+
+The script ends by rendering an HTML stakeholder card under
+``artifacts/ad_targeting_card.html`` so a non-technical PM can read the
+verdict.
+"""
+
+from sklearn.ensemble import HistGradientBoostingRegressor
+from sklearn.linear_model import Ridge
+
+import skdr_eval
+
+
+def main() -> None:
+    print("skdr-eval: Ad targeting use case")
+    print("=" * 60)
+
+    # 1. Logged impressions with multiple candidate creatives.
+    print("\n1. Building synthetic ad-impression logs (n=3000, 4 creatives)...")
+    logs, creatives, _ = skdr_eval.make_synth_logs(n=3000, n_ops=4, seed=11)
+    skdr_eval.validate_logs(logs)
+    print(f"   Impressions: {len(logs):,}")
+    print(f"   Candidate creatives: {list(creatives)}")
+
+    # 2. Candidate bidding-policy backbones.
+    models = {
+        "HGB_bidder": HistGradientBoostingRegressor(max_iter=120, random_state=11),
+        "Ridge_bidder": Ridge(alpha=1.0, random_state=11),
+    }
+
+    # 3. Evaluate. We deliberately keep clip_grid wide because real ad
+    # logs tend to have heavy weight tails; the support-health banner
+    # will surface that as `caution` or `high_risk`.
+    print("\n2. Running DR / SNDR with wide clip grid...")
+    artifact = skdr_eval.evaluate_sklearn_models(
+        logs=logs,
+        models=models,
+        fit_models=True,
+        n_splits=3,
+        outcome_estimator="hgb",
+        random_state=11,
+        policy_train="pre_split",
+        policy_train_frac=0.8,
+        clip_grid=(2.0, 5.0, 10.0, 20.0, 50.0, float("inf")),
+    )
+
+    # 4. Stakeholder summary.
+    print("\n3. Stakeholder summary")
+    print("-" * 60)
+    cols = [
+        "model",
+        "estimator",
+        "V_hat",
+        "SE_if",
+        "ESS",
+        "match_rate",
+        "support_health",
+        "pareto_k",
+    ]
+    cols = [c for c in cols if c in artifact.report.columns]
+    print(artifact.report[cols].round(4).to_string(index=False))
+
+    # 5. Pick the best model by DR and write a stakeholder card.
+    dr_rows = artifact.report[artifact.report["estimator"] == "DR"]
+    best_name = dr_rows.loc[dr_rows["V_hat"].idxmin(), "model"]
+    card_path = artifact.save_card(
+        f"artifacts/ad_targeting_{best_name}_card.html", best_name
+    )
+    print(f"\n4. Stakeholder card written to: {card_path}")
+
+    print(
+        "\nDone. (Replace make_synth_logs with a Criteo loader when issue #70 ships.)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/use_cases/03_healthcare_cate.py
+++ b/examples/use_cases/03_healthcare_cate.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Healthcare CATE — offline evaluation of a treatment-assignment policy.
+
+This use case mirrors a retrospective EHR-style setup:
+
+- Patients arrived; a *baseline-of-care* policy assigned one of several
+  treatments; an outcome was recorded.
+- A *candidate* policy (e.g., a risk-stratified rule) is being
+  considered. We need an estimate of its conditional-average treatment
+  effect (CATE) over the population *without* running a clinical trial.
+
+For demonstration we reuse the synthetic generator with three
+"treatments" mapped onto operator ids. `evaluate_sklearn_models` returns
+the same `EvaluationArtifact` and the same support-health diagnostics
+apply — they're particularly important in healthcare, where overlap
+violations (e.g., almost no patient with profile X received treatment
+B in the logs) are common and dangerous.
+
+The script reports both DR and SNDR; we recommend reading both — large
+disagreement is itself a trust signal.
+"""
+
+from sklearn.ensemble import HistGradientBoostingRegressor, RandomForestRegressor
+
+import skdr_eval
+
+
+def main() -> None:
+    print("skdr-eval: Healthcare CATE use case")
+    print("=" * 60)
+
+    # 1. Build retrospective patient logs (small for CI smoke).
+    print("\n1. Building synthetic patient logs (n=2500, 3 treatments)...")
+    logs, treatments, _ = skdr_eval.make_synth_logs(n=2500, n_ops=3, seed=23)
+    skdr_eval.validate_logs(logs)
+    print(f"   Patients: {len(logs):,}")
+    print(f"   Treatments: {list(treatments)}")
+
+    # 2. Candidate treatment-assignment policies.
+    candidates = {
+        "RF_rule": RandomForestRegressor(
+            n_estimators=120, max_depth=6, random_state=23
+        ),
+        "HGB_rule": HistGradientBoostingRegressor(max_iter=120, random_state=23),
+    }
+
+    # 3. Evaluate with DR + SNDR; bootstrap CIs on for clinical reporting.
+    print("\n2. Running DR / SNDR with bootstrap CIs...")
+    artifact = skdr_eval.evaluate_sklearn_models(
+        logs=logs,
+        models=candidates,
+        fit_models=True,
+        n_splits=3,
+        outcome_estimator="hgb",
+        random_state=23,
+        policy_train="pre_split",
+        policy_train_frac=0.8,
+        ci_bootstrap=True,
+        alpha=0.05,
+    )
+
+    # 4. Stakeholder summary.
+    print("\n3. Stakeholder summary")
+    print("-" * 60)
+    cols = [
+        "model",
+        "estimator",
+        "V_hat",
+        "CI_lo",
+        "CI_hi",
+        "ESS",
+        "match_rate",
+        "support_health",
+    ]
+    cols = [c for c in cols if c in artifact.report.columns]
+    print(artifact.report[cols].round(4).to_string(index=False))
+
+    # 5. Surface DR-vs-SNDR disagreement explicitly — a divergence between
+    # the two estimators is the most common trust failure in healthcare
+    # OPE because thin overlap inflates DR variance.
+    print("\n4. DR vs. SNDR divergence (large gap = trust risk)")
+    print("-" * 60)
+    for model_name in candidates:
+        rows = artifact.report[artifact.report["model"] == model_name]
+        dr = rows[rows["estimator"] == "DR"]["V_hat"].iloc[0]
+        sndr = rows[rows["estimator"] == "SNDR"]["V_hat"].iloc[0]
+        gap = abs(dr - sndr)
+        print(f"   {model_name}: |DR - SNDR| = {gap:.3f}")
+
+    # 6. Render a stakeholder card for the best model.
+    dr_rows = artifact.report[artifact.report["estimator"] == "DR"]
+    best_name = dr_rows.loc[dr_rows["V_hat"].idxmin(), "model"]
+    card_path = artifact.save_card(
+        f"artifacts/healthcare_cate_{best_name}_card.html", best_name
+    )
+    print(f"\n5. Stakeholder card: {card_path}")
+
+    print("\nDone. CATE-specific subgroup slicing is tracked in issue #87.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/use_cases/04_call_routing.py
+++ b/examples/use_cases/04_call_routing.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Call routing — pairwise offline evaluation of a routing policy.
+
+This is the original motivating use case for ``skdr-eval``: a call
+center logs (client, operator, service_time) tuples under a baseline
+routing policy and wants to evaluate a candidate routing model that
+chooses an operator per client.
+
+The pairwise API differs from the standard contextual-bandit API in
+two ways:
+
+1. The action space (operators) varies by day (eligibility / shifts).
+2. Service-time is the *target* to minimize, not maximize.
+
+Both shape differences are handled by ``evaluate_pairwise_models``; the
+returned ``EvaluationArtifact`` has the same shape as in the other use
+cases, so the same stakeholder card / warnings / sensitivity surface
+applies.
+"""
+
+from sklearn.ensemble import HistGradientBoostingRegressor
+
+import skdr_eval
+
+
+def main() -> None:
+    print("skdr-eval: Call routing (pairwise) use case")
+    print("=" * 60)
+
+    # 1. Build pairwise synthetic data — small for CI smoke.
+    print("\n1. Building synthetic pairwise logs (3 days, 300 clients/day, 6 ops)...")
+    logs_df, op_daily_df = skdr_eval.make_pairwise_synth(
+        n_days=3, n_clients_day=300, n_ops=6, seed=29
+    )
+    skdr_eval.validate_pairwise_inputs(logs_df, op_daily_df, metric_col="service_time")
+    print(f"   Decisions: {len(logs_df):,}")
+    print(f"   Operator-day snapshots: {len(op_daily_df):,}")
+
+    # 2. Train a candidate routing model on the observed columns.
+    feature_cols = [c for c in logs_df.columns if c.startswith(("cli_", "op_"))]
+    candidate = HistGradientBoostingRegressor(max_iter=120, random_state=29)
+    candidate.fit(logs_df[feature_cols].values, logs_df["service_time"].values)
+
+    # 3. Pairwise evaluation under the autoscaling / streaming strategy.
+    print("\n2. Running pairwise evaluation with stream_topk...")
+    artifact = skdr_eval.evaluate_pairwise_models(
+        logs_df=logs_df,
+        op_daily_df=op_daily_df,
+        models={"HGB_router": candidate},
+        metric_col="service_time",
+        task_type="regression",
+        direction="min",
+        strategy="stream_topk",
+        topk=4,
+        n_splits=3,
+        random_state=29,
+    )
+
+    # 4. Stakeholder summary.
+    print("\n3. Stakeholder summary")
+    print("-" * 60)
+    cols = [
+        "model",
+        "estimator",
+        "V_hat",
+        "SE_if",
+        "ESS",
+        "match_rate",
+        "support_health",
+    ]
+    cols = [c for c in cols if c in artifact.report.columns]
+    print(artifact.report[cols].round(4).to_string(index=False))
+
+    # 5. Render the stakeholder card.
+    card_path = artifact.save_card(
+        "artifacts/call_routing_HGB_router_card.html", "HGB_router"
+    )
+    print(f"\n4. Stakeholder card: {card_path}")
+
+    # 6. Compare to the observed baseline (mean service_time).
+    baseline = logs_df["service_time"].mean()
+    dr = artifact.report.query("model == 'HGB_router' and estimator == 'DR'")[
+        "V_hat"
+    ].iloc[0]
+    improvement = (baseline - dr) / baseline * 100
+    print(
+        f"\n5. Baseline mean service_time: {baseline:.2f}  "
+        f"Candidate DR estimate: {dr:.2f}  Improvement: {improvement:+.1f}%"
+    )
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,31 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "skdr-eval"
 dynamic = ["version"]
-description = "Offline policy evaluation using Doubly Robust and Stabilized DR estimators"
+description = "General-purpose offline policy evaluation for sklearn-compatible models with time-aware Doubly Robust (DR) and Stabilized DR (SNDR) estimators, calibrated propensities, and stakeholder evaluation cards"
 readme = "README.md"
 license = {text = "MIT"}
 authors = [
     {name = "Diogo Santos", email = "diogofcul@gmail.com"}
 ]
-keywords = ["offline evaluation", "doubly robust", "policy evaluation", "service time", "time series", "autoscaling", "bandits", "causal inference"]
+keywords = [
+    "offline policy evaluation",
+    "ope",
+    "doubly robust",
+    "stabilized doubly robust",
+    "sndr",
+    "counterfactual evaluation",
+    "contextual bandits",
+    "causal inference",
+    "treatment effects",
+    "ranking",
+    "recommender systems",
+    "ad targeting",
+    "uplift modeling",
+    "autoscaling",
+    "service time",
+    "time series",
+    "scikit-learn",
+]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
@@ -58,16 +76,26 @@ dev = [
     "twine",
     "pre-commit",
     "matplotlib",
+    "nbmake>=1.5",
+    "nbformat>=5.0",
 ]
 examples = [
     "jupyter",
     "matplotlib",
 ]
+notebooks = [
+    "jupyter",
+    "matplotlib>=3.5",
+    "nbformat>=5.0",
+    "nbclient>=0.10",
+]
 
 [project.urls]
-Homepage = "https://github.com/dandrsantos/skdr-eval"
-Repository = "https://github.com/dandrsantos/skdr-eval"
-Issues = "https://github.com/dandrsantos/skdr-eval/issues"
+Homepage = "https://github.com/dgenio/skdr-eval"
+Repository = "https://github.com/dgenio/skdr-eval"
+Issues = "https://github.com/dgenio/skdr-eval/issues"
+Changelog = "https://github.com/dgenio/skdr-eval/blob/main/CHANGELOG.md"
+Documentation = "https://github.com/dgenio/skdr-eval#readme"
 
 [tool.setuptools]
 package-dir = {"" = "src"}


### PR DESCRIPTION
Implements six related open issues in one onboarding/adoption sweep
(no statistical code touched):

- #67: reposition README + pyproject description as general-purpose OPE
  (was service-time-only); add "When should I use this?" section.
- #98: fix repo metadata URLs across pyproject `[project.urls]`, README
  badges/clone snippets, and CITATION.cff (`dandrsantos` → `dgenio`); add
  Changelog/Documentation URLs; broaden description and keywords.
- #69 + #90: ship five nbmake-tested Colab notebooks under
  `examples/notebooks/` (quickstart, pairwise quickstart, e-commerce
  ranking, ad targeting, healthcare CATE) with Open-in-Colab badges in
  README; add `notebooks-smoke` CI job. Install cell guarded with
  `if "google.colab" in sys.modules:` so local/CI runs skip the pip
  install.
- #78: ship four runnable use-case scripts under `examples/use_cases/`
  (e-commerce ranking, ad targeting, healthcare CATE, call routing)
  and a `use-cases-smoke` CI job to keep them green.
- #77: polish CITATION.cff (version 0.8.0, identifiers, preferred-citation);
  add `.zenodo.json` for the next-release DOI mint; add `docs/zenodo.md`
  (maintainer checklist) and `docs/methods.md` (preprint outline).

Also adds a `[notebooks]` optional extra (`jupyter`, `matplotlib`,
`nbformat`, `nbclient`) and pulls `nbmake>=1.5` + `nbformat>=5.0` into
`[dev]`; Makefile gets new `notebooks` and `use-cases` targets mirroring
the CI jobs.

### Verified locally

- `ruff check src/ tests/ examples/` — clean
- `ruff format --check src/ tests/ examples/` — clean (48 files)
- `mypy src/skdr_eval/` — clean
- `pytest tests/` — 453 passed, 3 skipped
- `pytest --nbmake examples/notebooks/` — 5 passed in 32 s
- `python examples/use_cases/*.py` — all four scripts complete