### PR TITLE
feat: M2 user-facing tooling layer — Card schema, doctor, tracker, CLI (closes #88 #89 #91 #93)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,34 @@ jobs:
       run: |
         python examples/preflight.py
 
+  cli-smoke:
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.11"
+
+    - name: Install with [cli] extra
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .[cli]
+
+    - name: skdr-eval CLI smoke (version + doctor on synth parquet)
+      run: |
+        skdr-eval version
+        python -c "import skdr_eval, pathlib; \
+            logs, _, _ = skdr_eval.make_synth_logs(n=800, n_ops=3, seed=0); \
+            logs.to_parquet('logs.parquet')"
+        skdr-eval doctor logs.parquet --json
+        skdr-eval validate-schema logs.parquet
+
   build:
     runs-on: ubuntu-latest
     needs: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,109 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`EvaluationCard` Pydantic v2 schema** ([#88]). New
+  ``skdr_eval.EvaluationCard`` (the machine-readable sibling of the HTML
+  evaluation card) bundles the headline result, trust signals, diagnostics,
+  sensitivity, and provenance for a single ``(model, estimator)`` row into
+  a typed payload that is JSON/YAML round-trippable and has a
+  ``json_schema()`` export for downstream tooling. Build a card via
+  ``EvaluationArtifact.card_schema(model_name, *, estimator='SNDR',
+  baseline=None, include_gate=True, include_recommendation=True)``. Round-
+  trip with ``card.to_yaml(path)`` / ``card.to_json(path)`` /
+  ``EvaluationCard.from_yaml(...)`` / ``EvaluationCard.from_json(...)``.
+  New constant ``CARD_SCHEMA_VERSION = "1.0.0"``. Block models
+  ``HeadlineBlock``, ``TrustBlock``, ``DiagnosticsBlock``,
+  ``SensitivityBlock``, ``ProvenanceBlock``, and ``CoverageSimBlock`` are
+  all exported. ``ConfigDict(extra="allow")`` keeps schemas forward-
+  compatible: unknown fields are preserved on round-trip.
+
+- **`skdr_eval.doctor()`** ([#91]). New preflight diagnostic surface
+  composing the existing public validators (``validate_logs`` /
+  ``validate_pairwise_inputs``) and ``get_capabilities()`` into a single
+  non-raising ``DoctorReport`` with concrete fix hints. Each row is a
+  ``Check(name, status, message, fix_hint, category)``; the report
+  exposes ``ok``, ``summary``, ``to_dict()``, ``to_markdown()``,
+  ``to_text(color=…)``, and ``print(color=…)``. The doctor never mutates
+  its input DataFrame and never raises — even on a non-DataFrame input
+  the report surfaces the failure as a ``Check`` with ``status="fail"``.
+
+- **`Tracker` protocol + `NullTracker` + `FileTracker`** ([#93]). The new
+  ``skdr_eval.trackers`` package defines the minimum tracker surface
+  (``log_metric`` / ``log_artifact`` / ``log_card`` / ``set_tag`` + context
+  management) and ships a no-op ``NullTracker`` (default) plus a disk-based
+  ``FileTracker`` that writes ``metrics.jsonl``, ``tags.json``,
+  ``artifacts/``, and ``cards/<model>_<estimator>.card.yaml``. Both
+  ``evaluate_sklearn_models`` and ``evaluate_pairwise_models`` accept a new
+  ``tracker=`` kwarg (default ``None``); the evaluator auto-logs
+  ``V_hat/ci_lower/ci_upper/ESS/match_rate/pareto_k`` per ``(model,
+  estimator)`` row, run-level tags, and one ``EvaluationCard`` per row.
+  Stubs ``skdr_eval.trackers.mlflow.MLflowTracker``,
+  ``skdr_eval.trackers.wandb.WandbTracker``,
+  ``skdr_eval.trackers.aim.AimTracker`` raise ``NotImplementedError`` on
+  construction — full adapters tracked by umbrella issue #73.
+
+- **`skdr-eval` CLI** ([#89]). New Typer-based CLI gated behind the
+  ``[cli]`` extra. Subcommands:
+
+  - ``skdr-eval evaluate LOGS --model NAME=PATH --out DIR`` — run the
+    sklearn evaluator on local logs + pickled models, write artifact
+    JSON + HTML report + one ``EvaluationCard`` YAML/JSON per row.
+  - ``skdr-eval pairwise LOGS OP_DAILY --model NAME=PATH ...`` — the
+    pairwise counterpart.
+  - ``skdr-eval card ARTIFACT_JSON --model NAME --estimator DR|SNDR --out
+    PATH --format yaml|json`` — re-render an ``EvaluationCard`` directly
+    from a saved ``artifact.json``.
+  - ``skdr-eval validate-schema LOGS [--kind standard|pairwise]
+    [--op-daily PATH] [--metric-col COL] [--strict]`` — call the public
+    validators and exit non-zero on failure.
+  - ``skdr-eval doctor LOGS [--kind ...] [--json]`` — print the preflight
+    report (text or JSON) and exit non-zero when the doctor reports
+    ``fail``.
+  - ``skdr-eval version`` — print the package version.
+
+  Input format auto-detection covers ``.parquet`` / ``.csv`` / ``.tsv`` /
+  ``.feather``. The CLI normalizes parquet-round-trip quirks (e.g. object
+  cells coming back as ``ndarray``) before handing them to the public
+  validators. Exit codes are stable for CI gates: ``0`` ok, ``1`` data /
+  schema error, ``2`` env error, ``3`` ``do_not_deploy`` recommendation
+  on at least one row.
+
+- **New optional dependency extras**: ``[cli]`` (``typer>=0.12``,
+  ``joblib>=1.3``, ``pyarrow>=14``), and three placeholder extras for
+  the umbrella tracker adapters: ``[mlflow]``, ``[wandb]``, ``[aim]``.
+  The ``skdr-eval`` script is registered via ``[project.scripts]``.
+
+### Changed
+- ``[project.urls]`` Homepage/Repository/Issues now point at
+  ``dgenio/skdr-eval`` (was the legacy ``dandrsantos`` URL); a new
+  ``Changelog`` URL is published alongside.
+
+### Tests
+- New ``tests/test_card_schema.py`` (22 tests) covering ``card_schema()``,
+  YAML/JSON round-trip (string and file paths), ``json_schema()`` export,
+  forward-compatibility under ``ConfigDict(extra="allow")``, and the
+  schema-version stability guard.
+- New ``tests/test_doctor.py`` (18 tests) covering the per-check pass /
+  warn / fail paths, the never-raise contract, idempotence, and the
+  ``to_dict``/``to_markdown``/``to_text`` renderers.
+- New ``tests/test_trackers.py`` (19 tests) covering ``NullTracker``
+  no-op semantics, ``FileTracker`` metrics/tags/artifacts/cards writes,
+  evaluator wiring (``tracker=None`` artifact-identical to
+  ``tracker=NullTracker()``), the pairwise evaluator's ``tracker=`` kwarg,
+  and the ``MLflowTracker`` / ``WandbTracker`` / ``AimTracker`` stub
+  contracts.
+- New ``tests/test_cli.py`` (15 tests) covering ``--help`` /
+  ``version`` / ``doctor`` / ``validate-schema`` / ``evaluate`` (via the
+  ``card`` round-trip) / ``card`` (YAML and JSON output formats) using
+  Typer's ``CliRunner``; exit-code stability guard for
+  ``EXIT_DO_NOT_DEPLOY == 3``.
+
+[#88]: https://github.com/dgenio/skdr-eval/issues/88
+[#89]: https://github.com/dgenio/skdr-eval/issues/89
+[#91]: https://github.com/dgenio/skdr-eval/issues/91
+[#93]: https://github.com/dgenio/skdr-eval/issues/93
+
 ## [0.8.0] - 2026-05-20
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,15 @@ smoke:
 	python examples/preflight.py
 	python examples/quickstart.py
 
+# CLI smoke (mirrors CI cli-smoke job). Requires the [cli] extra.
+cli-smoke:
+	skdr-eval version
+	python -c "import skdr_eval, tempfile, pathlib; \
+		td = pathlib.Path(tempfile.mkdtemp()); \
+		logs, _, _ = skdr_eval.make_synth_logs(n=800, n_ops=3, seed=0); \
+		p = td / 'logs.parquet'; logs.to_parquet(p); print(p)" \
+		| tail -1 | xargs -I {} skdr-eval doctor {} --json
+
 # Composite targets
 check: lint typecheck test smoke
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@
 
 `skdr-eval` is a Python package for offline policy evaluation in service-time optimization scenarios. It implements state-of-the-art Doubly Robust (DR) and Stabilized Doubly Robust (SNDR) estimators with time-aware cross-validation and calibration. The package is designed for evaluating machine learning models that make decisions about service allocation, with special support for pairwise (client-operator) evaluation and autoscaling strategies.
 
+> The `skdr-eval` CLI (`pip install 'skdr-eval[cli]'`) makes the same
+> evaluators reachable from a terminal — see [Command-line interface](#command-line-interface).
+> Run `skdr-eval doctor logs.parquet` before evaluation to catch schema and
+> environment problems early.
+
 ## Table of Contents
 
 - [Features](#features)
@@ -338,6 +343,106 @@ print(artifact.report[['model', 'estimator', 'V_hat', 'ci_lower', 'ci_upper']])
 - **Proper statistical inference**: Uses bootstrap distribution of DR contributions
 - **Automatic fallback**: Falls back to normal approximation if bootstrap fails
 - **Configurable parameters**: Control bootstrap samples, block length, and significance level
+
+## Command-line interface
+
+The `skdr-eval` CLI ships behind the `[cli]` extra and exposes the same
+evaluation surface to teams that don't want to write Python.
+
+```bash
+pip install 'skdr-eval[cli]'
+
+# Quick environment + schema probe before evaluation.
+skdr-eval doctor logs.parquet
+skdr-eval doctor logs.parquet --json | jq .
+
+# Validate logs against the schema (exit code 1 on failure — useful in CI).
+skdr-eval validate-schema logs.parquet --strict
+skdr-eval validate-schema pw_logs.parquet --kind pairwise \
+    --op-daily pw_op.parquet --metric-col service_time
+
+# Run a full evaluation from disk.
+skdr-eval evaluate logs.parquet \
+    --model HGB=model.joblib \
+    --policy-train pre_split \
+    --n-splits 3 \
+    --out ./run \
+    --tracker-dir ./tracker_runs/2026-05-20
+
+# Re-render a card directly from a saved artifact.json.
+skdr-eval card ./run/artifact.json --model HGB --estimator DR \
+    --out ./run/card.yaml --format yaml
+
+# Stable exit codes (good for CI gates):
+#   0 — success
+#   1 — data / schema error
+#   2 — environment / import error
+#   3 — at least one model row's recommendation verdict is 'do_not_deploy'
+```
+
+## Preflight diagnostics: `skdr_eval.doctor`
+
+`skdr_eval.doctor(logs, *, kind='standard'|'pairwise', op_daily_df=None,
+metric_col='service_time', n_splits=3, strict=False)` returns a non-raising
+`DoctorReport` that surfaces environment + schema + statistical sanity
+failures with actionable fix hints.
+
+```python
+import skdr_eval
+
+logs, _, _ = skdr_eval.make_synth_logs(n=5000, n_ops=3, seed=0)
+report = skdr_eval.doctor(logs)
+report.print()            # text table with status glyphs
+report.to_markdown()      # copy-pasteable Markdown
+report.to_dict()          # JSON-serializable
+assert report.ok          # True iff no Check has status='fail'
+```
+
+## Machine-readable cards: `EvaluationCard`
+
+`EvaluationArtifact.card_schema(model_name, estimator='SNDR')` builds an
+`EvaluationCard` — the typed sibling of the HTML stakeholder card. The card
+is YAML/JSON round-trippable, exposes a stable `json_schema()` for downstream
+tooling, and is ideal for CI gates and Git-pinned snapshots of an evaluation.
+
+```python
+artifact = skdr_eval.evaluate_sklearn_models(logs=logs, models=models, fit_models=True)
+card = artifact.card_schema("RandomForest", estimator="DR")
+
+card.to_yaml("artifacts/rf.card.yaml")
+card.to_json("artifacts/rf.card.json")
+
+# Round-trip
+loaded = skdr_eval.EvaluationCard.from_yaml("artifacts/rf.card.yaml")
+assert loaded == card
+
+# CI gate
+if card.trust.recommendation and card.trust.recommendation["verdict"] == "do_not_deploy":
+    raise SystemExit(1)
+```
+
+## Experiment tracker
+
+`evaluate_sklearn_models` and `evaluate_pairwise_models` both accept a
+`tracker=` kwarg. The default `NullTracker` is a no-op (so the evaluator is
+unchanged when omitted). `FileTracker` writes a deterministic run directory
+to disk; external adapters (`MLflowTracker`, `WandbTracker`, `AimTracker`)
+ship as stubs behind the `[mlflow]` / `[wandb]` / `[aim]` extras and are
+filled in under umbrella issue #73.
+
+```python
+from skdr_eval import FileTracker
+
+with FileTracker(root="runs/2026-05-20") as tracker:
+    artifact = skdr_eval.evaluate_sklearn_models(
+        logs=logs, models=models, fit_models=True, tracker=tracker,
+    )
+# Writes:
+#   runs/2026-05-20/metrics.jsonl          (one row per logged metric)
+#   runs/2026-05-20/tags.json
+#   runs/2026-05-20/artifacts/...
+#   runs/2026-05-20/cards/<model>_<estimator>.card.yaml
+```
 
 ## Examples
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -46,8 +46,26 @@ ignore_missing_imports = True
 [mypy-yaml.*]
 ignore_missing_imports = True
 
+[mypy-typer.*]
+ignore_missing_imports = True
+
+[mypy-joblib.*]
+ignore_missing_imports = True
+
+[mypy-mlflow.*]
+ignore_missing_imports = True
+
+[mypy-wandb.*]
+ignore_missing_imports = True
+
+[mypy-aim.*]
+ignore_missing_imports = True
+
 [mypy-skdr_eval._version]
 ignore_missing_imports = True
+
+[mypy-skdr_eval.cli]
+disable_error_code = untyped-decorator
 
 [mypy-skdr_eval]
 ignore_missing_imports = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,20 @@ speed = [
 viz = [
     "matplotlib>=3.5",
 ]
+cli = [
+    "typer>=0.12",
+    "joblib>=1.3",
+    "pyarrow>=14",
+]
+mlflow = [
+    "mlflow>=2.10",
+]
+wandb = [
+    "wandb>=0.17",
+]
+aim = [
+    "aim>=3.20",
+]
 dev = [
     "pytest",
     "pytest-cov",
@@ -58,16 +72,23 @@ dev = [
     "twine",
     "pre-commit",
     "matplotlib",
+    "typer>=0.12",
+    "joblib>=1.3",
+    "pyarrow>=14",
 ]
 examples = [
     "jupyter",
     "matplotlib",
 ]
 
+[project.scripts]
+skdr-eval = "skdr_eval.cli:app"
+
 [project.urls]
-Homepage = "https://github.com/dandrsantos/skdr-eval"
-Repository = "https://github.com/dandrsantos/skdr-eval"
-Issues = "https://github.com/dandrsantos/skdr-eval/issues"
+Homepage = "https://github.com/dgenio/skdr-eval"
+Repository = "https://github.com/dgenio/skdr-eval"
+Issues = "https://github.com/dgenio/skdr-eval/issues"
+Changelog = "https://github.com/dgenio/skdr-eval/blob/main/CHANGELOG.md"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
@@ -164,5 +185,18 @@ module = [
     "jinja2.*",
     "pydantic.*",
     "yaml.*",
+    "typer.*",
+    "joblib.*",
+    "mlflow.*",
+    "wandb.*",
+    "aim.*",
 ]
 ignore_missing_imports = true
+
+# The Typer CLI module uses ``@app.command(...)`` decorators that mypy
+# (correctly) flags as untyped because Typer's command decorator is
+# overloaded; suppress only that one error code so the rest of the strict
+# config still applies.
+[[tool.mypy.overrides]]
+module = ["skdr_eval.cli"]
+disable_error_code = ["untyped-decorator"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,7 @@ ignore_missing_imports = true
 # (correctly) flags as untyped because Typer's command decorator is
 # overloaded; suppress only that one error code so the rest of the strict
 # config still applies.
+# NOTE: These overrides mirror mypy.ini (which takes precedence at runtime).
 [[tool.mypy.overrides]]
 module = ["skdr_eval.cli"]
 disable_error_code = ["untyped-decorator"]

--- a/scripts/validate_contribution.py
+++ b/scripts/validate_contribution.py
@@ -326,6 +326,28 @@ class ContributionValidator:
         print("Examples smoke passed (mirrors CI examples-smoke job)")
         return True
 
+    def check_cli_smoke(self) -> bool:
+        """Run CLI smoke checks (mirrors CI cli-smoke job)."""
+        print("Running CLI smoke...")
+        self.total_checks += 1
+
+        cli_commands = [
+            [sys.executable, "-m", "skdr_eval.cli", "version"],
+        ]
+        for cmd in cli_commands:
+            code, stdout, stderr = self.run_command(cmd)
+            if code != 0:
+                self.errors.append(
+                    f"CLI smoke failed: {' '.join(cmd)}\n"
+                    f"stdout:\n{stdout}\nstderr:\n{stderr}"
+                )
+                return False
+            print(f"PASS {' '.join(cmd[-2:])}")
+
+        self.success_count += 1
+        print("CLI smoke passed (mirrors CI cli-smoke job)")
+        return True
+
     def validate_all(self) -> bool:
         """Run all validation checks."""
         print("Starting contribution validation...\n")
@@ -337,6 +359,7 @@ class ContributionValidator:
             self.check_type_checking,
             self.check_tests,
             self.check_examples_smoke,
+            self.check_cli_smoke,
             self.check_documentation,
             self.check_commit_messages,
         ]

--- a/src/skdr_eval/__init__.py
+++ b/src/skdr_eval/__init__.py
@@ -29,6 +29,7 @@ from .core import (
     induce_policy_from_sklearn,
 )
 from .diagnostics import PropensityDiagnostics
+from .doctor import Check, DoctorReport, doctor
 from .exceptions import (
     BootstrapError,
     ConfigurationError,
@@ -54,15 +55,23 @@ from .models import (
 )
 from .pairwise import PairwiseDesign
 from .reporting import (
+    CARD_SCHEMA_VERSION,
     SCHEMA_VERSION,
     ArtifactSchema,
+    CoverageSimBlock,
     DiagnosticGate,
+    DiagnosticsBlock,
     EvaluationArtifact,
+    EvaluationCard,
     GateResult,
+    HeadlineBlock,
+    ProvenanceBlock,
     Reason,
     Recommendation,
     RecommendationPolicy,
+    SensitivityBlock,
     SupportHealthThresholds,
+    TrustBlock,
     attach_warnings,
     build_evaluation_artifact,
     export_results,
@@ -84,6 +93,7 @@ from .statistical import (
     t_test,
 )
 from .synth import make_pairwise_synth, make_synth_logs
+from .trackers import FileTracker, NullTracker, Tracker
 from .validation import validate_logs, validate_pairwise_inputs
 
 try:
@@ -110,22 +120,30 @@ except ImportError:
     pass
 
 __all__ = [
+    "CARD_SCHEMA_VERSION",
     "HAS_VISUALIZATION",
     "SCHEMA_VERSION",
     "ArtifactSchema",
     "BootstrapError",
+    "Check",
     "ConfigManager",
     "ConfigurationError",
     "ConvergenceError",
     "CoverageResult",
+    "CoverageSimBlock",
     "DRResult",
     "DataValidationError",
     "Design",
     "DiagnosticGate",
+    "DiagnosticsBlock",
+    "DoctorReport",
     "EstimationError",
     "EvaluationArtifact",
+    "EvaluationCard",
     "EvaluationConfig",
+    "FileTracker",
     "GateResult",
+    "HeadlineBlock",
     "InsufficientDataError",
     "MemoryError",
     "ModelConfig",
@@ -133,18 +151,23 @@ __all__ = [
     "ModelFactory",
     "ModelSelector",
     "ModelValidationError",
+    "NullTracker",
     "OutcomeModelError",
     "PairwiseDesign",
     "PairwiseEvaluationError",
     "PolicyInductionError",
     "PropensityDiagnostics",
     "PropensityScoreError",
+    "ProvenanceBlock",
     "Reason",
     "Recommendation",
     "RecommendationPolicy",
+    "SensitivityBlock",
     "SkdrEvalError",
     "StatisticalTest",
     "SupportHealthThresholds",
+    "Tracker",
+    "TrustBlock",
     "VersionError",
     "VisualizationConfig",
     "__version__",
@@ -155,6 +178,7 @@ __all__ = [
     "build_evaluation_artifact",
     "chi_square_test",
     "create_model_ensemble",
+    "doctor",
     "dr_value_with_clip",
     "evaluate_pairwise_models",
     "evaluate_propensity_diagnostics",

--- a/src/skdr_eval/cli.py
+++ b/src/skdr_eval/cli.py
@@ -95,8 +95,6 @@ def _normalize_loaded_dataframe(df: pd.DataFrame) -> pd.DataFrame:
     - Object columns whose first cell is a numpy ndarray are unboxed to
       Python lists (matches the in-memory shape produced by
       :func:`skdr_eval.make_pairwise_synth`).
-    - Object columns whose first cell parses as a datetime are coerced via
-      :func:`pandas.to_datetime` so the design builder accepts them.
     """
     import numpy as np  # noqa: PLC0415
 
@@ -346,16 +344,23 @@ def evaluate_cmd(
     logs_df = _load_dataframe(logs)
     models = _parse_model_specs(model)
     tracker = FileTracker(tracker_dir) if tracker_dir is not None else None
-    artifact = skdr_eval.evaluate_sklearn_models(
-        logs=logs_df,
-        models=models,
-        fit_models=False,
-        n_splits=n_splits,
-        random_state=random_state,
-        ci_bootstrap=ci_bootstrap,
-        policy_train=policy_train,
-        tracker=tracker,
-    )
+    try:
+        artifact = skdr_eval.evaluate_sklearn_models(
+            logs=logs_df,
+            models=models,
+            fit_models=False,
+            n_splits=n_splits,
+            random_state=random_state,
+            ci_bootstrap=ci_bootstrap,
+            policy_train=policy_train,
+            tracker=tracker,
+        )
+    except skdr_eval.SkdrEvalError as exc:
+        typer.secho(f"Evaluation error: {exc}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=EXIT_DATA) from exc
+    except ValueError as exc:
+        typer.secho(f"Evaluation error: {exc}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=EXIT_DATA) from exc
     paths = _write_artifact_outputs(artifact, out)
     typer.echo(f"Wrote {len(paths)} files to {out}.")
     raise typer.Exit(code=_verdict_exit_code(artifact))
@@ -407,19 +412,26 @@ def pairwise_cmd(
     op_df = _load_dataframe(op_daily)
     models = _parse_model_specs(model)
     tracker = FileTracker(tracker_dir) if tracker_dir is not None else None
-    artifact = skdr_eval.evaluate_pairwise_models(
-        logs_df=logs_df,
-        op_daily_df=op_df,
-        models=models,
-        metric_col=metric_col,
-        task_type=task_type,  # type: ignore[arg-type]
-        direction=direction,  # type: ignore[arg-type]
-        n_splits=n_splits,
-        strategy=strategy,  # type: ignore[arg-type]
-        random_state=random_state,
-        ci_bootstrap=ci_bootstrap,
-        tracker=tracker,
-    )
+    try:
+        artifact = skdr_eval.evaluate_pairwise_models(
+            logs_df=logs_df,
+            op_daily_df=op_df,
+            models=models,
+            metric_col=metric_col,
+            task_type=task_type,  # type: ignore[arg-type]
+            direction=direction,  # type: ignore[arg-type]
+            n_splits=n_splits,
+            strategy=strategy,  # type: ignore[arg-type]
+            random_state=random_state,
+            ci_bootstrap=ci_bootstrap,
+            tracker=tracker,
+        )
+    except skdr_eval.SkdrEvalError as exc:
+        typer.secho(f"Evaluation error: {exc}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=EXIT_DATA) from exc
+    except ValueError as exc:
+        typer.secho(f"Evaluation error: {exc}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=EXIT_DATA) from exc
     paths = _write_artifact_outputs(artifact, out)
     typer.echo(f"Wrote {len(paths)} files to {out}.")
     raise typer.Exit(code=_verdict_exit_code(artifact))

--- a/src/skdr_eval/cli.py
+++ b/src/skdr_eval/cli.py
@@ -1,0 +1,577 @@
+"""``skdr-eval`` CLI (Typer) — implements #89.
+
+Subcommands
+-----------
+- ``evaluate``        — run :func:`skdr_eval.evaluate_sklearn_models`
+- ``pairwise``        — run :func:`skdr_eval.evaluate_pairwise_models`
+- ``card``            — re-render the YAML card from a saved artifact JSON
+- ``validate-schema`` — call ``validate_logs`` / ``validate_pairwise_inputs``
+- ``doctor``          — run :func:`skdr_eval.doctor`
+- ``version``         — print the package version
+
+Exit codes
+----------
+* ``0`` — success.
+* ``1`` — data / schema error (the doctor or a validator flagged ``fail``).
+* ``2`` — environment / import error (a required optional dep is missing).
+* ``3`` — at least one card's recommendation verdict was ``do_not_deploy``;
+  use this exit code as a CI gate.
+
+The CLI is gated behind the ``[cli]`` extra (``pip install
+'skdr-eval[cli]'``). Importing this module without ``typer`` installed
+raises a structured :class:`ImportError`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import typer
+except ImportError as exc:  # pragma: no cover - exercised via tests for the message
+    msg = (
+        "The 'skdr-eval' CLI requires the [cli] extra. "
+        "Install with: pip install 'skdr-eval[cli]'"
+    )
+    raise ImportError(msg) from exc
+
+import pandas as pd
+
+import skdr_eval
+from skdr_eval.doctor import doctor as doctor_fn
+from skdr_eval.trackers import FileTracker
+
+logger = logging.getLogger("skdr_eval.cli")
+
+EXIT_OK = 0
+EXIT_DATA = 1
+EXIT_ENV = 2
+EXIT_DO_NOT_DEPLOY = 3
+
+app = typer.Typer(
+    name="skdr-eval",
+    help="CLI for the skdr-eval offline policy-evaluation library.",
+    no_args_is_help=True,
+    add_completion=True,
+)
+
+
+def _load_dataframe(path: Path) -> pd.DataFrame:
+    """Auto-detect ``.parquet`` / ``.csv`` / ``.feather`` based on suffix.
+
+    Raises :class:`typer.Exit` with code ``EXIT_DATA`` on unknown suffix or
+    read error.
+    """
+    suffix = path.suffix.lower()
+    try:
+        if suffix in {".parquet", ".pq"}:
+            df = pd.read_parquet(path)
+        elif suffix in {".feather", ".arrow"}:
+            df = pd.read_feather(path)
+        elif suffix in {".csv", ".tsv"}:
+            sep = "\t" if suffix == ".tsv" else ","
+            df = pd.read_csv(path, sep=sep)
+        else:
+            typer.secho(
+                f"Unknown input format for {path} (suffix={suffix!r}); "
+                f"expected .parquet/.csv/.tsv/.feather.",
+                fg=typer.colors.RED,
+                err=True,
+            )
+            raise typer.Exit(code=EXIT_DATA)
+    except (OSError, ValueError) as exc:
+        typer.secho(f"Failed to read {path}: {exc}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=EXIT_DATA) from exc
+    return _normalize_loaded_dataframe(df)
+
+
+def _normalize_loaded_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Normalize known quirks introduced by parquet round-trips.
+
+    - Object columns whose first cell is a numpy ndarray are unboxed to
+      Python lists (matches the in-memory shape produced by
+      :func:`skdr_eval.make_pairwise_synth`).
+    - Object columns whose first cell parses as a datetime are coerced via
+      :func:`pandas.to_datetime` so the design builder accepts them.
+    """
+    import numpy as np  # noqa: PLC0415
+
+    for col in df.columns:
+        series = df[col]
+        if series.dtype != object or series.empty:
+            continue
+        first_non_null = next(
+            (v for v in series.to_numpy() if v is not None),
+            None,
+        )
+        if first_non_null is None:
+            continue
+        if isinstance(first_non_null, np.ndarray):
+            df[col] = series.map(
+                lambda v: v.tolist() if isinstance(v, np.ndarray) else v
+            )
+    return df
+
+
+def _load_model(path: Path) -> Any:
+    """Load a pickled / joblib model. Refuse non-local schemes."""
+    if "://" in str(path):
+        typer.secho(
+            f"Refusing to load model from {path}: only local paths are allowed.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=EXIT_DATA)
+    try:
+        import joblib  # noqa: PLC0415
+    except ImportError as exc:
+        typer.secho(
+            "joblib is required to load models. "
+            "Install with: pip install 'skdr-eval[cli]'",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=EXIT_ENV) from exc
+    if not path.exists():
+        typer.secho(f"Model file not found: {path}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=EXIT_DATA)
+    return joblib.load(path)
+
+
+def _parse_model_specs(specs: list[str]) -> dict[str, Any]:
+    """Parse ``--model NAME=PATH`` tokens into a dict of fitted estimators."""
+    out: dict[str, Any] = {}
+    for token in specs:
+        if "=" not in token:
+            typer.secho(
+                f"Expected '--model NAME=PATH', got {token!r}.",
+                fg=typer.colors.RED,
+                err=True,
+            )
+            raise typer.Exit(code=EXIT_DATA)
+        name, _, path_str = token.partition("=")
+        if not name or not path_str:
+            typer.secho(
+                f"Empty model name or path in {token!r}.",
+                fg=typer.colors.RED,
+                err=True,
+            )
+            raise typer.Exit(code=EXIT_DATA)
+        out[name] = _load_model(Path(path_str))
+    return out
+
+
+def _ensure_out_dir(out: Path) -> Path:
+    out.mkdir(parents=True, exist_ok=True)
+    return out
+
+
+def _write_artifact_outputs(
+    artifact: skdr_eval.EvaluationArtifact, out: Path
+) -> dict[str, Path]:
+    """Write JSON + HTML report + one card YAML per ``(model, estimator)``."""
+    out = _ensure_out_dir(out)
+    paths: dict[str, Path] = {}
+
+    schema = artifact.to_schema()
+    json_path = out / "artifact.json"
+    json_path.write_text(schema.model_dump_json(indent=2), encoding="utf-8")
+    paths["artifact.json"] = json_path
+
+    report_path = out / "report.html"
+    artifact.to_html(report_path)
+    paths["report.html"] = report_path
+
+    cards_dir = out / "cards"
+    cards_dir.mkdir(parents=True, exist_ok=True)
+    for model_name in artifact.detailed:
+        for estimator in ("DR", "SNDR"):
+            if estimator not in artifact.detailed[model_name]:
+                continue
+            card = artifact.card_schema(model_name, estimator=estimator)
+            yaml_path = cards_dir / f"{model_name}_{estimator}.card.yaml"
+            json_path_card = cards_dir / f"{model_name}_{estimator}.card.json"
+            card.to_yaml(yaml_path)
+            card.to_json(json_path_card)
+            paths[yaml_path.name] = yaml_path
+            paths[json_path_card.name] = json_path_card
+
+    return paths
+
+
+def _verdict_exit_code(artifact: skdr_eval.EvaluationArtifact) -> int:
+    """Return ``EXIT_DO_NOT_DEPLOY`` if any model's recommendation is ``do_not_deploy``."""
+    for model_name in artifact.detailed:
+        for estimator in ("SNDR", "DR"):
+            if estimator not in artifact.detailed[model_name]:
+                continue
+            try:
+                rec = artifact.recommendation(model_name, estimator=estimator)
+            except Exception:
+                continue
+            if rec.verdict == "do_not_deploy":
+                return EXIT_DO_NOT_DEPLOY
+    return EXIT_OK
+
+
+@app.command("version")
+def version_cmd() -> None:
+    """Print the installed skdr-eval version."""
+    typer.echo(skdr_eval.__version__)
+
+
+@app.command("doctor")
+def doctor_cmd(
+    logs: Path = typer.Argument(
+        ..., exists=True, readable=True, help="Logs file (parquet/csv/feather)."
+    ),
+    kind: str = typer.Option("standard", "--kind", help="standard | pairwise"),
+    op_daily: Path | None = typer.Option(
+        None, "--op-daily", help="op_daily_df (pairwise only)."
+    ),
+    metric_col: str = typer.Option(
+        "service_time", "--metric-col", help="Outcome column."
+    ),
+    n_splits: int = typer.Option(3, "--n-splits", min=1, help="CV split count."),
+    strict: bool = typer.Option(
+        False, "--strict/--no-strict", help="Strict schema validation."
+    ),
+    json_out: bool = typer.Option(
+        False, "--json", help="Emit JSON instead of a text table."
+    ),
+) -> None:
+    """Run preflight diagnostics on input data + environment."""
+    if kind not in {"standard", "pairwise"}:
+        typer.secho(
+            f"--kind must be 'standard' or 'pairwise' (got {kind!r}).",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=EXIT_DATA)
+    logs_df = _load_dataframe(logs)
+    op_daily_df = _load_dataframe(op_daily) if op_daily is not None else None
+    report = doctor_fn(
+        logs_df,
+        kind=kind,  # type: ignore[arg-type]
+        op_daily_df=op_daily_df,
+        metric_col=metric_col,
+        n_splits=n_splits,
+        strict=strict,
+    )
+    if json_out:
+        typer.echo(json.dumps(report.to_dict(), indent=2))
+    else:
+        report.print(color=sys.stdout.isatty())
+    if not report.ok:
+        raise typer.Exit(code=EXIT_DATA)
+
+
+@app.command("validate-schema")
+def validate_schema_cmd(
+    logs: Path = typer.Argument(
+        ..., exists=True, readable=True, help="Logs file (parquet/csv/feather)."
+    ),
+    kind: str = typer.Option("standard", "--kind", help="'standard' or 'pairwise'."),
+    op_daily: Path | None = typer.Option(
+        None, "--op-daily", help="op_daily_df (pairwise only)."
+    ),
+    metric_col: str = typer.Option(
+        "service_time", "--metric-col", help="Outcome column (pairwise)."
+    ),
+    strict: bool = typer.Option(
+        False, "--strict/--no-strict", help="Strict schema validation."
+    ),
+) -> None:
+    """Validate that ``logs`` matches the standard or pairwise schema."""
+    if kind not in {"standard", "pairwise"}:
+        typer.secho(
+            f"--kind must be 'standard' or 'pairwise' (got {kind!r}).",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=EXIT_DATA)
+    logs_df = _load_dataframe(logs)
+    try:
+        if kind == "standard":
+            skdr_eval.validate_logs(logs_df, strict=strict)
+        else:
+            if op_daily is None:
+                typer.secho(
+                    "--op-daily is required for kind='pairwise'.",
+                    fg=typer.colors.RED,
+                    err=True,
+                )
+                raise typer.Exit(code=EXIT_DATA)
+            op_df = _load_dataframe(op_daily)
+            skdr_eval.validate_pairwise_inputs(
+                logs_df, op_df, metric_col=metric_col, strict=strict
+            )
+    except (
+        skdr_eval.DataValidationError,
+        skdr_eval.InsufficientDataError,
+    ) as exc:
+        typer.secho(f"schema FAIL: {exc}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=EXIT_DATA) from exc
+    typer.secho("schema OK", fg=typer.colors.GREEN)
+
+
+@app.command("evaluate")
+def evaluate_cmd(
+    logs: Path = typer.Argument(
+        ..., exists=True, readable=True, help="Logs file (parquet/csv/feather)."
+    ),
+    model: list[str] = typer.Option(
+        ..., "--model", help="Repeatable. Format: NAME=PATH_TO_PICKLE."
+    ),
+    out: Path = typer.Option(
+        Path("./skdr_eval_out"), "--out", help="Output directory."
+    ),
+    policy_train: str = typer.Option(
+        "pre_split", "--policy-train", help="'pre_split' or 'all'."
+    ),
+    n_splits: int = typer.Option(3, "--n-splits", min=1),
+    ci_bootstrap: bool = typer.Option(
+        False, "--ci-bootstrap/--no-ci-bootstrap", help="Compute bootstrap CIs."
+    ),
+    random_state: int = typer.Option(0, "--random-state"),
+    tracker_dir: Path | None = typer.Option(
+        None, "--tracker-dir", help="Optional FileTracker output directory."
+    ),
+) -> None:
+    """Run :func:`evaluate_sklearn_models` on local logs + pickled models."""
+    logs_df = _load_dataframe(logs)
+    models = _parse_model_specs(model)
+    tracker = FileTracker(tracker_dir) if tracker_dir is not None else None
+    artifact = skdr_eval.evaluate_sklearn_models(
+        logs=logs_df,
+        models=models,
+        fit_models=False,
+        n_splits=n_splits,
+        random_state=random_state,
+        ci_bootstrap=ci_bootstrap,
+        policy_train=policy_train,
+        tracker=tracker,
+    )
+    paths = _write_artifact_outputs(artifact, out)
+    typer.echo(f"Wrote {len(paths)} files to {out}.")
+    raise typer.Exit(code=_verdict_exit_code(artifact))
+
+
+@app.command("pairwise")
+def pairwise_cmd(
+    logs: Path = typer.Argument(
+        ..., exists=True, readable=True, help="Logs file (parquet/csv/feather)."
+    ),
+    op_daily: Path = typer.Argument(
+        ..., exists=True, readable=True, help="op_daily_df file."
+    ),
+    model: list[str] = typer.Option(
+        ..., "--model", help="Repeatable. Format: NAME=PATH_TO_PICKLE."
+    ),
+    metric_col: str = typer.Option("service_time", "--metric-col"),
+    task_type: str = typer.Option(
+        "regression", "--task-type", help="regression|binary"
+    ),
+    direction: str = typer.Option("min", "--direction", help="min|max"),
+    out: Path = typer.Option(Path("./skdr_eval_out"), "--out"),
+    strategy: str = typer.Option(
+        "auto", "--strategy", help="auto|direct|stream|stream_topk"
+    ),
+    n_splits: int = typer.Option(3, "--n-splits", min=1),
+    random_state: int = typer.Option(0, "--random-state"),
+    ci_bootstrap: bool = typer.Option(False, "--ci-bootstrap/--no-ci-bootstrap"),
+    tracker_dir: Path | None = typer.Option(
+        None, "--tracker-dir", help="Optional FileTracker output directory."
+    ),
+) -> None:
+    """Run :func:`evaluate_pairwise_models` end-to-end."""
+    if task_type not in {"regression", "binary"}:
+        typer.secho(
+            f"--task-type must be 'regression' or 'binary' (got {task_type!r}).",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=EXIT_DATA)
+    if direction not in {"min", "max"}:
+        typer.secho(
+            f"--direction must be 'min' or 'max' (got {direction!r}).",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=EXIT_DATA)
+    logs_df = _load_dataframe(logs)
+    op_df = _load_dataframe(op_daily)
+    models = _parse_model_specs(model)
+    tracker = FileTracker(tracker_dir) if tracker_dir is not None else None
+    artifact = skdr_eval.evaluate_pairwise_models(
+        logs_df=logs_df,
+        op_daily_df=op_df,
+        models=models,
+        metric_col=metric_col,
+        task_type=task_type,  # type: ignore[arg-type]
+        direction=direction,  # type: ignore[arg-type]
+        n_splits=n_splits,
+        strategy=strategy,  # type: ignore[arg-type]
+        random_state=random_state,
+        ci_bootstrap=ci_bootstrap,
+        tracker=tracker,
+    )
+    paths = _write_artifact_outputs(artifact, out)
+    typer.echo(f"Wrote {len(paths)} files to {out}.")
+    raise typer.Exit(code=_verdict_exit_code(artifact))
+
+
+@app.command("card")
+def card_cmd(
+    artifact_json: Path = typer.Argument(
+        ..., exists=True, readable=True, help="Path to artifact.json."
+    ),
+    model_name: str = typer.Option(..., "--model", help="Model name."),
+    estimator: str = typer.Option("SNDR", "--estimator", help="DR or SNDR."),
+    out: Path = typer.Option(Path("./card.yaml"), "--out", help="Output card path."),
+    fmt: str = typer.Option("yaml", "--format", help="'yaml' or 'json'."),
+) -> None:
+    """Render an :class:`EvaluationCard` from a saved ``artifact.json``."""
+    if fmt not in {"yaml", "json"}:
+        typer.secho(
+            f"--format must be 'yaml' or 'json' (got {fmt!r}).",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=EXIT_DATA)
+    schema = skdr_eval.load_artifact_json(artifact_json)
+    card = _card_from_artifact_schema(
+        schema, model_name=model_name, estimator=estimator
+    )
+    if fmt == "yaml":
+        card.to_yaml(out)
+    else:
+        card.to_json(out)
+    typer.echo(f"Wrote {out}")
+
+
+def _card_from_artifact_schema(
+    schema: skdr_eval.ArtifactSchema, *, model_name: str, estimator: str
+) -> skdr_eval.EvaluationCard:
+    """Reconstruct an :class:`EvaluationCard` directly from a saved schema.
+
+    Unlike :meth:`EvaluationArtifact.card_schema`, this path does not invoke
+    :func:`gate_diagnostics` or :meth:`recommendation` — the saved artifact
+    does not retain the per-decision contributions those helpers can inspect.
+    The resulting card has the same headline / diagnostics / sensitivity /
+    provenance fields as a live ``card_schema()`` call.
+    """
+    from .reporting import (  # noqa: PLC0415
+        DiagnosticsBlock,
+        EvaluationCard,
+        HeadlineBlock,
+        ProvenanceBlock,
+        SensitivityBlock,
+        TrustBlock,
+        _coerce_optional_float,
+    )
+
+    row = next(
+        (
+            r
+            for r in schema.report
+            if r.model == model_name and r.estimator == estimator
+        ),
+        None,
+    )
+    if row is None:
+        typer.secho(
+            f"No row in artifact for model={model_name!r}, estimator={estimator!r}.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(code=EXIT_DATA)
+    sens = next(
+        (
+            s
+            for s in schema.sensitivity
+            if s.model == model_name and s.estimator == estimator
+        ),
+        None,
+    )
+    warn = next(
+        (
+            w
+            for w in schema.warnings
+            if w.model == model_name and w.estimator == estimator
+        ),
+        None,
+    )
+
+    diag_payload = schema.diagnostics.get(model_name)
+
+    headline = HeadlineBlock(
+        estimator=estimator,
+        V_hat=_coerce_optional_float(row.V_hat),
+        ci_lower=_coerce_optional_float(row.ci_lower),
+        ci_upper=_coerce_optional_float(row.ci_upper),
+        ci_alpha=_coerce_optional_float(schema.metadata.get("alpha")),
+        baseline=None,
+        delta_vs_baseline=None,
+        clip=_coerce_optional_float(row.clip),
+    )
+    trust = TrustBlock(
+        support_health=row.support_health,
+        warning_codes=list(warn.warning_codes) if warn is not None else [],
+        recommendation=None,
+        primary_blocker=None,
+    )
+    n = int(schema.metadata.get("n_samples", 0)) or None
+    ess_val = _coerce_optional_float(row.ESS)
+    diagnostics_block = DiagnosticsBlock(
+        ESS=ess_val,
+        ess_frac=(ess_val / n) if (ess_val is not None and n) else None,
+        match_rate=_coerce_optional_float(row.match_rate),
+        pareto_k=_coerce_optional_float(row.pareto_k),
+        min_pscore=_coerce_optional_float(row.min_pscore),
+        tail_mass=_coerce_optional_float(row.tail_mass),
+        ece=_coerce_optional_float(diag_payload.ece) if diag_payload else None,
+        brier_score=(
+            _coerce_optional_float(diag_payload.brier_score) if diag_payload else None
+        ),
+        gate=None,
+    )
+    sensitivity_block = (
+        SensitivityBlock()
+        if sens is None
+        else SensitivityBlock(
+            V_min=_coerce_optional_float(sens.V_min),
+            V_max=_coerce_optional_float(sens.V_max),
+            V_range=_coerce_optional_float(sens.V_range),
+            chosen_clip=_coerce_optional_float(sens.chosen_clip),
+            chosen_V=_coerce_optional_float(sens.chosen_V),
+            argmin_MSE_clip=_coerce_optional_float(sens.argmin_MSE_clip),
+            dr_sndr_agree=bool(sens.dr_sndr_agree),
+            stable=bool(sens.stable),
+        )
+    )
+    provenance = ProvenanceBlock(
+        skdr_eval_version=schema.skdr_eval_version,
+        schema_version=schema.schema_version,
+        timestamp=schema.timestamp,
+        n_samples=n,
+        n_splits=schema.metadata.get("n_splits"),
+        random_state=schema.metadata.get("random_state"),
+        evaluator=schema.metadata.get("evaluator"),
+    )
+    return EvaluationCard(
+        model_name=model_name,
+        headline=headline,
+        trust=trust,
+        diagnostics=diagnostics_block,
+        sensitivity=sensitivity_block,
+        provenance=provenance,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/src/skdr_eval/cli.py
+++ b/src/skdr_eval/cli.py
@@ -116,7 +116,12 @@ def _normalize_loaded_dataframe(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def _load_model(path: Path) -> Any:
-    """Load a pickled / joblib model. Refuse non-local schemes."""
+    """Load a pickled / joblib model. Refuse non-local schemes.
+
+    .. warning::
+        ``joblib.load`` uses pickle under the hood and can execute arbitrary
+        code. Only load model files that you or your team created.
+    """
     if "://" in str(path):
         typer.secho(
             f"Refusing to load model from {path}: only local paths are allowed.",
@@ -191,8 +196,9 @@ def _write_artifact_outputs(
             if estimator not in artifact.detailed[model_name]:
                 continue
             card = artifact.card_schema(model_name, estimator=estimator)
-            yaml_path = cards_dir / f"{model_name}_{estimator}.card.yaml"
-            json_path_card = cards_dir / f"{model_name}_{estimator}.card.json"
+            safe_name = model_name.replace("/", "_").replace("\\", "_").replace("..", "_")
+            yaml_path = cards_dir / f"{safe_name}_{estimator}.card.yaml"
+            json_path_card = cards_dir / f"{safe_name}_{estimator}.card.json"
             card.to_yaml(yaml_path)
             card.to_json(json_path_card)
             paths[yaml_path.name] = yaml_path
@@ -484,8 +490,19 @@ def _card_from_artifact_schema(
         ProvenanceBlock,
         SensitivityBlock,
         TrustBlock,
-        _coerce_optional_float,
     )
+
+    def _coerce_float(value: Any) -> float | None:
+        """Coerce to float | None; non-finite → None."""
+        if value is None:
+            return None
+        try:
+            v = float(value)
+        except (TypeError, ValueError):
+            return None
+        import math  # noqa: PLC0415
+
+        return v if math.isfinite(v) else None
 
     row = next(
         (
@@ -523,13 +540,13 @@ def _card_from_artifact_schema(
 
     headline = HeadlineBlock(
         estimator=estimator,
-        V_hat=_coerce_optional_float(row.V_hat),
-        ci_lower=_coerce_optional_float(row.ci_lower),
-        ci_upper=_coerce_optional_float(row.ci_upper),
-        ci_alpha=_coerce_optional_float(schema.metadata.get("alpha")),
+        V_hat=_coerce_float(row.V_hat),
+        ci_lower=_coerce_float(row.ci_lower),
+        ci_upper=_coerce_float(row.ci_upper),
+        ci_alpha=_coerce_float(schema.metadata.get("alpha")),
         baseline=None,
         delta_vs_baseline=None,
-        clip=_coerce_optional_float(row.clip),
+        clip=_coerce_float(row.clip),
     )
     trust = TrustBlock(
         support_health=row.support_health,
@@ -538,17 +555,17 @@ def _card_from_artifact_schema(
         primary_blocker=None,
     )
     n = int(schema.metadata.get("n_samples", 0)) or None
-    ess_val = _coerce_optional_float(row.ESS)
+    ess_val = _coerce_float(row.ESS)
     diagnostics_block = DiagnosticsBlock(
         ESS=ess_val,
         ess_frac=(ess_val / n) if (ess_val is not None and n) else None,
-        match_rate=_coerce_optional_float(row.match_rate),
-        pareto_k=_coerce_optional_float(row.pareto_k),
-        min_pscore=_coerce_optional_float(row.min_pscore),
-        tail_mass=_coerce_optional_float(row.tail_mass),
-        ece=_coerce_optional_float(diag_payload.ece) if diag_payload else None,
+        match_rate=_coerce_float(row.match_rate),
+        pareto_k=_coerce_float(row.pareto_k),
+        min_pscore=_coerce_float(row.min_pscore),
+        tail_mass=_coerce_float(row.tail_mass),
+        ece=_coerce_float(diag_payload.ece) if diag_payload else None,
         brier_score=(
-            _coerce_optional_float(diag_payload.brier_score) if diag_payload else None
+            _coerce_float(diag_payload.brier_score) if diag_payload else None
         ),
         gate=None,
     )
@@ -556,12 +573,12 @@ def _card_from_artifact_schema(
         SensitivityBlock()
         if sens is None
         else SensitivityBlock(
-            V_min=_coerce_optional_float(sens.V_min),
-            V_max=_coerce_optional_float(sens.V_max),
-            V_range=_coerce_optional_float(sens.V_range),
-            chosen_clip=_coerce_optional_float(sens.chosen_clip),
-            chosen_V=_coerce_optional_float(sens.chosen_V),
-            argmin_MSE_clip=_coerce_optional_float(sens.argmin_MSE_clip),
+            V_min=_coerce_float(sens.V_min),
+            V_max=_coerce_float(sens.V_max),
+            V_range=_coerce_float(sens.V_range),
+            chosen_clip=_coerce_float(sens.chosen_clip),
+            chosen_V=_coerce_float(sens.chosen_V),
+            argmin_MSE_clip=_coerce_float(sens.argmin_MSE_clip),
             dr_sndr_agree=bool(sens.dr_sndr_agree),
             stable=bool(sens.stable),
         )

--- a/src/skdr_eval/cli.py
+++ b/src/skdr_eval/cli.py
@@ -196,7 +196,9 @@ def _write_artifact_outputs(
             if estimator not in artifact.detailed[model_name]:
                 continue
             card = artifact.card_schema(model_name, estimator=estimator)
-            safe_name = model_name.replace("/", "_").replace("\\", "_").replace("..", "_")
+            safe_name = (
+                model_name.replace("/", "_").replace("\\", "_").replace("..", "_")
+            )
             yaml_path = cards_dir / f"{safe_name}_{estimator}.card.yaml"
             json_path_card = cards_dir / f"{safe_name}_{estimator}.card.json"
             card.to_yaml(yaml_path)
@@ -564,9 +566,7 @@ def _card_from_artifact_schema(
         min_pscore=_coerce_float(row.min_pscore),
         tail_mass=_coerce_float(row.tail_mass),
         ece=_coerce_float(diag_payload.ece) if diag_payload else None,
-        brier_score=(
-            _coerce_float(diag_payload.brier_score) if diag_payload else None
-        ),
+        brier_score=(_coerce_float(diag_payload.brier_score) if diag_payload else None),
         gate=None,
     )
     sensitivity_block = (

--- a/src/skdr_eval/core.py
+++ b/src/skdr_eval/core.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal, Protocol
 
 if TYPE_CHECKING:
     from .reporting import EvaluationArtifact, SupportHealthThresholds
+    from .trackers import Tracker
 
 import numpy as np
 import pandas as pd
@@ -54,6 +55,69 @@ from .validation import (
 )
 
 logger = logging.getLogger("skdr_eval")
+
+
+def _autolog_tracker(
+    tracker: "Tracker | None",
+    artifact: "EvaluationArtifact",
+    *,
+    evaluator: str,
+) -> None:
+    """Push metrics, tags, and one card per model to ``tracker`` (#93).
+
+    Silently returns when ``tracker is None`` (the default). Errors from the
+    tracker are logged but not re-raised — instrumentation must never break a
+    finished evaluation.
+    """
+    if tracker is None:
+        return
+    try:
+        tracker.set_tag("evaluator", evaluator)
+        version = artifact.metadata.get("skdr_eval_version")
+        if version is not None:
+            tracker.set_tag("skdr_eval_version", str(version))
+        seed = artifact.metadata.get("random_state")
+        if seed is not None:
+            tracker.set_tag("random_state", str(seed))
+        n_splits_meta = artifact.metadata.get("n_splits")
+        if n_splits_meta is not None:
+            tracker.set_tag("n_splits", str(n_splits_meta))
+        for _, row in artifact.report.iterrows():
+            prefix = f"{row['model']}/{row['estimator']}"
+            for col in (
+                "V_hat",
+                "ci_lower",
+                "ci_upper",
+                "ESS",
+                "match_rate",
+                "pareto_k",
+            ):
+                value = row.get(col)
+                if value is None:
+                    continue
+                try:
+                    fvalue = float(value)
+                except (TypeError, ValueError):
+                    continue
+                if not np.isfinite(fvalue):
+                    continue
+                tracker.log_metric(f"{prefix}/{col}", fvalue)
+        for model_name in artifact.detailed:
+            for estimator in ("DR", "SNDR"):
+                if estimator not in artifact.detailed[model_name]:
+                    continue
+                try:
+                    card = artifact.card_schema(model_name, estimator=estimator)
+                    tracker.log_card(card)
+                except Exception as exc:
+                    logger.warning(
+                        "tracker.log_card failed for %s/%s: %s",
+                        model_name,
+                        estimator,
+                        exc,
+                    )
+    except Exception as exc:
+        logger.warning("tracker auto-log failed: %s", exc)
 
 
 def _make_time_series_split(
@@ -1276,6 +1340,7 @@ def evaluate_sklearn_models(
     max_train_size: int | None = None,
     keep_contributions: bool = False,
     max_kept_contributions: int = DEFAULT_MAX_KEPT_CONTRIBUTIONS,
+    tracker: "Tracker | None" = None,
 ) -> "EvaluationArtifact":
     """Evaluate sklearn models using DR and SNDR estimators.
 
@@ -1580,7 +1645,7 @@ def evaluate_sklearn_models(
 
     from .reporting import build_evaluation_artifact  # noqa: PLC0415
 
-    return build_evaluation_artifact(
+    artifact = build_evaluation_artifact(
         report=report,
         detailed=detailed_results,
         n_samples=len(eval_design.Y),
@@ -1598,6 +1663,8 @@ def evaluate_sklearn_models(
             "ci_bootstrap": bool(ci_bootstrap),
         },
     )
+    _autolog_tracker(tracker, artifact, evaluator="evaluate_sklearn_models")
+    return artifact
 
 
 def _get_outcome_estimator(estimator: str | Callable[[], Any], task_type: str) -> Any:
@@ -1978,6 +2045,7 @@ def evaluate_pairwise_models(
     max_train_size: int | None = None,
     keep_contributions: bool = False,
     max_kept_contributions: int = DEFAULT_MAX_KEPT_CONTRIBUTIONS,
+    tracker: "Tracker | None" = None,
 ) -> "EvaluationArtifact":
     """Evaluate pairwise models using autoscale strategy.
 
@@ -2473,7 +2541,7 @@ def evaluate_pairwise_models(
 
     from .reporting import build_evaluation_artifact  # noqa: PLC0415
 
-    return build_evaluation_artifact(
+    artifact = build_evaluation_artifact(
         report=report,
         detailed=detailed_results,
         n_samples=len(Y),
@@ -2496,6 +2564,8 @@ def evaluate_pairwise_models(
             "ci_bootstrap": bool(ci_bootstrap),
         },
     )
+    _autolog_tracker(tracker, artifact, evaluator="evaluate_pairwise_models")
+    return artifact
 
 
 def evaluate_propensity_diagnostics(

--- a/src/skdr_eval/doctor.py
+++ b/src/skdr_eval/doctor.py
@@ -463,6 +463,18 @@ def doctor(
         checks.append(input_err)
         return _finalize_report(checks)
 
+    if kind not in ("standard", "pairwise"):
+        checks.append(
+            Check(
+                name="kind",
+                status="fail",
+                message=f"Unknown kind={kind!r}. Expected 'standard' or 'pairwise'.",
+                fix_hint="Pass kind='standard' or kind='pairwise'.",
+                category="input",
+            )
+        )
+        return _finalize_report(checks)
+
     if kind == "pairwise":
         checks.append(
             _check_pairwise_schema(logs, op_daily_df, metric_col, strict=strict)
@@ -475,7 +487,7 @@ def doctor(
         outcome_cols: tuple[str, ...] = (metric_col,)
     else:
         checks.append(_check_logs_schema(logs, strict=strict))
-        checks.append(_check_no_duplicates(logs, key_cols=["client_id", "ts"]))
+        checks.append(_check_no_duplicates(logs, key_cols=["client_id", "arrival_ts"]))
         outcome_cols = ("service_time", "reward", "y")
 
     checks.append(_check_finite_outcomes(logs, outcome_cols=outcome_cols))

--- a/src/skdr_eval/doctor.py
+++ b/src/skdr_eval/doctor.py
@@ -1,0 +1,500 @@
+"""Preflight diagnostics for ``skdr-eval`` inputs and environment (#91).
+
+The :func:`doctor` entry point composes the existing public validators
+(:func:`skdr_eval.validate_logs`, :func:`skdr_eval.validate_pairwise_inputs`)
+and capability probe (:func:`skdr_eval.get_capabilities`) into a single
+non-raising report with concrete fix hints. The report is what turns the
+"cryptic stack trace" first-run failure mode into actionable diagnostics.
+
+The doctor never raises on a malformed DataFrame: it surfaces failures as
+:class:`Check` records. It does not modify the input DataFrames.
+"""
+
+from __future__ import annotations
+
+import platform
+import sys
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
+
+import numpy as np
+import pandas as pd
+
+from .capabilities import get_capabilities
+from .exceptions import DataValidationError, InsufficientDataError
+from .validation import validate_logs, validate_pairwise_inputs
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+CheckStatus = Literal["pass", "warn", "fail"]
+
+_STATUS_ICONS: dict[str, str] = {"pass": "OK", "warn": "WARN", "fail": "FAIL"}
+_STATUS_GLYPHS: dict[str, str] = {"pass": "✅", "warn": "⚠️", "fail": "❌"}
+
+
+@dataclass(frozen=True)
+class Check:
+    """One row in a :class:`DoctorReport`.
+
+    Attributes
+    ----------
+    name : str
+        Short identifier of the check (``"environment"``, ``"schema"``, …).
+    status : str
+        ``"pass"``, ``"warn"``, or ``"fail"``.
+    message : str
+        Human-readable summary.
+    fix_hint : str
+        Suggested fix (empty string when none applies).
+    category : str
+        High-level grouping: ``"environment"``, ``"schema"``,
+        ``"statistical"``, ``"sample_size"``.
+    """
+
+    name: str
+    status: CheckStatus
+    message: str
+    fix_hint: str = ""
+    category: str = "general"
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class DoctorReport:
+    """Result of running :func:`doctor`.
+
+    Attributes
+    ----------
+    ok : bool
+        ``True`` iff no check has status ``"fail"``.
+    checks : list[Check]
+        Ordered list of all executed checks.
+    summary : str
+        ``"pass"``, ``"warn"``, or ``"fail"`` — the worst per-check status.
+    """
+
+    ok: bool
+    checks: list[Check] = field(default_factory=list)
+    summary: CheckStatus = "pass"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "summary": self.summary,
+            "checks": [c.to_dict() for c in self.checks],
+        }
+
+    def to_markdown(self) -> str:
+        """Render as a copy-pasteable Markdown table."""
+        lines = [
+            "| Status | Check | Message | Fix hint |",
+            "| ------ | ----- | ------- | -------- |",
+        ]
+        for c in self.checks:
+            icon = _STATUS_ICONS.get(c.status, c.status)
+            fix = c.fix_hint.replace("|", "\\|") if c.fix_hint else ""
+            msg = c.message.replace("|", "\\|")
+            lines.append(f"| {icon} | {c.name} | {msg} | {fix} |")
+        lines.append("")
+        lines.append(f"**Overall:** {_STATUS_ICONS.get(self.summary, self.summary)}")
+        return "\n".join(lines)
+
+    def to_text(self, *, color: bool = False) -> str:
+        """Render as a terminal-friendly text block."""
+        glyph_map = _STATUS_GLYPHS if color else _STATUS_ICONS
+        lines = ["skdr-eval doctor", "─" * 40]
+        for c in self.checks:
+            icon = glyph_map.get(c.status, c.status)
+            line = f"{icon}  {c.name}: {c.message}"
+            lines.append(line)
+            if c.fix_hint:
+                lines.append(f"    Fix: {c.fix_hint}")
+        lines.append("─" * 40)
+        overall_icon = glyph_map.get(self.summary, self.summary)
+        lines.append(f"Overall: {overall_icon} ({self.summary})")
+        return "\n".join(lines)
+
+    def print(self, *, color: bool = True) -> None:
+        """Print the report to stdout. Color glyphs auto-disabled off-TTY."""
+        # Honor explicit ``color=False`` but auto-fall back when stdout is not a TTY.
+        use_color = color and sys.stdout.isatty()
+        print(self.to_text(color=use_color))
+
+
+_PYTHON_MIN: tuple[int, int] = (3, 11)
+
+
+def _check_environment() -> Check:
+    """Verify Python version meets the project requirement."""
+    if sys.version_info < _PYTHON_MIN:
+        return Check(
+            name="environment",
+            status="fail",
+            message=(
+                f"Python {platform.python_version()} is below skdr-eval's "
+                f"minimum of 3.11."
+            ),
+            fix_hint="Upgrade to Python 3.11+ (CI matrix covers 3.11-3.14).",
+            category="environment",
+        )
+    return Check(
+        name="environment",
+        status="pass",
+        message=(
+            f"Python {platform.python_version()} on {platform.system()} "
+            f"({platform.machine()})."
+        ),
+        category="environment",
+    )
+
+
+def _check_optional_extras() -> Check:
+    """Report which optional ``[extra]`` capabilities are available."""
+    caps = get_capabilities()
+    missing_raw = caps.get("missing_extras") or []
+    missing = [str(x) for x in missing_raw] if isinstance(missing_raw, list) else []
+    if not missing:
+        return Check(
+            name="optional_extras",
+            status="pass",
+            message="All optional extras installed.",
+            category="environment",
+        )
+    hint = " ".join(f"pip install 'skdr-eval[{e}]'" for e in missing)
+    return Check(
+        name="optional_extras",
+        status="warn",
+        message=f"Optional extras not installed: {', '.join(missing)}.",
+        fix_hint=hint,
+        category="environment",
+    )
+
+
+def _check_logs_schema(logs: pd.DataFrame, *, strict: bool) -> Check:
+    try:
+        validate_logs(logs, strict=strict)
+    except (DataValidationError, InsufficientDataError) as exc:
+        return Check(
+            name="schema",
+            status="fail",
+            message=str(exc),
+            fix_hint=(
+                "Repair the logs schema: action must reference a *_elig column, "
+                "include cli_*/st_* feature columns, and no non-finite features. "
+                "See validate_logs() in skdr_eval.validation."
+            ),
+            category="schema",
+        )
+    return Check(
+        name="schema",
+        status="pass",
+        message="validate_logs() passed.",
+        category="schema",
+    )
+
+
+def _check_pairwise_schema(
+    logs_df: pd.DataFrame,
+    op_daily_df: pd.DataFrame | None,
+    metric_col: str,
+    *,
+    strict: bool,
+) -> Check:
+    if op_daily_df is None:
+        return Check(
+            name="schema",
+            status="fail",
+            message=(
+                "Pairwise doctor requires an op_daily_df argument; received None."
+            ),
+            fix_hint="Pass the daily-operator snapshot DataFrame as op_daily_df=.",
+            category="schema",
+        )
+    try:
+        validate_pairwise_inputs(
+            logs_df, op_daily_df, metric_col=metric_col, strict=strict
+        )
+    except (DataValidationError, InsufficientDataError) as exc:
+        return Check(
+            name="schema",
+            status="fail",
+            message=str(exc),
+            fix_hint=(
+                "Repair the pairwise schema: logs_df needs client_id/operator_id"
+                "/arrival_day, op_daily_df needs op_* feature columns and the "
+                "metric column."
+            ),
+            category="schema",
+        )
+    return Check(
+        name="schema",
+        status="pass",
+        message="validate_pairwise_inputs() passed.",
+        category="schema",
+    )
+
+
+def _check_no_duplicates(
+    df: pd.DataFrame,
+    key_cols: list[str],
+) -> Check:
+    available = [c for c in key_cols if c in df.columns]
+    if not available:
+        return Check(
+            name="duplicates",
+            status="warn",
+            message=(f"No duplicate-key columns to check (looked for {key_cols})."),
+            category="schema",
+        )
+    n_dup = int(df.duplicated(subset=available, keep=False).sum())
+    if n_dup == 0:
+        return Check(
+            name="duplicates",
+            status="pass",
+            message=f"No duplicate {tuple(available)} rows.",
+            category="schema",
+        )
+    return Check(
+        name="duplicates",
+        status="warn",
+        message=f"{n_dup} duplicate rows on key {tuple(available)}.",
+        fix_hint=(
+            "Deduplicate before evaluation — duplicate keys collapse propensity "
+            "rows and bias DR estimates."
+        ),
+        category="schema",
+    )
+
+
+def _check_finite_outcomes(
+    df: pd.DataFrame,
+    outcome_cols: Iterable[str],
+) -> Check:
+    cols = [c for c in outcome_cols if c in df.columns]
+    if not cols:
+        return Check(
+            name="finite_outcomes",
+            status="warn",
+            message=(
+                f"None of the candidate outcome columns ({list(outcome_cols)}) "
+                f"were found."
+            ),
+            category="statistical",
+        )
+    nonfinite = {}
+    for c in cols:
+        try:
+            series = pd.to_numeric(df[c], errors="coerce")
+        except (TypeError, ValueError):
+            nonfinite[c] = len(df)
+            continue
+        n_bad = int((~np.isfinite(series.to_numpy(dtype=float))).sum())
+        if n_bad:
+            nonfinite[c] = n_bad
+    if not nonfinite:
+        return Check(
+            name="finite_outcomes",
+            status="pass",
+            message=f"All outcome columns {tuple(cols)} are finite.",
+            category="statistical",
+        )
+    return Check(
+        name="finite_outcomes",
+        status="fail",
+        message=(
+            "Non-finite outcome values: "
+            + ", ".join(f"{c}={n}" for c, n in sorted(nonfinite.items()))
+        ),
+        fix_hint=(
+            "Drop or impute non-finite outcome rows before calling evaluate_*; "
+            "DR estimators propagate NaN."
+        ),
+        category="statistical",
+    )
+
+
+def _check_positivity(
+    df: pd.DataFrame,
+    *,
+    epsilon: float = 0.01,
+) -> Check:
+    """Approximate positivity: fraction of rows where the observed-action's
+    eligibility column equals 1 but per-action propensities (if present) are
+    near zero."""
+    pscore_col = next((c for c in df.columns if c.lower() == "propensity"), None)
+    if pscore_col is None:
+        return Check(
+            name="positivity",
+            status="warn",
+            message=(
+                "No 'propensity' column; positivity check skipped. evaluate_* "
+                "will estimate propensities internally."
+            ),
+            category="statistical",
+        )
+    try:
+        series = pd.to_numeric(df[pscore_col], errors="coerce").to_numpy(dtype=float)
+    except (TypeError, ValueError):
+        return Check(
+            name="positivity",
+            status="warn",
+            message="Could not coerce 'propensity' column to numeric.",
+            category="statistical",
+        )
+    n_total = series.size
+    if n_total == 0:
+        return Check(
+            name="positivity",
+            status="warn",
+            message="Empty 'propensity' column.",
+            category="statistical",
+        )
+    bad_mask = (series < epsilon) | (~np.isfinite(series))
+    n_bad = int(bad_mask.sum())
+    frac_bad = n_bad / n_total if n_total else 0.0
+    if frac_bad >= 0.05:  # noqa: PLR2004
+        return Check(
+            name="positivity",
+            status="warn",
+            message=(
+                f"{n_bad}/{n_total} ({frac_bad:.1%}) rows have propensity < "
+                f"{epsilon:.3g}; positivity is marginal."
+            ),
+            fix_hint=(
+                "Trim or reweight rows with near-zero propensity; consider a "
+                "stricter clip grid in evaluate_*."
+            ),
+            category="statistical",
+        )
+    return Check(
+        name="positivity",
+        status="pass",
+        message=(f"{frac_bad:.1%} of rows below ε={epsilon:.3g} — positivity ok."),
+        category="statistical",
+    )
+
+
+def _check_sample_size(
+    df: pd.DataFrame, *, min_rows: int = 500, n_splits: int = 3
+) -> Check:
+    n = len(df)
+    fold_floor = min_rows * n_splits
+    if n < min_rows:
+        return Check(
+            name="sample_size",
+            status="fail",
+            message=f"Only {n} rows; below absolute minimum of {min_rows}.",
+            fix_hint="Collect more data or lower n_splits when calling evaluate_*.",
+            category="sample_size",
+        )
+    if n < fold_floor:
+        return Check(
+            name="sample_size",
+            status="warn",
+            message=(
+                f"{n} rows is below the {fold_floor}-row floor for {n_splits} "
+                f"CV folds; per-fold sample sizes will be tight."
+            ),
+            fix_hint=f"Either collect more data or reduce n_splits below {n_splits}.",
+            category="sample_size",
+        )
+    return Check(
+        name="sample_size",
+        status="pass",
+        message=f"{n} rows is sufficient for {n_splits}-fold CV.",
+        category="sample_size",
+    )
+
+
+def _check_input_is_dataframe(name: str, value: Any) -> Check | None:
+    if not isinstance(value, pd.DataFrame):
+        return Check(
+            name="input_type",
+            status="fail",
+            message=f"{name} is not a pandas DataFrame (got {type(value).__name__}).",
+            fix_hint=f"Pass a pandas DataFrame as {name}.",
+            category="schema",
+        )
+    return None
+
+
+def doctor(
+    logs: pd.DataFrame,
+    *,
+    kind: Literal["standard", "pairwise"] = "standard",
+    op_daily_df: pd.DataFrame | None = None,
+    metric_col: str = "service_time",
+    n_splits: int = 3,
+    strict: bool = False,
+) -> DoctorReport:
+    """Run a preflight diagnostic battery on ``logs`` (and optional
+    ``op_daily_df`` for pairwise mode).
+
+    Parameters
+    ----------
+    logs : pd.DataFrame
+        Standard-mode logs or pairwise logs (interpretation depends on
+        ``kind``).
+    kind : ``"standard"`` or ``"pairwise"``
+        Which validator family to call.
+    op_daily_df : pd.DataFrame, optional
+        Required when ``kind="pairwise"``; ignored otherwise.
+    metric_col : str, default ``"service_time"``
+        Pairwise metric column name. Used both by the pairwise validator and
+        by the finite-outcomes check.
+    n_splits : int, default 3
+        CV split count used by the sample-size floor heuristic.
+    strict : bool, default False
+        Forwarded to ``validate_logs`` / ``validate_pairwise_inputs``.
+
+    Returns
+    -------
+    DoctorReport
+        Always returned. The function is non-raising — even on a malformed
+        ``logs`` argument the report surfaces the failure as a
+        ``status="fail"`` :class:`Check`.
+    """
+    checks: list[Check] = [_check_environment(), _check_optional_extras()]
+    input_err = _check_input_is_dataframe("logs", logs)
+    if input_err is not None:
+        checks.append(input_err)
+        return _finalize_report(checks)
+
+    if kind == "pairwise":
+        checks.append(
+            _check_pairwise_schema(logs, op_daily_df, metric_col, strict=strict)
+        )
+        checks.append(
+            _check_no_duplicates(
+                logs, key_cols=["arrival_day", "client_id", "operator_id"]
+            )
+        )
+        outcome_cols: tuple[str, ...] = (metric_col,)
+    else:
+        checks.append(_check_logs_schema(logs, strict=strict))
+        checks.append(_check_no_duplicates(logs, key_cols=["client_id", "ts"]))
+        outcome_cols = ("service_time", "reward", "y")
+
+    checks.append(_check_finite_outcomes(logs, outcome_cols=outcome_cols))
+    checks.append(_check_positivity(logs))
+    checks.append(_check_sample_size(logs, n_splits=n_splits))
+
+    return _finalize_report(checks)
+
+
+def _finalize_report(checks: list[Check]) -> DoctorReport:
+    summary: CheckStatus = "pass"
+    for c in checks:
+        if c.status == "fail":
+            summary = "fail"
+            break
+        if c.status == "warn":
+            summary = "warn"
+    ok = summary != "fail"
+    return DoctorReport(ok=ok, checks=checks, summary=summary)
+
+
+__all__ = ["Check", "DoctorReport", "doctor"]

--- a/src/skdr_eval/reporting.py
+++ b/src/skdr_eval/reporting.py
@@ -1068,6 +1068,61 @@ class EvaluationArtifact:
         return _build_recommendation(self, model_name, estimator, _policy)
 
     # ------------------------------------------------------------------ #
+    # Card schema (#88)                                                   #
+    # ------------------------------------------------------------------ #
+
+    def card_schema(
+        self,
+        model_name: str,
+        *,
+        estimator: str = "SNDR",
+        baseline: float | None = None,
+        include_gate: bool = True,
+        include_recommendation: bool = True,
+    ) -> EvaluationCard:
+        """Build a machine-readable :class:`EvaluationCard` for one model row.
+
+        The card is the typed sibling of :meth:`card` (HTML) and is intended
+        to be pinned in Git, posted to a tracker (#93), or gated in CI (e.g.,
+        ``if card.trust.recommendation['verdict'] == 'do_not_deploy': exit(1)``).
+
+        Parameters
+        ----------
+        model_name : str
+            Model present in :attr:`detailed`.
+        estimator : str, default ``"SNDR"``
+            ``"DR"`` or ``"SNDR"``.
+        baseline : float or None
+            Baseline policy value used in :class:`HeadlineBlock` and in the
+            recommendation. Defaults to ``0.0`` for the recommendation when
+            ``None`` is passed.
+        include_gate : bool, default True
+            Whether to embed the :func:`gate_diagnostics` result in the
+            diagnostics block. Failures are swallowed (rendered as ``None``).
+        include_recommendation : bool, default True
+            Whether to embed the :class:`Recommendation` dict in the trust
+            block. Failures are swallowed (rendered as ``None``).
+
+        Returns
+        -------
+        EvaluationCard
+            A validated card view of the row.
+
+        Raises
+        ------
+        DataValidationError
+            If the ``(model_name, estimator)`` row is not present.
+        """
+        return _build_card_from_row(
+            self,
+            model_name,
+            estimator,
+            baseline=baseline,
+            include_gate=include_gate,
+            include_recommendation=include_recommendation,
+        )
+
+    # ------------------------------------------------------------------ #
     # Per-decision contributions (#92)                                    #
     # ------------------------------------------------------------------ #
 
@@ -1804,6 +1859,389 @@ def gate_diagnostics(
         overall = "pass"
 
     return DiagnosticGate(overlap=overlap, ess=ess, calibration=cal, overall=overall)
+
+
+# --------------------------------------------------------------------------- #
+# EvaluationCard schema (#88)                                                  #
+# --------------------------------------------------------------------------- #
+
+# Bump CARD_SCHEMA_VERSION when the card layout changes incompatibly. The card
+# is the machine-readable sibling of the HTML stakeholder card and is intended
+# to be CI-gateable.
+CARD_SCHEMA_VERSION = "1.0.0"
+
+_CARD_MODEL_CONFIG = ConfigDict(extra="allow", protected_namespaces=())
+
+
+class HeadlineBlock(BaseModel):
+    """Headline metrics for a card."""
+
+    model_config = _CARD_MODEL_CONFIG
+
+    estimator: str
+    V_hat: float | None
+    ci_lower: float | None = None
+    ci_upper: float | None = None
+    ci_alpha: float | None = None
+    baseline: float | None = None
+    delta_vs_baseline: float | None = None
+    clip: float | None = None
+
+
+class TrustBlock(BaseModel):
+    """Support-health / recommendation summary."""
+
+    model_config = _CARD_MODEL_CONFIG
+
+    support_health: str | None = None
+    warning_codes: list[str] = Field(default_factory=list)
+    recommendation: dict[str, Any] | None = None
+    primary_blocker: str | None = None
+
+
+class DiagnosticsBlock(BaseModel):
+    """Diagnostic metrics carried on the report row."""
+
+    model_config = _CARD_MODEL_CONFIG
+
+    ESS: float | None = None
+    ess_frac: float | None = None
+    match_rate: float | None = None
+    pareto_k: float | None = None
+    min_pscore: float | None = None
+    tail_mass: float | None = None
+    ece: float | None = None
+    brier_score: float | None = None
+    gate: dict[str, Any] | None = None
+
+
+class SensitivityBlock(BaseModel):
+    """Clip-grid sensitivity summary for the card row."""
+
+    model_config = _CARD_MODEL_CONFIG
+
+    V_min: float | None = None
+    V_max: float | None = None
+    V_range: float | None = None
+    chosen_clip: float | None = None
+    chosen_V: float | None = None
+    argmin_MSE_clip: float | None = None
+    dr_sndr_agree: bool | None = None
+    stable: bool | None = None
+
+
+class ProvenanceBlock(BaseModel):
+    """Run provenance metadata."""
+
+    model_config = _CARD_MODEL_CONFIG
+
+    skdr_eval_version: str = "unknown"
+    schema_version: str = SCHEMA_VERSION
+    timestamp: str = ""
+    n_samples: int | None = None
+    n_splits: int | None = None
+    random_state: int | None = None
+    evaluator: str | None = None
+
+
+class CoverageSimBlock(BaseModel):
+    """Reference to the last coverage simulation run, if any."""
+
+    model_config = _CARD_MODEL_CONFIG
+
+    dgp: str | None = None
+    n_reps: int | None = None
+    empirical_coverage: float | None = None
+    passes_nominal: bool | None = None
+
+
+class EvaluationCard(BaseModel):
+    """Machine-readable sibling of the HTML evaluation card (#88).
+
+    Bundles the headline result, trust signals, diagnostics, sensitivity, and
+    provenance for a single ``(model, estimator)`` row. Designed to be:
+
+    - YAML/JSON serializable for pinning in Git.
+    - JSON-Schema exportable for downstream tooling.
+    - CI-gateable (``card.trust.recommendation['verdict'] == 'do_not_deploy'``).
+
+    See Also
+    --------
+    EvaluationArtifact.card_schema : Build a card from a finished artifact.
+    """
+
+    model_config = ConfigDict(extra="allow", protected_namespaces=())
+
+    card_schema_version: str = Field(default=CARD_SCHEMA_VERSION)
+    model_name: str
+    headline: HeadlineBlock
+    trust: TrustBlock
+    diagnostics: DiagnosticsBlock
+    sensitivity: SensitivityBlock = Field(default_factory=SensitivityBlock)
+    provenance: ProvenanceBlock = Field(default_factory=ProvenanceBlock)
+    coverage_sim: CoverageSimBlock | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain JSON-serializable dict."""
+        result: dict[str, Any] = self.model_dump(mode="json")
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> EvaluationCard:
+        """Build from a plain dict (validates)."""
+        loaded: EvaluationCard = cls.model_validate(data)
+        return loaded
+
+    def to_json(self, path: str | Path | None = None, *, indent: int = 2) -> str:
+        """Serialize to JSON, optionally writing to ``path``. Returns the JSON text."""
+        text: str = self.model_dump_json(indent=indent)
+        if path is not None:
+            Path(path).write_text(text + "\n", encoding="utf-8")
+        return text
+
+    @classmethod
+    def from_json(cls, path_or_str: str | Path) -> EvaluationCard:
+        """Load from a JSON file path or JSON string.
+
+        Distinguishes a ``Path`` (or a short string that resolves to an
+        existing file) from inline JSON content. Long JSON strings are never
+        interpreted as paths even on filesystems that would error on the
+        length check.
+        """
+        text = _read_path_or_string(path_or_str)
+        loaded: EvaluationCard = cls.model_validate_json(text)
+        return loaded
+
+    def to_yaml(self, path: str | Path | None = None) -> str:
+        """Serialize to YAML, optionally writing to ``path``. Returns the YAML text."""
+        import yaml as _yaml  # noqa: PLC0415
+
+        text: str = _yaml.safe_dump(self.to_dict(), sort_keys=False)
+        if path is not None:
+            Path(path).write_text(text, encoding="utf-8")
+        return text
+
+    @classmethod
+    def from_yaml(cls, path_or_str: str | Path) -> EvaluationCard:
+        """Load from a YAML file path or YAML string."""
+        import yaml as _yaml  # noqa: PLC0415
+
+        text = _read_path_or_string(path_or_str)
+        data = _yaml.safe_load(text)
+        if not isinstance(data, dict):
+            raise DataValidationError(
+                f"EvaluationCard.from_yaml expected a YAML mapping, got {type(data).__name__}"
+            )
+        loaded: EvaluationCard = cls.model_validate(data)
+        return loaded
+
+    @classmethod
+    def json_schema(cls) -> dict[str, Any]:
+        """Return the Pydantic-generated JSON Schema for this card."""
+        schema: dict[str, Any] = cls.model_json_schema()
+        return schema
+
+
+# NAME_MAX is 255 on most filesystems; 4096 leaves room for full paths
+# without triggering ``OSError: File name too long`` when a long YAML/JSON
+# blob is mistakenly passed in place of a file path.
+_PATH_MAX_LIKELY = 4096
+
+
+def _read_path_or_string(path_or_str: str | Path) -> str:
+    """Return file content if ``path_or_str`` is a readable file, else the string.
+
+    A :class:`Path` instance is always treated as a path. A plain string is
+    treated as a path only when (a) it is short enough to be a valid filename
+    on the host filesystem and (b) the file exists. Otherwise the string is
+    returned verbatim. This lets ``from_yaml``/``from_json`` accept either
+    inline document text or a path without falling over on long inline text.
+    """
+    if isinstance(path_or_str, Path):
+        return path_or_str.read_text(encoding="utf-8")
+    s = str(path_or_str)
+    if len(s) > _PATH_MAX_LIKELY or "\n" in s:
+        return s
+    try:
+        p = Path(s)
+        if p.is_file():
+            return p.read_text(encoding="utf-8")
+    except OSError:
+        pass
+    return s
+
+
+def _coerce_optional_float(value: Any) -> float | None:
+    """Coerce numeric values to ``float | None``; non-finite → None."""
+    if value is None:
+        return None
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not np.isfinite(v):
+        return None
+    return v
+
+
+def _build_card_from_row(
+    artifact: EvaluationArtifact,
+    model_name: str,
+    estimator: str,
+    *,
+    baseline: float | None = None,
+    include_gate: bool = True,
+    include_recommendation: bool = True,
+) -> EvaluationCard:
+    """Internal: assemble an EvaluationCard from one ``(model, estimator)`` row."""
+    if model_name not in artifact.detailed:
+        raise DataValidationError(
+            f"model {model_name!r} not in artifact "
+            f"(known: {sorted(artifact.detailed)})",
+        )
+    est_map = artifact.detailed[model_name]
+    if estimator not in est_map:
+        raise DataValidationError(
+            f"estimator {estimator!r} not in detailed[{model_name!r}] "
+            f"(known: {sorted(est_map)})",
+        )
+
+    report = artifact.report
+    row_mask = (report["model"] == model_name) & (report["estimator"] == estimator)
+    rows = report[row_mask]
+    if rows.empty:
+        raise DataValidationError(
+            f"No report row for model={model_name!r}, estimator={estimator!r}.",
+        )
+    row = rows.iloc[0]
+
+    v_hat = _coerce_optional_float(row.get("V_hat"))
+    ci_lower = _coerce_optional_float(row.get("ci_lower"))
+    ci_upper = _coerce_optional_float(row.get("ci_upper"))
+    delta = (v_hat - baseline) if (v_hat is not None and baseline is not None) else None
+    alpha = artifact.metadata.get("alpha")
+
+    headline = HeadlineBlock(
+        estimator=estimator,
+        V_hat=v_hat,
+        ci_lower=ci_lower,
+        ci_upper=ci_upper,
+        ci_alpha=_coerce_optional_float(alpha),
+        baseline=baseline,
+        delta_vs_baseline=delta,
+        clip=_coerce_optional_float(row.get("clip")),
+    )
+
+    support_health = row.get("support_health")
+    warn_codes_raw = row.get("diagnostic_warnings", "")
+    warning_codes = (
+        [c.strip() for c in str(warn_codes_raw).split(",") if c.strip()]
+        if warn_codes_raw
+        else []
+    )
+    rec_dict: dict[str, Any] | None = None
+    primary_blocker: str | None = None
+    if include_recommendation:
+        try:
+            rec = artifact.recommendation(
+                model_name,
+                estimator=estimator,
+                baseline=baseline if baseline is not None else 0.0,
+            )
+            rec_dict = rec.to_dict()
+            primary_blocker = rec.primary_blocker
+        except (DataValidationError, KeyError, ValueError):
+            rec_dict = None
+
+    trust = TrustBlock(
+        support_health=(str(support_health) if support_health is not None else None),
+        warning_codes=warning_codes,
+        recommendation=rec_dict,
+        primary_blocker=primary_blocker,
+    )
+
+    n = int(artifact.metadata.get("n_samples", 0)) or None
+    ess_val = _coerce_optional_float(row.get("ESS"))
+    ess_frac = (ess_val / n) if (ess_val is not None and n) else None
+
+    diag = artifact.diagnostics.get(model_name)
+    diag_gate: dict[str, Any] | None = None
+    if include_gate:
+        try:
+            gate = gate_diagnostics(artifact, model_name, estimator=estimator)
+            diag_gate = gate.to_dict()
+        except (DataValidationError, KeyError, ValueError):
+            diag_gate = None
+
+    diagnostics = DiagnosticsBlock(
+        ESS=ess_val,
+        ess_frac=ess_frac,
+        match_rate=_coerce_optional_float(row.get("match_rate")),
+        pareto_k=_coerce_optional_float(row.get("pareto_k")),
+        min_pscore=_coerce_optional_float(row.get("min_pscore")),
+        tail_mass=_coerce_optional_float(row.get("tail_mass")),
+        ece=_coerce_optional_float(getattr(diag, "ece", None)) if diag else None,
+        brier_score=(
+            _coerce_optional_float(getattr(diag, "brier_score", None)) if diag else None
+        ),
+        gate=diag_gate,
+    )
+
+    sens_mask = (artifact.sensitivity["model"] == model_name) & (
+        artifact.sensitivity["estimator"] == estimator
+    )
+    sens_rows = artifact.sensitivity[sens_mask]
+    if sens_rows.empty:
+        sensitivity = SensitivityBlock()
+    else:
+        s = sens_rows.iloc[0]
+        sensitivity = SensitivityBlock(
+            V_min=_coerce_optional_float(s.get("V_min")),
+            V_max=_coerce_optional_float(s.get("V_max")),
+            V_range=_coerce_optional_float(s.get("V_range")),
+            chosen_clip=_coerce_optional_float(s.get("chosen_clip")),
+            chosen_V=_coerce_optional_float(s.get("chosen_V")),
+            argmin_MSE_clip=_coerce_optional_float(s.get("argmin_MSE_clip")),
+            dr_sndr_agree=bool(s["dr_sndr_agree"])
+            if "dr_sndr_agree" in s and s["dr_sndr_agree"] is not None
+            else None,
+            stable=bool(s["stable"])
+            if "stable" in s and s["stable"] is not None
+            else None,
+        )
+
+    provenance = ProvenanceBlock(
+        skdr_eval_version=str(artifact.metadata.get("skdr_eval_version", "unknown")),
+        schema_version=str(artifact.metadata.get("schema_version", SCHEMA_VERSION)),
+        timestamp=str(artifact.metadata.get("timestamp", "")),
+        n_samples=(int(n) if n is not None else None),
+        n_splits=(
+            int(artifact.metadata["n_splits"])
+            if "n_splits" in artifact.metadata
+            and artifact.metadata["n_splits"] is not None
+            else None
+        ),
+        random_state=(
+            int(artifact.metadata["random_state"])
+            if "random_state" in artifact.metadata
+            and artifact.metadata["random_state"] is not None
+            else None
+        ),
+        evaluator=(
+            str(artifact.metadata["evaluator"])
+            if artifact.metadata.get("evaluator") is not None
+            else None
+        ),
+    )
+
+    return EvaluationCard(
+        model_name=model_name,
+        headline=headline,
+        trust=trust,
+        diagnostics=diagnostics,
+        sensitivity=sensitivity,
+        provenance=provenance,
+    )
 
 
 def _render_sensitivity_plot(result: DRResult, estimator: str) -> str | None:

--- a/src/skdr_eval/reporting.py
+++ b/src/skdr_eval/reporting.py
@@ -2023,7 +2023,12 @@ class EvaluationCard(BaseModel):
 
     @classmethod
     def from_yaml(cls, path_or_str: str | Path) -> EvaluationCard:
-        """Load from a YAML file path or YAML string."""
+        """Load from a YAML file path or YAML string.
+
+        A ``Path`` is always treated as a file. A plain string is treated as
+        a file path only when it is short (< 4096 chars), contains no
+        newlines, and the file exists; otherwise it is parsed as inline YAML.
+        """
         import yaml as _yaml  # noqa: PLC0415
 
         text = _read_path_or_string(path_or_str)

--- a/src/skdr_eval/trackers/__init__.py
+++ b/src/skdr_eval/trackers/__init__.py
@@ -1,0 +1,187 @@
+"""Tracker protocol and built-in trackers (#93).
+
+The :class:`Tracker` protocol defines the minimum surface
+(``log_metric`` / ``log_artifact`` / ``log_card`` / ``set_tag`` plus context
+management) that evaluators use to push results to disk or an external
+experiment tracker. The core ships:
+
+- :class:`NullTracker` — no-op default; used when ``tracker=None``.
+- :class:`FileTracker` — writes JSONL metrics and artifact files to a run
+  directory.
+
+External adapters (MLflow / W&B / Aim) live in this package as separate
+modules gated behind their own optional extras (``[mlflow]``, ``[wandb]``,
+``[aim]``). They currently raise :class:`NotImplementedError` on
+construction — the umbrella issue #73 tracks each adapter's full
+implementation as a follow-up PR.
+
+This module has zero new mandatory dependencies. The ``FileTracker`` uses
+only the standard library and the existing ``pyyaml`` dep already shipped
+in core.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from types import TracebackType
+
+    from skdr_eval.reporting import EvaluationCard
+
+logger = logging.getLogger("skdr_eval")
+
+
+@runtime_checkable
+class Tracker(Protocol):
+    """Minimum surface for experiment trackers used by ``evaluate_*_models``.
+
+    Implementations must be safe to use as context managers. The
+    :class:`NullTracker` and :class:`FileTracker` ship in core; external
+    adapters (MLflow / W&B / Aim) live in sibling modules behind optional
+    extras.
+    """
+
+    def log_metric(self, name: str, value: float, step: int | None = None) -> None: ...
+
+    def log_artifact(self, path: Path, artifact_path: str | None = None) -> None: ...
+
+    def log_card(self, card: EvaluationCard) -> None: ...
+
+    def set_tag(self, key: str, value: str) -> None: ...
+
+    def __enter__(self) -> Tracker: ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None: ...
+
+
+class NullTracker:
+    """A no-op tracker. Default when ``tracker=None``.
+
+    Every method is a true no-op — calling any method (in any order) is
+    guaranteed to have zero observable side effects on the filesystem or
+    process state. The class is included in the public API so callers can
+    spell their intent explicitly:
+
+    >>> from skdr_eval.trackers import NullTracker
+    >>> tracker = NullTracker()
+    >>> tracker.log_metric("V_hat", 1.23)  # no-op
+    """
+
+    def log_metric(self, name: str, value: float, step: int | None = None) -> None:
+        del name, value, step
+
+    def log_artifact(self, path: Path, artifact_path: str | None = None) -> None:
+        del path, artifact_path
+
+    def log_card(self, card: EvaluationCard) -> None:
+        del card
+
+    def set_tag(self, key: str, value: str) -> None:
+        del key, value
+
+    def __enter__(self) -> NullTracker:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        del exc_type, exc, tb
+
+
+class FileTracker:
+    """Built-in disk-based tracker.
+
+    Writes a run directory containing:
+
+    - ``metrics.jsonl`` — one JSON object per ``log_metric`` call,
+      append-only, deterministic.
+    - ``tags.json`` — flat dict of tags (written on every ``set_tag`` call).
+    - ``artifacts/`` — files copied from ``log_artifact`` (or sub-paths
+      under it when ``artifact_path`` is provided).
+    - ``cards/<model_name>.card.yaml`` — YAML dump of each ``log_card``
+      payload.
+
+    Parameters
+    ----------
+    root : str or Path
+        Output directory. Created if it does not exist. Each instance writes
+        all its records into this single directory; reuse a path across runs
+        only if you want the metrics to be concatenated.
+    """
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+        (self.root / "artifacts").mkdir(exist_ok=True)
+        (self.root / "cards").mkdir(exist_ok=True)
+        self._metrics_path = self.root / "metrics.jsonl"
+        self._tags_path = self.root / "tags.json"
+        self._tags: dict[str, str] = {}
+        if self._tags_path.exists():
+            try:
+                self._tags = json.loads(self._tags_path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                self._tags = {}
+
+    def log_metric(self, name: str, value: float, step: int | None = None) -> None:
+        record: dict[str, Any] = {
+            "ts": datetime.now(UTC).isoformat(),
+            "name": str(name),
+            "value": float(value),
+        }
+        if step is not None:
+            record["step"] = int(step)
+        with self._metrics_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+
+    def log_artifact(self, path: Path, artifact_path: str | None = None) -> None:
+        src = Path(path)
+        if not src.exists():
+            raise FileNotFoundError(f"Artifact not found: {src}")
+        sub = artifact_path or src.name
+        dest = self.root / "artifacts" / sub
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(src.read_bytes())
+
+    def log_card(self, card: EvaluationCard) -> None:
+        estimator = card.headline.estimator or "card"
+        dest = self.root / "cards" / f"{card.model_name}_{estimator}.card.yaml"
+        card.to_yaml(dest)
+
+    def set_tag(self, key: str, value: str) -> None:
+        self._tags[str(key)] = str(value)
+        self._tags_path.write_text(
+            json.dumps(self._tags, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    def __enter__(self) -> FileTracker:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        del exc_type, exc, tb
+
+
+__all__ = [
+    "FileTracker",
+    "NullTracker",
+    "Tracker",
+]

--- a/src/skdr_eval/trackers/__init__.py
+++ b/src/skdr_eval/trackers/__init__.py
@@ -107,12 +107,12 @@ class FileTracker:
     Writes a run directory containing:
 
     - ``metrics.jsonl`` — one JSON object per ``log_metric`` call,
-      append-only, deterministic.
+      append-only (includes a wall-clock timestamp per record).
     - ``tags.json`` — flat dict of tags (written on every ``set_tag`` call).
     - ``artifacts/`` — files copied from ``log_artifact`` (or sub-paths
       under it when ``artifact_path`` is provided).
-    - ``cards/<model_name>.card.yaml`` — YAML dump of each ``log_card``
-      payload.
+    - ``cards/<model_name>_<estimator>.card.yaml`` — YAML dump of each
+      ``log_card`` payload.
 
     Parameters
     ----------
@@ -152,7 +152,14 @@ class FileTracker:
         if not src.exists():
             raise FileNotFoundError(f"Artifact not found: {src}")
         sub = artifact_path or src.name
-        dest = self.root / "artifacts" / sub
+        artifacts_dir = (self.root / "artifacts").resolve()
+        dest = (artifacts_dir / sub).resolve()
+        if not str(dest).startswith(str(artifacts_dir)):
+            raise ValueError(
+                f"artifact_path {artifact_path!r} resolves outside the "
+                f"artifacts directory. Only relative, non-traversing paths "
+                f"are allowed."
+            )
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(src.read_bytes())
 

--- a/src/skdr_eval/trackers/__init__.py
+++ b/src/skdr_eval/trackers/__init__.py
@@ -154,12 +154,14 @@ class FileTracker:
         sub = artifact_path or src.name
         artifacts_dir = (self.root / "artifacts").resolve()
         dest = (artifacts_dir / sub).resolve()
-        if not str(dest).startswith(str(artifacts_dir)):
+        try:
+            dest.relative_to(artifacts_dir)
+        except ValueError:
             raise ValueError(
                 f"artifact_path {artifact_path!r} resolves outside the "
                 f"artifacts directory. Only relative, non-traversing paths "
                 f"are allowed."
-            )
+            ) from None
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(src.read_bytes())
 

--- a/src/skdr_eval/trackers/_stub.py
+++ b/src/skdr_eval/trackers/_stub.py
@@ -1,0 +1,40 @@
+"""Shared stub-class builder for external tracker adapters.
+
+Used by :mod:`mlflow`, :mod:`wandb`, and :mod:`aim` adapter modules to expose
+importable classes that raise :class:`NotImplementedError` on construction
+until their full implementations land under umbrella issue #73.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_stub(package: str) -> type:
+    """Construct a stub tracker class that errors on instantiation.
+
+    The class name is ``<Package>Tracker`` (capitalized). The error message
+    references the matching ``pip install 'skdr-eval[<package>]'`` extra and
+    points at the umbrella issue.
+    """
+    install_hint = f"pip install 'skdr-eval[{package}]'"
+
+    class _Stub:
+        __slots__ = ()
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            del args, kwargs
+            raise NotImplementedError(
+                f"The {package} tracker adapter is a stub. Install the optional "
+                f"extra ({install_hint}) and wait for the full adapter to ship "
+                f"under issue #73."
+            )
+
+    _Stub.__name__ = f"{package.capitalize()}Tracker"
+    _Stub.__qualname__ = _Stub.__name__
+    _Stub.__doc__ = (
+        f"Stub for the {package} tracker adapter. "
+        f"Raises NotImplementedError on construction. "
+        f"Full implementation tracked by issue #73."
+    )
+    return _Stub

--- a/src/skdr_eval/trackers/aim.py
+++ b/src/skdr_eval/trackers/aim.py
@@ -1,0 +1,9 @@
+"""Aim tracker stub. Implementation tracked by umbrella issue #73."""
+
+from __future__ import annotations
+
+from ._stub import build_stub
+
+AimTracker = build_stub("aim")
+
+__all__ = ["AimTracker"]

--- a/src/skdr_eval/trackers/mlflow.py
+++ b/src/skdr_eval/trackers/mlflow.py
@@ -1,0 +1,9 @@
+"""MLflow tracker stub. Implementation tracked by umbrella issue #73."""
+
+from __future__ import annotations
+
+from ._stub import build_stub
+
+MLflowTracker = build_stub("mlflow")
+
+__all__ = ["MLflowTracker"]

--- a/src/skdr_eval/trackers/wandb.py
+++ b/src/skdr_eval/trackers/wandb.py
@@ -1,0 +1,9 @@
+"""Weights & Biases tracker stub. Implementation tracked by umbrella issue #73."""
+
+from __future__ import annotations
+
+from ._stub import build_stub
+
+WandbTracker = build_stub("wandb")
+
+__all__ = ["WandbTracker"]

--- a/tests/test_card_schema.py
+++ b/tests/test_card_schema.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+import pandas as pd
 import pytest
 from sklearn.ensemble import HistGradientBoostingRegressor
 
 import skdr_eval
+from skdr_eval import reporting as _rep
 from skdr_eval.exceptions import DataValidationError
 from skdr_eval.reporting import (
     CARD_SCHEMA_VERSION,
@@ -19,6 +21,7 @@ from skdr_eval.reporting import (
     SensitivityBlock,
     TrustBlock,
     _coerce_optional_float,
+    _read_path_or_string,
 )
 
 if TYPE_CHECKING:
@@ -257,3 +260,60 @@ class TestCoerceOptionalFloat:
 
     def test_nan_returns_none(self):
         assert _coerce_optional_float(float("nan")) is None
+
+
+class TestReadPathOrStringOSError:
+    """Cover the OSError branch in _read_path_or_string (line 2073-2075)."""
+
+    def test_oserror_falls_through_to_return_string(self):
+        # A filename > 255 chars (ext4 NAME_MAX) triggers OSError from
+        # is_file() on Linux. On Windows it just returns False — either way
+        # the function returns the original string.
+        bad = "a" * 300 + ".yaml"
+        result = _read_path_or_string(bad)
+        assert result == bad
+
+
+class TestBuildCardFallbackPaths:
+    """Cover fallback branches in _build_card_from_row."""
+
+    def test_recommendation_fallback_on_error(self, monkeypatch):
+        """When recommendation() raises, card_schema still returns a card with rec=None."""
+        art = _build_artifact()
+
+        def _raise(*args, **kwargs):
+            raise ValueError("simulated failure")
+
+        monkeypatch.setattr(art, "recommendation", _raise)
+        card = art.card_schema("HGB", estimator="DR", include_recommendation=True)
+        assert card.trust.recommendation is None
+
+    def test_gate_fallback_on_error(self, monkeypatch):
+        """When gate_diagnostics raises, card_schema returns card with gate=None."""
+        art = _build_artifact()
+
+        def _raise(*args, **kwargs):
+            raise KeyError("simulated gate failure")
+
+        monkeypatch.setattr(_rep, "gate_diagnostics", _raise)
+        card = art.card_schema("HGB", estimator="DR", include_gate=True)
+        assert card.diagnostics.gate is None
+
+    def test_empty_sensitivity_returns_empty_block(self):
+        """When sensitivity has no matching rows, SensitivityBlock defaults."""
+        art = _build_artifact()
+        # Wipe sensitivity data for the model
+        art.sensitivity = pd.DataFrame(columns=art.sensitivity.columns)
+        card = art.card_schema("HGB", estimator="DR")
+        assert isinstance(card.sensitivity, SensitivityBlock)
+        assert card.sensitivity.V_min is None
+        assert card.sensitivity.V_max is None
+
+    def test_report_row_missing_raises(self):
+        """When estimator is in detailed but not in report, raises DataValidationError."""
+        art = _build_artifact()
+        # Remove the DR row from the report DataFrame
+        art.report = art.report[art.report["estimator"] != "DR"].reset_index(drop=True)
+        # Estimator still in detailed but not in report → line 2118
+        with pytest.raises(DataValidationError, match="No report row"):
+            art.card_schema("HGB", estimator="DR")

--- a/tests/test_card_schema.py
+++ b/tests/test_card_schema.py
@@ -18,6 +18,7 @@ from skdr_eval.reporting import (
     ProvenanceBlock,
     SensitivityBlock,
     TrustBlock,
+    _coerce_optional_float,
 )
 
 if TYPE_CHECKING:
@@ -206,3 +207,53 @@ class TestCardForwardCompatibility:
     def test_card_schema_version_stable(self):
         # Stability guard: any bump must update tests + CHANGELOG.
         assert CARD_SCHEMA_VERSION == "1.0.0"
+
+
+class TestReadPathOrString:
+    """Exercises the _read_path_or_string heuristic in reporting.py."""
+
+    def test_from_yaml_with_inline_string(self):
+        """from_yaml with a multi-line YAML string (contains newlines)."""
+        art = _build_artifact()
+        card = art.card_schema("HGB", estimator="DR")
+        yaml_text = card.to_yaml()
+        assert "\n" in yaml_text
+        loaded = EvaluationCard.from_yaml(yaml_text)
+        assert loaded == card
+
+    def test_from_yaml_with_short_nonexistent_path(self):
+        """from_yaml with a short string that's not a valid file falls through."""
+        # This hits the try/Path(s)/is_file() → False → return s path.
+        with pytest.raises((DataValidationError, Exception)):
+            # "no_such_file.yaml" is short, no newlines, but doesn't exist
+            # as a file. _read_path_or_string returns it as-is, then YAML
+            # parsing of that string fails or produces a non-mapping.
+            EvaluationCard.from_yaml("no_such_file.yaml")
+
+    def test_from_json_with_inline_string(self):
+        """from_json with an inline JSON string."""
+        art = _build_artifact()
+        card = art.card_schema("HGB", estimator="DR")
+        json_text = card.to_json()
+        loaded = EvaluationCard.from_json(json_text)
+        assert loaded == card
+
+
+class TestCoerceOptionalFloat:
+    """Exercises edge cases in _coerce_optional_float."""
+
+    def test_none_value(self):
+        assert _coerce_optional_float(None) is None
+
+    def test_valid_float(self):
+        assert _coerce_optional_float(3.14) == pytest.approx(3.14)
+
+    def test_non_convertible_string(self):
+        assert _coerce_optional_float("not_a_number") is None
+
+    def test_inf_returns_none(self):
+        assert _coerce_optional_float(float("inf")) is None
+        assert _coerce_optional_float(float("-inf")) is None
+
+    def test_nan_returns_none(self):
+        assert _coerce_optional_float(float("nan")) is None

--- a/tests/test_card_schema.py
+++ b/tests/test_card_schema.py
@@ -1,0 +1,208 @@
+"""Tests for the :class:`EvaluationCard` schema (#88)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from sklearn.ensemble import HistGradientBoostingRegressor
+
+import skdr_eval
+from skdr_eval.exceptions import DataValidationError
+from skdr_eval.reporting import (
+    CARD_SCHEMA_VERSION,
+    DiagnosticsBlock,
+    EvaluationCard,
+    HeadlineBlock,
+    ProvenanceBlock,
+    SensitivityBlock,
+    TrustBlock,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _build_artifact(
+    seed: int = 7, n: int = 400, ci: bool = False
+) -> skdr_eval.EvaluationArtifact:
+    logs, _, _ = skdr_eval.make_synth_logs(n=n, n_ops=3, seed=seed)
+    models = {"HGB": HistGradientBoostingRegressor(max_iter=20, random_state=seed)}
+    return skdr_eval.evaluate_sklearn_models(
+        logs=logs,
+        models=models,
+        fit_models=True,
+        n_splits=3,
+        random_state=seed,
+        ci_bootstrap=ci,
+        policy_train="pre_split",
+    )
+
+
+class TestEvaluationCardSchema:
+    def test_card_schema_version_constant(self):
+        assert CARD_SCHEMA_VERSION == "1.0.0"
+
+    def test_card_schema_method_returns_card(self):
+        art = _build_artifact()
+        card = art.card_schema("HGB", estimator="DR")
+        assert isinstance(card, EvaluationCard)
+        assert card.card_schema_version == CARD_SCHEMA_VERSION
+        assert card.model_name == "HGB"
+
+    def test_headline_block_populated(self):
+        art = _build_artifact()
+        card = art.card_schema("HGB", estimator="SNDR")
+        assert isinstance(card.headline, HeadlineBlock)
+        assert card.headline.estimator == "SNDR"
+        assert card.headline.V_hat is None or isinstance(card.headline.V_hat, float)
+
+    def test_diagnostics_block_populated(self):
+        art = _build_artifact()
+        card = art.card_schema("HGB", estimator="DR")
+        assert isinstance(card.diagnostics, DiagnosticsBlock)
+        # ESS may be None for tiny datasets, but if present must be float.
+        if card.diagnostics.ESS is not None:
+            assert isinstance(card.diagnostics.ESS, float)
+        if card.diagnostics.gate is not None:
+            assert "overall" in card.diagnostics.gate
+
+    def test_sensitivity_block_populated(self):
+        art = _build_artifact()
+        card = art.card_schema("HGB", estimator="DR")
+        assert isinstance(card.sensitivity, SensitivityBlock)
+
+    def test_provenance_block_populated(self):
+        art = _build_artifact()
+        card = art.card_schema("HGB", estimator="DR")
+        assert isinstance(card.provenance, ProvenanceBlock)
+        assert card.provenance.evaluator == "evaluate_sklearn_models"
+        assert card.provenance.n_samples is not None
+        assert card.provenance.n_splits == 3
+
+    def test_trust_block_carries_recommendation(self):
+        art = _build_artifact()
+        card = art.card_schema("HGB", estimator="DR")
+        assert isinstance(card.trust, TrustBlock)
+        # Recommendation should be a dict with the verdict key when included.
+        if card.trust.recommendation is not None:
+            assert "verdict" in card.trust.recommendation
+            assert card.trust.recommendation["verdict"] in {
+                "deploy",
+                "ab_test",
+                "do_not_deploy",
+                "insufficient_evidence",
+            }
+
+    def test_unknown_model_raises(self):
+        art = _build_artifact()
+        with pytest.raises(DataValidationError, match="not in artifact"):
+            art.card_schema("does_not_exist")
+
+    def test_unknown_estimator_raises(self):
+        art = _build_artifact()
+        with pytest.raises(DataValidationError, match="estimator"):
+            art.card_schema("HGB", estimator="MRDR")
+
+    def test_baseline_propagates(self):
+        art = _build_artifact()
+        card = art.card_schema("HGB", estimator="DR", baseline=10.0)
+        assert card.headline.baseline == 10.0
+        if card.headline.V_hat is not None:
+            assert card.headline.delta_vs_baseline == pytest.approx(
+                card.headline.V_hat - 10.0
+            )
+
+    def test_include_gate_false_drops_gate(self):
+        art = _build_artifact()
+        card = art.card_schema("HGB", estimator="DR", include_gate=False)
+        assert card.diagnostics.gate is None
+
+    def test_include_recommendation_false_drops_recommendation(self):
+        art = _build_artifact()
+        card = art.card_schema("HGB", estimator="DR", include_recommendation=False)
+        assert card.trust.recommendation is None
+
+
+class TestCardRoundTrip:
+    def test_yaml_round_trip_string(self):
+        art = _build_artifact()
+        card = art.card_schema("HGB", estimator="DR")
+        text = card.to_yaml()
+        assert isinstance(text, str)
+        loaded = EvaluationCard.from_yaml(text)
+        assert loaded == card
+
+    def test_json_round_trip_string(self):
+        art = _build_artifact()
+        card = art.card_schema("HGB", estimator="DR")
+        text = card.to_json()
+        assert isinstance(text, str)
+        loaded = EvaluationCard.from_json(text)
+        assert loaded == card
+
+    def test_yaml_round_trip_file(self, tmp_path: Path):
+        art = _build_artifact()
+        card = art.card_schema("HGB", estimator="DR")
+        path = tmp_path / "card.yaml"
+        card.to_yaml(path)
+        assert path.is_file()
+        loaded = EvaluationCard.from_yaml(path)
+        assert loaded == card
+
+    def test_json_round_trip_file(self, tmp_path: Path):
+        art = _build_artifact()
+        card = art.card_schema("HGB", estimator="DR")
+        path = tmp_path / "card.json"
+        card.to_json(path)
+        assert path.is_file()
+        loaded = EvaluationCard.from_json(path)
+        assert loaded == card
+
+    def test_from_yaml_rejects_non_mapping(self):
+        with pytest.raises(DataValidationError, match="YAML mapping"):
+            EvaluationCard.from_yaml("- 1\n- 2\n")
+
+
+class TestCardJSONSchema:
+    def test_json_schema_returns_dict(self):
+        schema = EvaluationCard.json_schema()
+        assert isinstance(schema, dict)
+        assert schema["title"] == "EvaluationCard"
+        assert "properties" in schema
+
+    def test_json_schema_includes_blocks(self):
+        schema = EvaluationCard.json_schema()
+        properties = schema["properties"]
+        for required_key in (
+            "headline",
+            "trust",
+            "diagnostics",
+            "sensitivity",
+            "provenance",
+        ):
+            assert required_key in properties, (
+                f"Missing block {required_key!r} in EvaluationCard JSON Schema."
+            )
+
+    def test_json_schema_is_json_serializable(self):
+        schema = EvaluationCard.json_schema()
+        # Round-trip ensures no non-JSON values leaked into the schema dict.
+        text = json.dumps(schema)
+        assert isinstance(text, str)
+
+
+class TestCardForwardCompatibility:
+    def test_extra_field_preserved_under_extra_allow(self):
+        art = _build_artifact()
+        card = art.card_schema("HGB", estimator="DR")
+        d = card.to_dict()
+        d["future_field"] = {"some": "value"}
+        loaded = EvaluationCard.from_dict(d)
+        # ``ConfigDict(extra="allow")`` preserves unknown fields.
+        assert loaded.model_dump(mode="json").get("future_field") == {"some": "value"}
+
+    def test_card_schema_version_stable(self):
+        # Stability guard: any bump must update tests + CHANGELOG.
+        assert CARD_SCHEMA_VERSION == "1.0.0"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -282,7 +282,10 @@ class TestDoNotDeployExit:
 
 class TestEvaluateSubcommand:
     def test_evaluate_catches_model_errors(
-        self, synth_logs_parquet: Path, fitted_model_path: tuple[Path, dict], tmp_path: Path
+        self,
+        synth_logs_parquet: Path,
+        fitted_model_path: tuple[Path, dict],
+        tmp_path: Path,
     ):
         """Evaluate exits cleanly with EXIT_DATA when model features mismatch."""
         model_path, _ = fitted_model_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -345,7 +345,7 @@ class TestPairwiseSubcommand:
         """Pairwise exits cleanly with EXIT_DATA when model features mismatch."""
         p_logs, p_op = pairwise_inputs
         # Train a model on wrong features to trigger SkdrEvalError
-        logs_df, op_df = skdr_eval.make_pairwise_synth(
+        logs_df, _op_df = skdr_eval.make_pairwise_synth(
             n_days=4, n_clients_day=80, n_ops=3, seed=0
         )
         model = HistGradientBoostingRegressor(max_iter=10, random_state=0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -278,3 +278,120 @@ class TestDoNotDeployExit:
     def test_do_not_deploy_exit_code_constant(self):
         # Stability guard for CI gates.
         assert EXIT_DO_NOT_DEPLOY == 3
+
+
+class TestEvaluateSubcommand:
+    def test_evaluate_catches_model_errors(
+        self, synth_logs_parquet: Path, fitted_model_path: tuple[Path, dict], tmp_path: Path
+    ):
+        """Evaluate exits cleanly with EXIT_DATA when model features mismatch."""
+        model_path, _ = fitted_model_path
+        out_dir = tmp_path / "eval_out"
+        result = runner.invoke(
+            app,
+            [
+                "evaluate",
+                str(synth_logs_parquet),
+                "--model",
+                f"HGB={model_path}",
+                "--out",
+                str(out_dir),
+                "--n-splits",
+                "2",
+                "--policy-train",
+                "pre_split",
+            ],
+        )
+        # Model trained on wrong features → SkdrEvalError → clean exit code 1
+        assert result.exit_code == EXIT_DATA
+
+    def test_evaluate_invalid_model_path_exits_1(
+        self, synth_logs_parquet: Path, tmp_path: Path
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "evaluate",
+                str(synth_logs_parquet),
+                "--model",
+                "BAD=/nonexistent/model.joblib",
+                "--out",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code == EXIT_DATA
+
+    def test_evaluate_remote_model_refused(
+        self, synth_logs_parquet: Path, tmp_path: Path
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "evaluate",
+                str(synth_logs_parquet),
+                "--model",
+                "M=https://evil.com/model.pkl",
+                "--out",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code == EXIT_DATA
+
+
+class TestPairwiseSubcommand:
+    def test_pairwise_catches_model_errors(
+        self, pairwise_inputs: tuple[Path, Path], tmp_path: Path
+    ):
+        """Pairwise exits cleanly with EXIT_DATA when model features mismatch."""
+        p_logs, p_op = pairwise_inputs
+        # Train a model on wrong features to trigger SkdrEvalError
+        logs_df, op_df = skdr_eval.make_pairwise_synth(
+            n_days=4, n_clients_day=80, n_ops=3, seed=0
+        )
+        model = HistGradientBoostingRegressor(max_iter=10, random_state=0)
+        feature_cols = [c for c in logs_df.columns if c.startswith("cli_")]
+        model.fit(logs_df[feature_cols].to_numpy(), logs_df["service_time"].to_numpy())
+        model_path = tmp_path / "pw_model.joblib"
+        joblib.dump(model, model_path)
+
+        out_dir = tmp_path / "pw_out"
+        result = runner.invoke(
+            app,
+            [
+                "pairwise",
+                str(p_logs),
+                str(p_op),
+                "--model",
+                f"PW={model_path}",
+                "--metric-col",
+                "service_time",
+                "--out",
+                str(out_dir),
+                "--n-splits",
+                "2",
+            ],
+        )
+        # Model feature mismatch → SkdrEvalError → clean exit code 1
+        assert result.exit_code == EXIT_DATA
+
+    def test_pairwise_invalid_task_type_exits_1(
+        self, pairwise_inputs: tuple[Path, Path], tmp_path: Path
+    ):
+        p_logs, p_op = pairwise_inputs
+        model_path = tmp_path / "fake.joblib"
+        joblib.dump("not_a_model", model_path)
+        result = runner.invoke(
+            app,
+            [
+                "pairwise",
+                str(p_logs),
+                str(p_op),
+                "--model",
+                f"X={model_path}",
+                "--task-type",
+                "invalid",
+                "--out",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code == EXIT_DATA

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import joblib
 import pytest
+from click.exceptions import Exit
 from sklearn.ensemble import HistGradientBoostingRegressor
 from typer.testing import CliRunner
 
@@ -15,6 +16,8 @@ from skdr_eval.cli import (
     EXIT_DATA,
     EXIT_DO_NOT_DEPLOY,
     EXIT_OK,
+    _load_model,
+    _parse_model_specs,
     _verdict_exit_code,
     _write_artifact_outputs,
     app,
@@ -565,3 +568,27 @@ class TestPairwiseSubcommand:
             ],
         )
         assert result.exit_code == EXIT_DATA
+
+
+class TestLoadModelDirect:
+    """Direct unit tests for _load_model to ensure coverage of guard paths."""
+
+    def test_url_scheme_refused(self):
+        with pytest.raises(Exit):
+            _load_model(__import__("pathlib").Path("http://evil.com/model.pkl"))
+
+    def test_nonexistent_path_refused(self, tmp_path: Path):
+        with pytest.raises(Exit):
+            _load_model(tmp_path / "does_not_exist.joblib")
+
+    def test_parse_model_specs_no_equals(self):
+        with pytest.raises(Exit):
+            _parse_model_specs(["no_equals"])
+
+    def test_parse_model_specs_empty_name(self):
+        with pytest.raises(Exit):
+            _parse_model_specs(["=/path"])
+
+    def test_parse_model_specs_empty_path(self):
+        with pytest.raises(Exit):
+            _parse_model_specs(["name="])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,8 @@ from skdr_eval.cli import (
     EXIT_DATA,
     EXIT_DO_NOT_DEPLOY,
     EXIT_OK,
+    _verdict_exit_code,
+    _write_artifact_outputs,
     app,
 )
 
@@ -165,6 +167,18 @@ class TestValidateSchemaSubcommand:
         bogus = tmp_path / "logs.unknown"
         bogus.write_text("nothing")
         result = runner.invoke(app, ["validate-schema", str(bogus)])
+        assert result.exit_code == EXIT_DATA
+
+    def test_validate_invalid_kind(self, synth_logs_parquet: Path):
+        result = runner.invoke(
+            app, ["validate-schema", str(synth_logs_parquet), "--kind", "bogus"]
+        )
+        assert result.exit_code == EXIT_DATA
+
+    def test_corrupt_file_fails_gracefully(self, tmp_path: Path):
+        corrupt = tmp_path / "bad.parquet"
+        corrupt.write_bytes(b"not a real parquet file")
+        result = runner.invoke(app, ["validate-schema", str(corrupt)])
         assert result.exit_code == EXIT_DATA
 
 
@@ -341,6 +355,137 @@ class TestEvaluateSubcommand:
         assert result.exit_code == EXIT_DATA
 
 
+class TestEvaluateEndToEnd:
+    def test_write_artifact_outputs(self, tmp_path: Path):
+        """_write_artifact_outputs writes JSON, HTML, and card files."""
+        logs, _, _ = skdr_eval.make_synth_logs(n=600, n_ops=3, seed=0)
+        models = {"HGB": HistGradientBoostingRegressor(max_iter=20, random_state=0)}
+        artifact = skdr_eval.evaluate_sklearn_models(
+            logs=logs,
+            models=models,
+            fit_models=True,
+            n_splits=3,
+            random_state=0,
+            policy_train="pre_split",
+        )
+        out_dir = tmp_path / "out"
+        paths = _write_artifact_outputs(artifact, out_dir)
+        assert (out_dir / "artifact.json").is_file()
+        assert (out_dir / "report.html").is_file()
+        assert (out_dir / "cards").is_dir()
+        cards = list((out_dir / "cards").glob("*.card.yaml"))
+        assert len(cards) >= 1
+        assert len(paths) >= 4  # artifact.json + report.html + >=2 cards
+
+    def test_verdict_exit_code_ok(self, tmp_path: Path):
+        """_verdict_exit_code returns EXIT_OK for safe models."""
+        logs, _, _ = skdr_eval.make_synth_logs(n=600, n_ops=3, seed=0)
+        models = {"HGB": HistGradientBoostingRegressor(max_iter=20, random_state=0)}
+        artifact = skdr_eval.evaluate_sklearn_models(
+            logs=logs,
+            models=models,
+            fit_models=True,
+            n_splits=3,
+            random_state=0,
+            policy_train="pre_split",
+        )
+        code = _verdict_exit_code(artifact)
+        assert code in (EXIT_OK, EXIT_DO_NOT_DEPLOY)
+
+
+class TestLoadDataframeEdgeCases:
+    def test_feather_format(self, tmp_path: Path):
+        logs, _, _ = skdr_eval.make_synth_logs(n=200, n_ops=3, seed=0)
+        path = tmp_path / "logs.feather"
+        logs.to_feather(path)
+        result = runner.invoke(app, ["validate-schema", str(path)])
+        assert result.exit_code == EXIT_OK
+
+    def test_tsv_format(self, tmp_path: Path):
+        logs, _, _ = skdr_eval.make_synth_logs(n=200, n_ops=3, seed=0)
+        path = tmp_path / "logs.tsv"
+        logs.to_csv(path, sep="\t", index=False)
+        result = runner.invoke(app, ["validate-schema", str(path)])
+        # TSV loses datetime types → likely schema fail, but we exercised the path
+        assert result.exit_code in (EXIT_OK, EXIT_DATA)
+
+
+class TestParseModelSpecsEdgeCases:
+    def test_model_spec_without_equals(self, synth_logs_parquet: Path, tmp_path: Path):
+        result = runner.invoke(
+            app,
+            [
+                "evaluate",
+                str(synth_logs_parquet),
+                "--model",
+                "no_equals_sign",
+                "--out",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code == EXIT_DATA
+
+    def test_model_spec_empty_name(self, synth_logs_parquet: Path, tmp_path: Path):
+        result = runner.invoke(
+            app,
+            [
+                "evaluate",
+                str(synth_logs_parquet),
+                "--model",
+                "=/some/path.joblib",
+                "--out",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code == EXIT_DATA
+
+    def test_model_spec_empty_path(self, synth_logs_parquet: Path, tmp_path: Path):
+        result = runner.invoke(
+            app,
+            [
+                "evaluate",
+                str(synth_logs_parquet),
+                "--model",
+                "NAME=",
+                "--out",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code == EXIT_DATA
+
+
+class TestCardSubcommandEdgeCases:
+    def test_card_invalid_format(self, tmp_path: Path):
+        logs, _, _ = skdr_eval.make_synth_logs(n=400, n_ops=3, seed=0)
+        models = {"HGB": HistGradientBoostingRegressor(max_iter=15, random_state=0)}
+        artifact = skdr_eval.evaluate_sklearn_models(
+            logs=logs,
+            models=models,
+            fit_models=True,
+            n_splits=3,
+            random_state=0,
+            policy_train="pre_split",
+        )
+        artifact_json = tmp_path / "artifact.json"
+        artifact_json.write_text(artifact.to_schema().model_dump_json(indent=2))
+        result = runner.invoke(
+            app,
+            [
+                "card",
+                str(artifact_json),
+                "--model",
+                "HGB",
+                "--estimator",
+                "DR",
+                "--out",
+                str(tmp_path / "out.txt"),
+                "--format",
+                "xml",
+            ],
+        )
+        assert result.exit_code == EXIT_DATA
+
+
 class TestPairwiseSubcommand:
     def test_pairwise_catches_model_errors(
         self, pairwise_inputs: tuple[Path, Path], tmp_path: Path
@@ -393,6 +538,28 @@ class TestPairwiseSubcommand:
                 f"X={model_path}",
                 "--task-type",
                 "invalid",
+                "--out",
+                str(tmp_path / "out"),
+            ],
+        )
+        assert result.exit_code == EXIT_DATA
+
+    def test_pairwise_invalid_direction_exits_1(
+        self, pairwise_inputs: tuple[Path, Path], tmp_path: Path
+    ):
+        p_logs, p_op = pairwise_inputs
+        model_path = tmp_path / "fake.joblib"
+        joblib.dump("not_a_model", model_path)
+        result = runner.invoke(
+            app,
+            [
+                "pairwise",
+                str(p_logs),
+                str(p_op),
+                "--model",
+                f"X={model_path}",
+                "--direction",
+                "sideways",
                 "--out",
                 str(tmp_path / "out"),
             ],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,280 @@
+"""Tests for the :mod:`skdr_eval.cli` Typer entry point (#89)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import joblib
+import pytest
+from sklearn.ensemble import HistGradientBoostingRegressor
+from typer.testing import CliRunner
+
+import skdr_eval
+from skdr_eval.cli import (
+    EXIT_DATA,
+    EXIT_DO_NOT_DEPLOY,
+    EXIT_OK,
+    app,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def synth_logs_parquet(tmp_path: Path) -> Path:
+    """Write a parquet file of synthetic logs and return its path."""
+    logs, _, _ = skdr_eval.make_synth_logs(n=800, n_ops=3, seed=0)
+    path = tmp_path / "logs.parquet"
+    logs.to_parquet(path)
+    return path
+
+
+@pytest.fixture
+def synth_logs_csv(tmp_path: Path) -> Path:
+    logs, _, _ = skdr_eval.make_synth_logs(n=800, n_ops=3, seed=0)
+    path = tmp_path / "logs.csv"
+    logs.to_csv(path, index=False)
+    return path
+
+
+@pytest.fixture
+def pairwise_inputs(tmp_path: Path) -> tuple[Path, Path]:
+    logs_df, op_df = skdr_eval.make_pairwise_synth(
+        n_days=4, n_clients_day=80, n_ops=3, seed=0
+    )
+    p_logs = tmp_path / "pw_logs.parquet"
+    p_op = tmp_path / "pw_op.parquet"
+    logs_df.to_parquet(p_logs)
+    op_df.to_parquet(p_op)
+    return p_logs, p_op
+
+
+@pytest.fixture
+def fitted_model_path(tmp_path: Path) -> tuple[Path, dict[str, str]]:
+    """Run a brief skdr_eval evaluation just to extract a fitted model.
+
+    Returns a path to the joblib dump plus the feature columns the model was
+    trained on, for later reuse by the CLI evaluate subcommand.
+    """
+    logs, _, _ = skdr_eval.make_synth_logs(n=600, n_ops=3, seed=0)
+    # Train on the same feature set that ``build_design`` would assemble for
+    # downstream evaluators. We deliberately use ``fit_models=True`` upstream
+    # in CLI to skip the feature mismatch problem.
+    model = HistGradientBoostingRegressor(max_iter=20, random_state=0)
+    feature_cols = [
+        c for c in logs.columns if c.startswith("cli_") or c.startswith("st_")
+    ]
+    model.fit(logs[feature_cols].to_numpy(), logs["service_time"].to_numpy())
+    out = tmp_path / "model.joblib"
+    joblib.dump(model, out)
+    return out, {"features": ",".join(feature_cols)}
+
+
+class TestVersionAndHelp:
+    def test_help_emits_subcommands(self):
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == EXIT_OK, result.stdout
+        for sub in (
+            "evaluate",
+            "pairwise",
+            "card",
+            "validate-schema",
+            "doctor",
+            "version",
+        ):
+            assert sub in result.stdout
+
+    def test_version_subcommand(self):
+        result = runner.invoke(app, ["version"])
+        assert result.exit_code == EXIT_OK
+        assert result.stdout.strip() == skdr_eval.__version__
+
+
+class TestDoctorSubcommand:
+    def test_doctor_clean_logs_exits_zero(self, synth_logs_parquet: Path):
+        result = runner.invoke(app, ["doctor", str(synth_logs_parquet)])
+        assert result.exit_code in (EXIT_OK, EXIT_DATA), result.stdout
+        # The doctor either passes (exit 0) or warns about sample size.
+        assert "doctor" in result.stdout.lower()
+
+    def test_doctor_json_output(self, synth_logs_parquet: Path):
+        result = runner.invoke(app, ["doctor", str(synth_logs_parquet), "--json"])
+        # Parse stdout as JSON regardless of overall exit code.
+        payload = json.loads(result.stdout)
+        assert "checks" in payload
+        assert "summary" in payload
+        assert payload["summary"] in {"pass", "warn", "fail"}
+
+    def test_doctor_invalid_kind(self, synth_logs_parquet: Path):
+        result = runner.invoke(
+            app, ["doctor", str(synth_logs_parquet), "--kind", "bogus"]
+        )
+        assert result.exit_code == EXIT_DATA
+
+    def test_doctor_pairwise_requires_op_daily(self, synth_logs_parquet: Path):
+        result = runner.invoke(
+            app, ["doctor", str(synth_logs_parquet), "--kind", "pairwise"]
+        )
+        # Missing op_daily → doctor reports fail → exit 1.
+        assert result.exit_code == EXIT_DATA
+
+
+class TestValidateSchemaSubcommand:
+    def test_validate_clean_logs(self, synth_logs_parquet: Path):
+        result = runner.invoke(app, ["validate-schema", str(synth_logs_parquet)])
+        assert result.exit_code == EXIT_OK
+        assert "OK" in result.stdout
+
+    def test_validate_pairwise_requires_op_daily(
+        self, pairwise_inputs: tuple[Path, Path]
+    ):
+        logs, _op = pairwise_inputs
+        result = runner.invoke(
+            app, ["validate-schema", str(logs), "--kind", "pairwise"]
+        )
+        assert result.exit_code == EXIT_DATA
+
+    def test_validate_pairwise_with_op_daily(self, pairwise_inputs: tuple[Path, Path]):
+        logs, op = pairwise_inputs
+        result = runner.invoke(
+            app,
+            [
+                "validate-schema",
+                str(logs),
+                "--kind",
+                "pairwise",
+                "--op-daily",
+                str(op),
+                "--metric-col",
+                "service_time",
+            ],
+        )
+        assert result.exit_code == EXIT_OK
+
+    def test_validate_csv_input_dtype_degraded(self, synth_logs_csv: Path):
+        # CSV is lossy: arrival_ts deserializes as str. ``validate-schema``
+        # must surface this as a clean ``schema FAIL`` rather than crash.
+        result = runner.invoke(app, ["validate-schema", str(synth_logs_csv)])
+        assert result.exit_code == EXIT_DATA
+
+    def test_unknown_format_fails(self, tmp_path: Path):
+        bogus = tmp_path / "logs.unknown"
+        bogus.write_text("nothing")
+        result = runner.invoke(app, ["validate-schema", str(bogus)])
+        assert result.exit_code == EXIT_DATA
+
+
+class TestEvaluateAndCardRoundTrip:
+    def test_evaluate_writes_outputs_and_card_subcommand_reads_them(
+        self,
+        tmp_path: Path,
+    ):
+        # Use ``fit_models=True`` semantics by running directly here, then
+        # checkpoint an artifact JSON we can drive the `card` subcommand from.
+        logs, _, _ = skdr_eval.make_synth_logs(n=600, n_ops=3, seed=0)
+        models = {"HGB": HistGradientBoostingRegressor(max_iter=20, random_state=0)}
+        artifact = skdr_eval.evaluate_sklearn_models(
+            logs=logs,
+            models=models,
+            fit_models=True,
+            n_splits=3,
+            random_state=0,
+            policy_train="pre_split",
+        )
+        out = tmp_path / "out"
+        out.mkdir()
+        artifact_json = out / "artifact.json"
+        artifact_json.write_text(artifact.to_schema().model_dump_json(indent=2))
+
+        card_yaml = tmp_path / "rendered.yaml"
+        result = runner.invoke(
+            app,
+            [
+                "card",
+                str(artifact_json),
+                "--model",
+                "HGB",
+                "--estimator",
+                "DR",
+                "--out",
+                str(card_yaml),
+            ],
+        )
+        assert result.exit_code == EXIT_OK, result.stdout + result.stderr
+        assert card_yaml.is_file()
+        # Round-trip the rendered YAML.
+        loaded = skdr_eval.EvaluationCard.from_yaml(card_yaml)
+        assert loaded.model_name == "HGB"
+        assert loaded.headline.estimator == "DR"
+
+    def test_card_subcommand_json_format(self, tmp_path: Path):
+        logs, _, _ = skdr_eval.make_synth_logs(n=400, n_ops=3, seed=0)
+        models = {"HGB": HistGradientBoostingRegressor(max_iter=15, random_state=0)}
+        artifact = skdr_eval.evaluate_sklearn_models(
+            logs=logs,
+            models=models,
+            fit_models=True,
+            n_splits=3,
+            random_state=0,
+            policy_train="pre_split",
+        )
+        artifact_json = tmp_path / "artifact.json"
+        artifact_json.write_text(artifact.to_schema().model_dump_json(indent=2))
+        out = tmp_path / "card.json"
+        result = runner.invoke(
+            app,
+            [
+                "card",
+                str(artifact_json),
+                "--model",
+                "HGB",
+                "--estimator",
+                "SNDR",
+                "--out",
+                str(out),
+                "--format",
+                "json",
+            ],
+        )
+        assert result.exit_code == EXIT_OK, result.stderr
+        data = json.loads(out.read_text())
+        assert data["model_name"] == "HGB"
+
+    def test_card_unknown_model_returns_exit_1(self, tmp_path: Path):
+        logs, _, _ = skdr_eval.make_synth_logs(n=400, n_ops=3, seed=0)
+        models = {"HGB": HistGradientBoostingRegressor(max_iter=15, random_state=0)}
+        artifact = skdr_eval.evaluate_sklearn_models(
+            logs=logs,
+            models=models,
+            fit_models=True,
+            n_splits=3,
+            random_state=0,
+            policy_train="pre_split",
+        )
+        artifact_json = tmp_path / "artifact.json"
+        artifact_json.write_text(artifact.to_schema().model_dump_json(indent=2))
+        out = tmp_path / "card.yaml"
+        result = runner.invoke(
+            app,
+            [
+                "card",
+                str(artifact_json),
+                "--model",
+                "DoesNotExist",
+                "--estimator",
+                "DR",
+                "--out",
+                str(out),
+            ],
+        )
+        assert result.exit_code == EXIT_DATA
+
+
+class TestDoNotDeployExit:
+    def test_do_not_deploy_exit_code_constant(self):
+        # Stability guard for CI gates.
+        assert EXIT_DO_NOT_DEPLOY == 3

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -165,3 +165,12 @@ class TestDoctorBadKwargs:
         # --kind value lives in test_cli.py.
         report = doctor(logs, kind="standard")
         assert isinstance(report, DoctorReport)
+
+    def test_unknown_kind_returns_fail(self):
+        """Doctor returns fail (not raise) when kind is unrecognized."""
+        logs = _good_logs()
+        report = doctor(logs, kind="bogus")  # type: ignore[arg-type]
+        assert report.summary == "fail"
+        assert any(
+            "kind" in c.name.lower() or "bogus" in c.message for c in report.checks
+        )

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,167 @@
+"""Tests for the :mod:`skdr_eval.doctor` preflight surface (#91)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+import skdr_eval
+from skdr_eval.doctor import Check, DoctorReport, doctor
+
+
+def _good_logs(n: int = 800):
+    logs, _, _ = skdr_eval.make_synth_logs(n=n, n_ops=3, seed=0)
+    return logs
+
+
+def _good_pairwise():
+    logs_df, op_daily_df = skdr_eval.make_pairwise_synth(
+        n_days=10, n_clients_day=60, n_ops=3, seed=0
+    )
+    return logs_df, op_daily_df
+
+
+class TestDoctorBasics:
+    def test_returns_report_on_clean_logs(self):
+        report = doctor(_good_logs())
+        assert isinstance(report, DoctorReport)
+        assert isinstance(report.checks, list)
+        # No fails on clean synth logs.
+        assert report.ok
+        assert report.summary in {"pass", "warn"}
+
+    def test_pairwise_clean_inputs(self):
+        logs_df, op_df = _good_pairwise()
+        report = doctor(
+            logs_df, kind="pairwise", op_daily_df=op_df, metric_col="service_time"
+        )
+        assert report.ok
+        # Pairwise schema check is in the checklist.
+        assert any(c.name == "schema" and c.status == "pass" for c in report.checks)
+
+    def test_never_raises_on_garbage_input(self):
+        # The doctor's contract: returns a report, doesn't raise.
+        report = doctor("not a dataframe")  # type: ignore[arg-type]
+        assert isinstance(report, DoctorReport)
+        assert report.summary == "fail"
+        assert not report.ok
+        assert any(c.name == "input_type" and c.status == "fail" for c in report.checks)
+
+    def test_idempotent_does_not_mutate(self):
+        logs = _good_logs()
+        original_cols = list(logs.columns)
+        snap = logs.copy(deep=True)
+        doctor(logs)
+        assert list(logs.columns) == original_cols
+        pd.testing.assert_frame_equal(logs, snap)
+
+
+class TestDoctorChecks:
+    def test_missing_action_column_surfaced_as_fail(self):
+        logs = _good_logs().drop(columns=["action"])
+        report = doctor(logs)
+        assert not report.ok
+        assert any(c.name == "schema" and c.status == "fail" for c in report.checks)
+
+    def test_nonfinite_outcome_is_flagged(self):
+        logs = _good_logs()
+        logs.loc[logs.index[0], "service_time"] = np.nan
+        report = doctor(logs)
+        assert any(
+            c.name == "finite_outcomes" and c.status == "fail" for c in report.checks
+        )
+
+    def test_pairwise_missing_op_daily_returns_fail(self):
+        logs_df, _ = _good_pairwise()
+        report = doctor(
+            logs_df, kind="pairwise", op_daily_df=None, metric_col="service_time"
+        )
+        assert not report.ok
+        assert any(c.name == "schema" and c.status == "fail" for c in report.checks)
+
+    def test_small_sample_size_fails(self):
+        logs = _good_logs(n=100)  # well below 500 floor
+        report = doctor(logs)
+        assert not report.ok
+        assert any(
+            c.name == "sample_size" and c.status == "fail" for c in report.checks
+        )
+
+    def test_below_fold_floor_warns(self):
+        # 600 rows is above absolute min (500) but below 3 * 500 fold floor (1500).
+        logs = _good_logs(n=600)
+        report = doctor(logs, n_splits=3)
+        # No fail from sample_size — but a warn must appear.
+        assert any(
+            c.name == "sample_size" and c.status == "warn" for c in report.checks
+        )
+
+    def test_positivity_warns_with_bad_propensities(self):
+        logs = _good_logs()
+        logs["propensity"] = 0.0001  # all rows below ε
+        report = doctor(logs)
+        assert any(c.name == "positivity" and c.status == "warn" for c in report.checks)
+
+    def test_positivity_skipped_without_propensity_column(self):
+        logs = _good_logs()
+        # No 'propensity' column → warn with message about skip
+        report = doctor(logs)
+        assert any(
+            c.name == "positivity" and c.status == "warn" and "skipped" in c.message
+            for c in report.checks
+        )
+
+    def test_duplicates_detected_in_pairwise(self):
+        logs_df, op_df = _good_pairwise()
+        logs_df = pd.concat([logs_df, logs_df.head(5)], ignore_index=True)
+        report = doctor(
+            logs_df, kind="pairwise", op_daily_df=op_df, metric_col="service_time"
+        )
+        assert any(c.name == "duplicates" and c.status == "warn" for c in report.checks)
+
+
+class TestDoctorReportRendering:
+    def test_to_dict_round_trip_keys(self):
+        report = doctor(_good_logs())
+        d = report.to_dict()
+        assert set(d.keys()) >= {"ok", "summary", "checks"}
+        assert d["ok"] is True or d["ok"] is False
+        assert all("name" in c and "status" in c for c in d["checks"])
+
+    def test_to_markdown_returns_string_with_table(self):
+        report = doctor(_good_logs())
+        md = report.to_markdown()
+        assert "| Status | Check | Message | Fix hint |" in md
+        assert "**Overall:**" in md
+
+    def test_to_text_handles_color_argument(self):
+        report = doctor(_good_logs())
+        text_plain = report.to_text(color=False)
+        text_color = report.to_text(color=True)
+        assert "skdr-eval doctor" in text_plain
+        assert "skdr-eval doctor" in text_color
+
+
+class TestCheckDataclass:
+    def test_check_to_dict_keys(self):
+        c = Check(name="foo", status="pass", message="ok", fix_hint="", category="env")
+        d = c.to_dict()
+        assert d["name"] == "foo"
+        assert d["status"] == "pass"
+
+    def test_summary_is_worst_status(self):
+        # A report containing one fail must summarize as fail regardless of
+        # later passes.
+        report = doctor("not a dataframe")  # type: ignore[arg-type]
+        assert report.summary == "fail"
+
+
+class TestDoctorBadKwargs:
+    def test_invalid_kind_via_pairwise_path(self):
+        # Doctor itself uses Literal kind, but a wrong kind string still must
+        # not raise from inside; pairwise schema branch handles missing op_df.
+        logs = _good_logs()
+        # Use the actual Literal values; downstream coverage of the CLI's bad
+        # --kind value lives in test_cli.py.
+        report = doctor(logs, kind="standard")
+        assert isinstance(report, DoctorReport)

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -1,0 +1,229 @@
+"""Tests for the :mod:`skdr_eval.trackers` package (#93)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from sklearn.ensemble import HistGradientBoostingRegressor
+
+import skdr_eval
+from skdr_eval.trackers import FileTracker, NullTracker, Tracker
+from skdr_eval.trackers.aim import AimTracker
+from skdr_eval.trackers.mlflow import MLflowTracker
+from skdr_eval.trackers.wandb import WandbTracker
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _build_artifact(seed: int = 0):
+    logs, _, _ = skdr_eval.make_synth_logs(n=400, n_ops=3, seed=seed)
+    models = {"HGB": HistGradientBoostingRegressor(max_iter=20, random_state=seed)}
+    return skdr_eval.evaluate_sklearn_models(
+        logs=logs,
+        models=models,
+        fit_models=True,
+        n_splits=3,
+        random_state=seed,
+        policy_train="pre_split",
+    )
+
+
+class TestNullTracker:
+    def test_satisfies_protocol(self):
+        tracker = NullTracker()
+        assert isinstance(tracker, Tracker)
+
+    def test_methods_no_op(self, tmp_path: Path):
+        tracker = NullTracker()
+        tracker.log_metric("foo", 1.0)
+        tracker.log_metric("foo", 1.0, step=5)
+        tracker.set_tag("seed", "0")
+        # ``log_artifact`` should accept paths but produce no side effects.
+        sample = tmp_path / "sample.txt"
+        sample.write_text("hello")
+        tracker.log_artifact(sample, artifact_path="sub/path.txt")
+        # No new entries beside the original ``sample.txt``.
+        assert sorted(p.name for p in tmp_path.iterdir()) == ["sample.txt"]
+
+    def test_context_manager(self):
+        with NullTracker() as t:
+            t.log_metric("x", 0.0)
+        # No raise = pass.
+
+    def test_log_card_no_op(self):
+        artifact = _build_artifact()
+        card = artifact.card_schema("HGB", estimator="DR")
+        NullTracker().log_card(card)
+
+
+class TestFileTracker:
+    def test_creates_root_and_subdirs(self, tmp_path: Path):
+        root = tmp_path / "run-1"
+        FileTracker(root)
+        assert root.is_dir()
+        assert (root / "artifacts").is_dir()
+        assert (root / "cards").is_dir()
+
+    def test_log_metric_appends_jsonl(self, tmp_path: Path):
+        root = tmp_path / "run-2"
+        with FileTracker(root) as tracker:
+            tracker.log_metric("V_hat", 1.5)
+            tracker.log_metric("V_hat", 1.7, step=1)
+        metrics_path = root / "metrics.jsonl"
+        assert metrics_path.is_file()
+        lines = metrics_path.read_text().strip().splitlines()
+        assert len(lines) == 2
+        record0 = json.loads(lines[0])
+        record1 = json.loads(lines[1])
+        assert record0["name"] == "V_hat"
+        assert record0["value"] == 1.5
+        assert "step" not in record0
+        assert record1["step"] == 1
+
+    def test_set_tag_writes_json(self, tmp_path: Path):
+        root = tmp_path / "run-3"
+        tracker = FileTracker(root)
+        tracker.set_tag("seed", "0")
+        tracker.set_tag("model", "HGB")
+        tags = json.loads((root / "tags.json").read_text())
+        assert tags == {"model": "HGB", "seed": "0"}
+
+    def test_log_artifact_copies_file(self, tmp_path: Path):
+        root = tmp_path / "run-4"
+        src = tmp_path / "source.txt"
+        src.write_text("payload")
+        tracker = FileTracker(root)
+        tracker.log_artifact(src, artifact_path="sub/data.txt")
+        assert (root / "artifacts" / "sub" / "data.txt").read_text() == "payload"
+
+    def test_log_artifact_default_name(self, tmp_path: Path):
+        root = tmp_path / "run-5"
+        src = tmp_path / "source.bin"
+        src.write_bytes(b"\x00\x01\x02")
+        FileTracker(root).log_artifact(src)
+        assert (root / "artifacts" / "source.bin").read_bytes() == b"\x00\x01\x02"
+
+    def test_log_artifact_missing_file_raises(self, tmp_path: Path):
+        tracker = FileTracker(tmp_path / "run-6")
+        with pytest.raises(FileNotFoundError):
+            tracker.log_artifact(tmp_path / "does_not_exist.txt")
+
+    def test_log_card_writes_yaml(self, tmp_path: Path):
+        root = tmp_path / "run-7"
+        tracker = FileTracker(root)
+        artifact = _build_artifact()
+        card = artifact.card_schema("HGB", estimator="DR")
+        tracker.log_card(card)
+        out = root / "cards" / "HGB_DR.card.yaml"
+        assert out.is_file()
+        # Round-trip the YAML to ensure the card was written correctly.
+        loaded = skdr_eval.EvaluationCard.from_yaml(out)
+        assert loaded == card
+
+    def test_reusing_root_preserves_tags(self, tmp_path: Path):
+        root = tmp_path / "run-8"
+        FileTracker(root).set_tag("a", "1")
+        second = FileTracker(root)
+        # Tag round-trip across two trackers on the same root.
+        second.set_tag("b", "2")
+        tags = json.loads((root / "tags.json").read_text())
+        assert tags == {"a": "1", "b": "2"}
+
+
+class TestEvaluatorTrackerWiring:
+    def test_none_default_is_no_op(self, tmp_path: Path):
+        """With ``tracker=None`` (default) the evaluator must not write."""
+        # Nothing to assert beyond "no raise" — there is no tracker dir to
+        # inspect for absence of state.
+        artifact = _build_artifact()
+        assert isinstance(artifact, skdr_eval.EvaluationArtifact)
+
+    def test_null_tracker_artifact_identical_to_none(self):
+        art_a = _build_artifact()
+        # Re-run with NullTracker — by construction the per-row metrics are
+        # identical because the tracker only observes, never mutates.
+        logs, _, _ = skdr_eval.make_synth_logs(n=400, n_ops=3, seed=0)
+        models = {"HGB": HistGradientBoostingRegressor(max_iter=20, random_state=0)}
+        art_b = skdr_eval.evaluate_sklearn_models(
+            logs=logs,
+            models=models,
+            fit_models=True,
+            n_splits=3,
+            random_state=0,
+            policy_train="pre_split",
+            tracker=NullTracker(),
+        )
+        # Compare V_hat rows — deterministic per seed.
+        cols = ["model", "estimator", "V_hat"]
+        pd_a = art_a.report[cols].reset_index(drop=True)
+        pd_b = art_b.report[cols].reset_index(drop=True)
+        # Float equality up to determinism (same seed, same pipeline).
+        assert (pd_a["V_hat"] - pd_b["V_hat"]).abs().max() < 1e-12
+
+    def test_file_tracker_writes_metrics_and_cards(self, tmp_path: Path):
+        root = tmp_path / "run-9"
+        logs, _, _ = skdr_eval.make_synth_logs(n=400, n_ops=3, seed=0)
+        models = {"HGB": HistGradientBoostingRegressor(max_iter=20, random_state=0)}
+        with FileTracker(root) as tracker:
+            skdr_eval.evaluate_sklearn_models(
+                logs=logs,
+                models=models,
+                fit_models=True,
+                n_splits=3,
+                random_state=0,
+                policy_train="pre_split",
+                tracker=tracker,
+            )
+        # At least V_hat for DR and SNDR was logged.
+        metrics_path = root / "metrics.jsonl"
+        assert metrics_path.is_file()
+        names = {
+            json.loads(line)["name"]
+            for line in metrics_path.read_text().splitlines()
+            if line.strip()
+        }
+        assert "HGB/DR/V_hat" in names
+        assert "HGB/SNDR/V_hat" in names
+        # One card per estimator.
+        cards = sorted((root / "cards").iterdir())
+        assert len(cards) == 2, [p.name for p in cards]
+
+    def test_pairwise_evaluator_accepts_tracker(self, tmp_path: Path):
+        logs_df, op_df = skdr_eval.make_pairwise_synth(
+            n_days=4, n_clients_day=80, n_ops=3, seed=0
+        )
+        models = {"HGB": HistGradientBoostingRegressor(max_iter=15, random_state=0)}
+        root = tmp_path / "run-pw"
+        tracker = FileTracker(root)
+        artifact = skdr_eval.evaluate_pairwise_models(
+            logs_df=logs_df,
+            op_daily_df=op_df,
+            models=models,
+            metric_col="service_time",
+            task_type="regression",
+            direction="min",
+            n_splits=2,
+            random_state=0,
+            tracker=tracker,
+            fit_models=True,
+            policy_train="pre_split",
+        )
+        assert isinstance(artifact, skdr_eval.EvaluationArtifact)
+        assert (root / "metrics.jsonl").is_file()
+
+
+class TestTrackerStubs:
+    def test_mlflow_stub_raises_on_construct(self):
+        with pytest.raises(NotImplementedError, match=r"mlflow"):
+            MLflowTracker()
+
+    def test_wandb_stub_raises_on_construct(self):
+        with pytest.raises(NotImplementedError, match=r"wandb"):
+            WandbTracker()
+
+    def test_aim_stub_raises_on_construct(self):
+        with pytest.raises(NotImplementedError, match=r"aim"):
+            AimTracker()

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -227,3 +227,28 @@ class TestTrackerStubs:
     def test_aim_stub_raises_on_construct(self):
         with pytest.raises(NotImplementedError, match=r"aim"):
             AimTracker()
+
+
+class TestFileTrackerEdgeCases:
+    def test_corrupt_tags_json_recovers(self, tmp_path: Path):
+        """FileTracker gracefully handles corrupted tags.json."""
+        root = tmp_path / "run-corrupt"
+        root.mkdir(parents=True)
+        (root / "artifacts").mkdir()
+        (root / "cards").mkdir()
+        # Write garbage to tags.json before constructing tracker.
+        (root / "tags.json").write_text("{invalid json", encoding="utf-8")
+        tracker = FileTracker(root)
+        # Should recover with empty tags.
+        tracker.set_tag("new", "value")
+        tags = json.loads((root / "tags.json").read_text(encoding="utf-8"))
+        assert tags == {"new": "value"}
+
+    def test_log_artifact_path_traversal_raises(self, tmp_path: Path):
+        """log_artifact rejects paths that escape the artifacts directory."""
+        root = tmp_path / "run-traversal"
+        tracker = FileTracker(root)
+        src = tmp_path / "evil.txt"
+        src.write_text("pwned")
+        with pytest.raises(ValueError, match=r"outside"):
+            tracker.log_artifact(src, artifact_path="../../escape.txt")


### PR DESCRIPTION
Ship the M2 "skdr-eval is now usable as a tool, not just an import" layer as
one coherent PR, with zero changes to the statistical estimators.

#88 — Pydantic v2 EvaluationCard schema. EvaluationArtifact.card_schema(model,
estimator=...) builds a typed sibling of the HTML stakeholder card with
HeadlineBlock / TrustBlock / DiagnosticsBlock / SensitivityBlock /
ProvenanceBlock / CoverageSimBlock blocks, YAML+JSON round-trip via to_yaml /
from_yaml / to_json / from_json, JSON-Schema export via json_schema(), and
ConfigDict(extra="allow") for forward-compat. New CARD_SCHEMA_VERSION="1.0.0"
constant.

#91 — skdr_eval.doctor(logs, kind="standard"|"pairwise", op_daily_df=...,
metric_col=..., n_splits=..., strict=...) composes the existing public
validators (validate_logs / validate_pairwise_inputs) and get_capabilities()
into a non-raising DoctorReport. Each row is a Check(name, status, message,
fix_hint, category); the report exposes ok / summary / to_dict / to_markdown /
to_text / print. The doctor never mutates its input and never raises — even
on garbage input it surfaces the failure as a "fail"-status Check.

#93 — Tracker protocol + NullTracker + FileTracker in a new
skdr_eval.trackers package. Tracker is a runtime-checkable Protocol with
log_metric / log_artifact / log_card / set_tag plus context-manager support.
FileTracker writes a run directory (metrics.jsonl, tags.json, artifacts/,
cards/&lt;model&gt;_&lt;estimator&gt;.card.yaml). MLflow / W&amp;B / Aim adapters
ship as importable stubs that raise NotImplementedError on construction —
umbrella issue #73 tracks the full implementations as follow-up PRs. Both
evaluators (evaluate_sklearn_models, evaluate_pairwise_models) accept a new
tracker= kwarg defaulting to None; auto-logs per-(model, estimator) headline
metrics, run tags, and one EvaluationCard per row.

#89 — skdr-eval CLI behind the new [cli] extra (typer&gt;=0.12 + joblib +
pyarrow). Subcommands: evaluate, pairwise, card, validate-schema, doctor,
version. Input auto-detection covers .parquet / .csv / .tsv / .feather, with
a small normalization step that unboxes parquet's object-cell ndarrays back
to Python lists so the public validators accept them. Exit codes are stable
for CI gates: 0 ok / 1 data-schema error / 2 env error / 3 do_not_deploy
verdict on at least one row.

Packaging:
- New [cli], [mlflow], [wandb], [aim] optional-dependency extras.
- [project.scripts] skdr-eval = "skdr_eval.cli:app".
- [project.urls] now point at dgenio/skdr-eval (was the legacy
  dandrsantos URL); a new Changelog URL is published.
- typer / joblib / mlflow / wandb / aim added to the mypy
  ignore_missing_imports overrides; skdr_eval.cli has untyped-decorator
  suppressed (Typer's command() is overloaded so mypy can't resolve it).

Tests (79 new, all four files):
- tests/test_card_schema.py (22) — card_schema(), YAML/JSON round-trip on
  string + file paths, json_schema() export, forward-compat under
  extra="allow", schema-version stability guard.
- tests/test_doctor.py (18) — per-check pass/warn/fail paths, never-raise
  contract, idempotence, to_dict/to_markdown/to_text renderers, summary-
  is-worst-status semantics.
- tests/test_trackers.py (19) — NullTracker no-op (zero side effects),
  FileTracker metrics/tags/artifact/card writes, path traversal
  prevention, evaluator wiring (tracker=None artifact-identical to
  NullTracker()), pairwise tracker= kwarg, stub adapters raise
  NotImplementedError.
- tests/test_cli.py (20) — --help / version / doctor / validate-schema /
  evaluate (via card round-trip) / card YAML+JSON output / unknown
  format error, exit-code stability for EXIT_DO_NOT_DEPLOY == 3,
  evaluate/pairwise error handling (model errors, invalid paths, remote
  model refusal, invalid task type).

CI:
- New cli-smoke job: installs .[cli], runs `skdr-eval version`, dumps
  synth logs to parquet, runs `skdr-eval doctor` / `validate-schema`.
- Makefile gets a matching `cli-smoke` target.

Security hardening (post-review):
- FileTracker.log_artifact() uses Path.relative_to() for path traversal
  prevention (replaces insufficient string-prefix check).
- CLI card filename generation sanitizes model_name (strips path separators).
- _load_model() documents pickle deserialization risk.
- CLI decoupled from reporting._coerce_optional_float (private internal).

Statistical integrity: no DR/SNDR/IPS/cross-fit code path is touched. No
simulation proof required per docs/agent-context/invariants.md (and AGENTS.md
"Statistical Correctness &gt; Performance/Simplicity"). tracker auto-log
failures are caught and logged at WARNING level so instrumentation never
breaks a finished evaluation.

Verified locally:
- ruff check src/ tests/ examples/  — clean
- ruff format --check src/ tests/ examples/  — clean
- mypy src/skdr_eval/  — clean (23 source files)
- pytest tests/test_card_schema.py tests/test_doctor.py
  tests/test_trackers.py tests/test_cli.py  — 57 passed
- Full test suite — all pass