### PR TITLE
fix: first-run correctness & documentation-drift pass (11 issues)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Configurable reward column** ([#105]). `evaluate_sklearn_models`,
   `build_design`, and `validate_logs` accept `y_col` (default
   `"service_time"`) so general-purpose OPE logs can name the reward column
-  anything (`reward`, `click`, `revenue`, ...).
+  anything (`reward`, `click`, `revenue`, ...). Default preserves prior
+  behavior exactly; revert by removing the `y_col` kwarg.
 - **`EvaluationArtifact.to_json()` / `.to_html()`** ([#108]) now follow the
   pandas convention: called with no argument they return the serialized
   string; called with a `path` they write the file and return its `Path`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `mips_bandwidth=1.0`. Default `estimators=("DR","SNDR")` preserves the
   historical report shape exactly. The new `estimators=` row order in the
   report follows the order in the kwarg.
+- **Configurable reward column** ([#105]). `evaluate_sklearn_models`,
+  `build_design`, and `validate_logs` accept `y_col` (default
+  `"service_time"`) so general-purpose OPE logs can name the reward column
+  anything (`reward`, `click`, `revenue`, ...).
+- **`EvaluationArtifact.to_json()` / `.to_html()`** ([#108]) now follow the
+  pandas convention: called with no argument they return the serialized
+  string; called with a `path` they write the file and return its `Path`.
+- **`models` contract validation** ([#109]). Both evaluators now raise a
+  clear `DataValidationError` (was an opaque `AttributeError` / `ValueError`)
+  when `models` is not a non-empty `{name: estimator}` dict, including a
+  "did you mean `models={...}`?" hint for a bare estimator.
+
+### Fixed
+- **README quickstart no longer warns** ([#104]). The canonical snippets pass
+  `policy_train="pre_split"` explicitly, so a copy-pasted quickstart runs
+  without a `DeprecationWarning`.
+- **Undefined `[choice]` extra** ([#107]). Removed the `pip install
+  skdr-eval[choice]` instruction; conditional-logit works out of the box
+  (SciPy is a core dependency). A test now guards README↔pyproject extra
+  drift.
+- **Stale repository owner / citation version** ([#110], [#111]). README
+  Trusted-Publishing block points at `dgenio/skdr-eval`; the BibTeX `version`
+  matches the released version.
+- **Python version drift in docs** ([#112]). `CONTRIBUTING.md` /
+  `DEVELOPMENT.md` now say Python 3.11+ to match `requires-python`.
+- **`make_pairwise_synth` docstring shapes** ([#113]) corrected to the actual
+  `(300, 14)` / `(30, 6)` output, with a regression test.
+- **Pre-split small-input error** ([#114]). With `policy_train="pre_split"`,
+  the `InsufficientDataError` now reports the original input row count and
+  `policy_train_frac` instead of the opaque post-split count.
+- **`validate_logs` int/str action mismatch** ([#115]). When actions are
+  ints but `*_elig` column names parse as str, the error now names the dtype
+  gap and suggests an `astype(str)` cast.
 
 ## [0.9.0] - 2026-05-22
 
@@ -239,6 +272,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#98]: https://github.com/dgenio/skdr-eval/issues/98
 [#101]: https://github.com/dgenio/skdr-eval/pull/101
 [#102]: https://github.com/dgenio/skdr-eval/pull/102
+[#104]: https://github.com/dgenio/skdr-eval/issues/104
+[#105]: https://github.com/dgenio/skdr-eval/issues/105
+[#107]: https://github.com/dgenio/skdr-eval/issues/107
+[#108]: https://github.com/dgenio/skdr-eval/issues/108
+[#109]: https://github.com/dgenio/skdr-eval/issues/109
+[#110]: https://github.com/dgenio/skdr-eval/issues/110
+[#111]: https://github.com/dgenio/skdr-eval/issues/111
+[#112]: https://github.com/dgenio/skdr-eval/issues/112
+[#113]: https://github.com/dgenio/skdr-eval/issues/113
+[#114]: https://github.com/dgenio/skdr-eval/issues/114
+[#115]: https://github.com/dgenio/skdr-eval/issues/115
 
 ## [0.8.0] - 2026-05-20
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -52,6 +52,6 @@ preferred-citation:
     - family-names: "Santos"
       given-names: "Diogo"
       email: "diogofcul@gmail.com"
-  version: "0.8.0"
+  version: "0.9.0"
   year: 2026
   url: "https://github.com/dgenio/skdr-eval"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,7 @@ We follow [Semantic Versioning](https://semver.org/):
 ## 🛠️ Development Setup
 
 ### Prerequisites
-- Python 3.9+
+- Python 3.11+
 - Git
 - GitHub account
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -231,7 +231,7 @@ if not data:
 ## 🚀 CI/CD Pipeline (GitHub Actions)
 
 ### Automated Checks (Must Pass)
-1. **Linting**: `ruff check` on Python 3.9-3.12
+1. **Linting**: `ruff check` on Python 3.11-3.14
 2. **Formatting**: `ruff format --check`
 3. **Type checking**: `mypy src/skdr_eval/`
 4. **Testing**: `pytest` with coverage report
@@ -278,7 +278,7 @@ git push origin v1.2.0
 ## 🛠️ Development Environment Setup
 
 ### Prerequisites
-- Python 3.9+ (tested on 3.9, 3.10, 3.11, 3.12)
+- Python 3.11+ (tested on 3.11, 3.12, 3.13, 3.14)
 - Git
 - GitHub account with SSH keys configured
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,20 @@ print(contribs)  # decision_id, q_pi, q_hat, weight, reward, contribution_to_V
 #  contribution_to_V.mean() == V_hat by construction (float64 precision)
 ```
 
+If your logs name the reward column anything other than `service_time` (e.g.,
+`reward`, `click`, `revenue`), pass it via the `y_col` keyword:
+
+```python
+artifact = skdr_eval.evaluate_sklearn_models(
+    logs=logs.rename(columns={"service_time": "reward"}),
+    models=models,
+    fit_models=True,
+    n_splits=3,
+    policy_train="pre_split",
+    y_col="reward",  # name of the reward column in your logs
+)
+```
+
 > **Breaking change in 0.6.0:** `evaluate_sklearn_models` and
 > `evaluate_pairwise_models` now return a single `EvaluationArtifact`
 > instead of the legacy `(report, detailed)` tuple. Unpack

--- a/README.md
+++ b/README.md
@@ -88,12 +88,10 @@ If you need *slate* / top-K ranking estimators (Cascade-DR, Reward-Interaction I
 pip install skdr-eval
 ```
 
-### Optional Dependencies
+Conditional-logit choice models work out of the box — SciPy is a core
+dependency, so no extra install is required.
 
-For choice models (conditional logit):
-```bash
-pip install skdr-eval[choice]
-```
+### Optional Dependencies
 
 For speed optimizations (PyArrow, Polars):
 ```bash
@@ -160,7 +158,12 @@ artifact = skdr_eval.evaluate_sklearn_models(
     fit_models=True,
     n_splits=3,
     random_state=42,
+    policy_train="pre_split",  # reserve a holdout slice for policy training
 )
+# `policy_train="pre_split"` fits the policy on the first 85% of the data and
+# evaluates on the held-out tail, avoiding training-on-test bias when
+# `fit_models=True`. Omitting it falls back to `"pre_split"` with a
+# DeprecationWarning; pass it explicitly to keep the output clean.
 
 # 4. View results
 print(artifact.report[['model', 'estimator', 'V_hat', 'ESS', 'match_rate']])
@@ -181,6 +184,7 @@ artifact = skdr_eval.evaluate_sklearn_models(
     fit_models=True,
     n_splits=3,
     random_state=42,
+    policy_train="pre_split",
     keep_contributions=True,  # attach per-decision DR/SNDR pseudo-outcomes
 )
 contribs = artifact.contributions("RandomForest", estimator="DR", top_k=5)
@@ -218,6 +222,7 @@ artifact = skdr_eval.evaluate_pairwise_models(
     strategy="auto",
     n_splits=3,
     random_state=42,
+    policy_train="pre_split",
 )
 
 # 4. View results
@@ -252,6 +257,10 @@ Evaluate sklearn models using DR and SNDR estimators.
 - `fit_models`: Whether to fit models (default: True)
 - `n_splits`: Number of time-series splits (default: 3)
 - `random_state`: Random seed for reproducibility
+- `y_col`: Name of the reward/outcome column (keyword-only, default:
+  `"service_time"`). Set it for general-purpose OPE logs whose reward is named
+  e.g. `"reward"`, `"click"`, or `"revenue"`:
+  `evaluate_sklearn_models(logs=logs, models=models, y_col="reward")`.
 
 **Temporal split controls (keyword-only):**
 - `gap`: Samples skipped between train and test in each CV fold
@@ -299,7 +308,7 @@ Evaluate models using pairwise (client-operator) evaluation with autoscaling.
 - `random_state`: Random seed for reproducibility (default: 0)
 
 **Returns:**
-- `EvaluationArtifact`: bundled result. Use `.report` for the summary DataFrame, `.detailed` for per-model `DRResult`s, `.warnings` for support-health warnings, `.sensitivity` for clip-grid stability, `.diagnostics` for propensity diagnostics, and `.to_json` / `.to_html` / `.card` / `.export` for stakeholder artifacts.
+- `EvaluationArtifact`: bundled result. Use `.report` for the summary DataFrame, `.detailed` for per-model `DRResult`s, `.warnings` for support-health warnings, `.sensitivity` for clip-grid stability, `.diagnostics` for propensity diagnostics, and `.to_json` / `.to_html` / `.card` / `.export` for stakeholder artifacts. `.to_json()` / `.to_html()` return a string when called with no argument, and write the file (returning its `Path`) when given a `path`.
 
 #### `make_pairwise_synth(n_days=14, n_clients_day=2000, n_ops=200, **kwargs)`
 Generate synthetic pairwise (client-operator) data for evaluation.
@@ -377,6 +386,7 @@ artifact = skdr_eval.evaluate_sklearn_models(
     models=models,
     ci_bootstrap=True,
     alpha=0.05,  # 95% confidence
+    policy_train="pre_split",
 )
 
 print(artifact.report[['model', 'estimator', 'V_hat', 'ci_lower', 'ci_upper']])
@@ -450,7 +460,9 @@ is YAML/JSON round-trippable, exposes a stable `json_schema()` for downstream
 tooling, and is ideal for CI gates and Git-pinned snapshots of an evaluation.
 
 ```python
-artifact = skdr_eval.evaluate_sklearn_models(logs=logs, models=models, fit_models=True)
+artifact = skdr_eval.evaluate_sklearn_models(
+    logs=logs, models=models, fit_models=True, policy_train="pre_split"
+)
 card = artifact.card_schema("RandomForest", estimator="DR")
 
 card.to_yaml("artifacts/rf.card.yaml")
@@ -479,7 +491,8 @@ from skdr_eval import FileTracker
 
 with FileTracker(root="runs/2026-05-20") as tracker:
     artifact = skdr_eval.evaluate_sklearn_models(
-        logs=logs, models=models, fit_models=True, tracker=tracker,
+        logs=logs, models=models, fit_models=True,
+        policy_train="pre_split", tracker=tracker,
     )
 # Writes:
 #   runs/2026-05-20/metrics.jsonl          (one row per logged metric)
@@ -614,7 +627,7 @@ If Trusted Publishing is not configured:
 ### Trusted Publishing Setup
 1. Go to https://pypi.org/manage/project/skdr-eval/settings/publishing/
 2. Add GitHub repository as trusted publisher:
-   - **Repository**: `dandrsantos/skdr-eval`
+   - **Repository**: `dgenio/skdr-eval`
    - **Workflow**: `release.yml`
    - **Environment**: `release`
 
@@ -628,7 +641,7 @@ If you use this software in your research, please cite:
   author  = {Santos, Diogo},
   year    = {2026},
   url     = {https://github.com/dgenio/skdr-eval},
-  version = {0.7.0},
+  version = {0.9.0},
   license = {MIT}
 }
 ```

--- a/examples/preflight.py
+++ b/examples/preflight.py
@@ -3,7 +3,7 @@
 
 Run this before kicking off a longer evaluation to confirm:
 - the package imports cleanly,
-- optional extras (``[choice]``, ``[viz]``, ``[speed]``) are available
+- optional extras (``[viz]``, ``[speed]``) are available
   if your pipeline needs them,
 - your logs DataFrame matches the schema consumed by
   :func:`skdr_eval.evaluate_sklearn_models`,

--- a/src/skdr_eval/core.py
+++ b/src/skdr_eval/core.py
@@ -46,6 +46,7 @@ from .pairwise import PairwiseDesign, induce_policy
 from .validation import (
     validate_dataframe,
     validate_finite_values,
+    validate_models_dict,
     validate_numpy_array,
     validate_positive_integer,
     validate_probabilities,
@@ -304,18 +305,25 @@ class DRResult:
 
 
 def build_design(
-    logs: pd.DataFrame, cli_pref: str = "cli_", st_pref: str = "st_"
+    logs: pd.DataFrame,
+    cli_pref: str = "cli_",
+    st_pref: str = "st_",
+    y_col: str = "service_time",
 ) -> Design:
     """Build design matrices from logs.
 
     Parameters
     ----------
     logs : pd.DataFrame
-        Log data with columns: arrival_ts, cli_*, st_*, op_*_elig, action, service_time.
+        Log data with columns: arrival_ts, cli_*, st_*, op_*_elig, action, and
+        the reward column ``y_col`` (``service_time`` by default).
     cli_pref : str, default="cli_"
         Prefix for client features.
     st_pref : str, default="st_"
         Prefix for service-time features.
+    y_col : str, default="service_time"
+        Name of the reward/outcome column read into ``Design.Y``. Defaults to
+        ``"service_time"`` for backward compatibility.
 
     Returns
     -------
@@ -331,7 +339,7 @@ def build_design(
     """
     try:
         # Validate input DataFrame
-        required_columns = ["arrival_ts", "action", "service_time"]
+        required_columns = ["arrival_ts", "action", y_col]
         validate_dataframe(logs, "logs", required_columns, min_rows=10)
 
         # Validate prefixes
@@ -396,7 +404,7 @@ def build_design(
         validate_finite_values(X_phi, "X_phi")
 
         # Outcomes and timestamps
-        Y: np.ndarray = logs["service_time"].values.astype(np.float64)
+        Y: np.ndarray = logs[y_col].values.astype(np.float64)
         ts: np.ndarray = logs["arrival_ts"].values.astype(np.float64)
 
         validate_numpy_array(Y, "Y", min_size=1)
@@ -1524,6 +1532,7 @@ def evaluate_sklearn_models(
     policy_train_frac: float = 0.85,
     support_thresholds: "SupportHealthThresholds | None" = None,
     *,
+    y_col: str = "service_time",
     gap: int = 1,
     test_size: int | None = None,
     max_train_size: int | None = None,
@@ -1579,6 +1588,11 @@ def evaluate_sklearn_models(
     support_thresholds : SupportHealthThresholds, optional
         Thresholds for support-health warnings attached to the returned
         artifact. See :class:`skdr_eval.reporting.SupportHealthThresholds`.
+    y_col : str, default="service_time"
+        Name of the reward/outcome column in ``logs``. Defaults to
+        ``"service_time"`` for backward compatibility; set it for
+        general-purpose OPE logs whose reward is named e.g. ``"reward"``,
+        ``"click"``, or ``"revenue"``.
     keep_contributions : bool, default=False
         If True, attach per-decision DR/SNDR contributions to each
         :class:`DRResult` under ``contributions`` and make them queryable
@@ -1616,16 +1630,12 @@ def evaluate_sklearn_models(
 
     Raises
     ------
-    ValueError
-        If ``models`` is empty or contains ``None`` values.
     DataValidationError
-        If ``keep_contributions=True`` is set with more than
+        If ``models`` is not a non-empty dict of ``{name: estimator}``, or if
+        ``keep_contributions=True`` is set with more than
         ``max_kept_contributions`` evaluated decisions.
     """
-    if not models:
-        raise ValueError("models dict must not be empty")
-    if any(v is None for v in models.values()):
-        raise ValueError("models dict values must not be None")
+    validate_models_dict(models)
 
     # Resolve policy_train sentinel: None means "pre_split" + emit warning.
     if policy_train is None:
@@ -1646,7 +1656,7 @@ def evaluate_sklearn_models(
         )
 
     # Build design
-    design = build_design(logs)
+    design = build_design(logs, y_col=y_col)
 
     # Split data for policy training if needed
     if policy_train == "pre_split":
@@ -1694,29 +1704,44 @@ def evaluate_sklearn_models(
             f"disable keep_contributions.",
         )
 
-    # Fit propensity model
-    propensities, _ = fit_propensity_timecal(
-        eval_design.X_phi,
-        eval_design.A,
-        eval_design.ts,
-        n_splits=n_splits,
-        random_state=random_state,
-        gap=gap,
-        test_size=test_size,
-        max_train_size=max_train_size,
-    )
+    # Fit propensity + outcome models on the evaluation slice. When
+    # policy_train="pre_split", the slice is only (1 - policy_train_frac) of
+    # the input, so a too-small-data failure reports the post-split count and
+    # confuses users who passed more rows (#114). Enrich the error with the
+    # pre_split context while leaving the policy_train="all" message untouched.
+    try:
+        propensities, _ = fit_propensity_timecal(
+            eval_design.X_phi,
+            eval_design.A,
+            eval_design.ts,
+            n_splits=n_splits,
+            random_state=random_state,
+            gap=gap,
+            test_size=test_size,
+            max_train_size=max_train_size,
+        )
 
-    # Fit outcome model
-    q_hat, _ = fit_outcome_crossfit(
-        eval_design.X_obs,
-        eval_design.Y,
-        n_splits=n_splits,
-        estimator=outcome_estimator,
-        random_state=random_state,
-        gap=gap,
-        test_size=test_size,
-        max_train_size=max_train_size,
-    )
+        # Fit outcome model
+        q_hat, _ = fit_outcome_crossfit(
+            eval_design.X_obs,
+            eval_design.Y,
+            n_splits=n_splits,
+            estimator=outcome_estimator,
+            random_state=random_state,
+            gap=gap,
+            test_size=test_size,
+            max_train_size=max_train_size,
+        )
+    except InsufficientDataError as exc:
+        if policy_train == "pre_split":
+            raise InsufficientDataError(
+                f"{exc} -- after policy_train='pre_split' reserved "
+                f"{policy_train_frac:.0%} of your {len(logs)} input rows for "
+                f"policy training, only {len(eval_design.Y)} evaluation rows "
+                "remain. Lower policy_train_frac, pass policy_train='all', or "
+                "provide more data."
+            ) from exc
+        raise
 
     # Evaluate each model
     report_rows = []
@@ -2436,13 +2461,15 @@ def evaluate_pairwise_models(
     Raises
     ------
     DataValidationError
-        If ``keep_contributions=True`` is set with more than
+        If ``models`` is not a non-empty dict of ``{name: estimator}``, or if
+        ``keep_contributions=True`` is set with more than
         ``max_kept_contributions`` evaluated decisions.
     """
 
     logger.info("Starting pairwise evaluation")
 
     # Validate parameters
+    validate_models_dict(models)
     if task_type not in ["regression", "binary"]:
         raise ValueError(
             f"Unknown task_type: {task_type}. Must be 'regression' or 'binary'"

--- a/src/skdr_eval/reporting.py
+++ b/src/skdr_eval/reporting.py
@@ -34,7 +34,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pandas as pd
@@ -774,11 +774,22 @@ class EvaluationArtifact:
         """Serialize the artifact to a JSON string via the Pydantic schema."""
         return str(self.to_schema().model_dump_json(indent=indent))
 
-    def to_json(self, path: str | Path, *, indent: int | None = 2) -> Path:
-        """Write the artifact JSON to ``path``. Creates parent dirs as needed."""
+    def to_json(
+        self, path: str | Path | None = None, *, indent: int | None = 2
+    ) -> str | Path:
+        """Serialize the artifact to JSON.
+
+        Follows the pandas-style convention: with ``path=None`` (the default)
+        the JSON **string** is returned; with a ``path`` the JSON is written
+        there (parent dirs created) and the written :class:`~pathlib.Path` is
+        returned.
+        """
+        text = self.to_json_str(indent=indent)
+        if path is None:
+            return text
         p = Path(path)
         p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(self.to_json_str(indent=indent), encoding="utf-8")
+        p.write_text(text, encoding="utf-8")
         logger.info("Wrote evaluation artifact JSON to %s", p)
         return p
 
@@ -822,11 +833,20 @@ class EvaluationArtifact:
             )
         )
 
-    def to_html(self, path: str | Path) -> Path:
-        """Write the artifact HTML to ``path``. Creates parent dirs as needed."""
+    def to_html(self, path: str | Path | None = None) -> str | Path:
+        """Render the artifact as HTML.
+
+        Follows the pandas-style convention: with ``path=None`` (the default)
+        the HTML **string** is returned; with a ``path`` the HTML is written
+        there (parent dirs created) and the written :class:`~pathlib.Path` is
+        returned.
+        """
+        html = self.to_html_str()
+        if path is None:
+            return html
         p = Path(path)
         p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(self.to_html_str(), encoding="utf-8")
+        p.write_text(html, encoding="utf-8")
         logger.info("Wrote evaluation artifact HTML to %s", p)
         return p
 
@@ -1264,9 +1284,11 @@ class EvaluationArtifact:
             else:
                 target = p.with_suffix(f".{fmt}")
             if fmt == "json":
-                written["json"] = self.to_json(target)
+                # ``target`` is always a concrete path here, so to_json returns
+                # the written Path (never the str branch).
+                written["json"] = cast("Path", self.to_json(target))
             elif fmt == "html":
-                written["html"] = self.to_html(target)
+                written["html"] = cast("Path", self.to_html(target))
         return written
 
 

--- a/src/skdr_eval/synth.py
+++ b/src/skdr_eval/synth.py
@@ -201,9 +201,9 @@ def make_pairwise_synth(
     --------
     >>> logs_df, op_daily_df = make_pairwise_synth(n_days=3, n_clients_day=100, n_ops=10)
     >>> print(logs_df.shape)
-    (300, 12)  # 3 days * 100 clients, ~12 columns
+    (300, 14)  # 3 days * 100 clients, 14 columns
     >>> print(op_daily_df.shape)
-    (30, 5)    # 3 days * 10 ops, ~5 columns
+    (30, 6)    # 3 days * 10 ops, 6 columns
     """
     rng = np.random.RandomState(seed)
 

--- a/src/skdr_eval/validation.py
+++ b/src/skdr_eval/validation.py
@@ -162,6 +162,58 @@ def validate_sklearn_estimator(
             )
 
 
+def validate_models_dict(models: Any, name: str = "models") -> None:
+    """Validate the ``{name: estimator}`` contract shared by the evaluators.
+
+    Both :func:`skdr_eval.evaluate_sklearn_models` and
+    :func:`skdr_eval.evaluate_pairwise_models` accept a ``models`` mapping.
+    Passing a bare estimator (the most common first-use mistake) otherwise
+    fails much later with an opaque ``AttributeError`` deep in the fit loop;
+    this surfaces an actionable error at the entry point instead.
+
+    Parameters
+    ----------
+    models : Any
+        The value passed as ``models``; expected to be a ``dict`` of
+        ``{name: estimator}``.
+    name : str, default="models"
+        Parameter name for error messages.
+
+    Raises
+    ------
+    DataValidationError
+        If ``models`` is not a non-empty dict of string keys mapping to
+        estimators (objects exposing a ``fit`` method).
+    """
+    if not isinstance(models, dict):
+        type_name = type(models).__name__
+        suggestion = ""
+        if hasattr(models, "fit"):
+            # Looks like a single estimator handed in directly.
+            suggestion = f'; did you mean {name}={{"model": {type_name}(...)}}?'
+        raise DataValidationError(
+            f"{name} must be a dict of {{name: estimator}}, got {type_name}{suggestion}"
+        )
+    if not models:
+        raise DataValidationError(
+            f"{name} dict is empty; provide at least one {{name: estimator}} entry"
+        )
+    bad_keys = [k for k in models if not isinstance(k, str)]
+    if bad_keys:
+        raise DataValidationError(
+            f"{name} keys must be strings (model names); got non-string keys: "
+            f"{bad_keys!r}"
+        )
+    bad_values = sorted(
+        k for k, v in models.items() if v is None or not hasattr(v, "fit")
+    )
+    if bad_values:
+        raise DataValidationError(
+            f"{name} values must be estimators with a 'fit' method; offending "
+            f"keys: {bad_values}"
+        )
+
+
 def validate_probabilities(
     probs: np.ndarray,
     name: str,
@@ -401,6 +453,7 @@ def validate_logs(
     *,
     cli_pref: str = "cli_",
     st_pref: str = "st_",
+    y_col: str = "service_time",
     strict: bool = False,
 ) -> None:
     """Validate a single-action logs DataFrame for ``evaluate_sklearn_models``.
@@ -408,7 +461,8 @@ def validate_logs(
     Performs a fast, surface-level check that ``logs`` carries the canonical
     schema consumed by :func:`skdr_eval.build_design`:
 
-    - required columns ``arrival_ts``, ``action``, ``service_time``;
+    - required columns ``arrival_ts``, ``action``, and the reward column
+      ``y_col`` (``"service_time"`` by default);
     - at least one eligibility column matching ``*_elig``;
     - at least one feature column matching ``cli_pref`` or ``st_pref``;
     - every ``action`` value is present as an ``*_elig`` operator;
@@ -422,6 +476,10 @@ def validate_logs(
         Prefix for client feature columns.
     st_pref : str, default="st_"
         Prefix for service-time feature columns.
+    y_col : str, default="service_time"
+        Name of the reward/outcome column. Defaults to ``"service_time"`` for
+        backward compatibility; pass your own column name for general-purpose
+        OPE logs whose reward is named e.g. ``"reward"`` or ``"click"``.
     strict : bool, default=False
         When True, additionally require:
 
@@ -443,7 +501,7 @@ def validate_logs(
     validate_dataframe(
         logs,
         "logs",
-        required_columns=["arrival_ts", "action", "service_time"],
+        required_columns=["arrival_ts", "action", y_col],
         min_rows=1,
     )
 
@@ -464,9 +522,23 @@ def validate_logs(
     ops_all = [c.removesuffix("_elig") for c in elig_cols]
     invalid_actions = set(logs["action"]) - set(ops_all)
     if invalid_actions:
+        # Common newcomer mistake: actions encoded as ints (0, 1, 2) while the
+        # '*_elig' column names parse as str ('0', '1', '2'). The two lists
+        # then look identical in the message, so surface the dtype gap when a
+        # str-cast of the actions would have matched. Genuinely-unrelated
+        # values (action 'op_X', elig 'op_A'/'op_B') leave the message intact.
+        hint = ""
+        if set(logs["action"].astype(str)) <= set(ops_all):
+            hint = (
+                f" -- logs.action dtype is {logs['action'].dtype} but the "
+                "'*_elig' column names parse as str; cast the actions with "
+                "logs['action'] = logs['action'].astype(str), or rename the "
+                "eligibility columns to match the action values"
+            )
         raise DataValidationError(
             f"logs.action contains values not present as '*_elig' columns: "
             f"{sorted(invalid_actions)} (eligible operators: {sorted(ops_all)})"
+            f"{hint}"
         )
 
     elig_values = logs[elig_cols].to_numpy()
@@ -498,8 +570,8 @@ def validate_logs(
     feature_values = logs[feature_cols].to_numpy(dtype=float, copy=False)
     validate_finite_values(feature_values, "logs[feature_cols]")
 
-    service_time = logs["service_time"].to_numpy(dtype=float, copy=False)
-    validate_finite_values(service_time, "logs.service_time")
+    reward = logs[y_col].to_numpy(dtype=float, copy=False)
+    validate_finite_values(reward, f"logs.{y_col}")
 
     # arrival_ts must be numeric or datetime64 -- build_design uses
     # ``.values.astype(float)`` which silently treats datetime64 as ns-since-

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,11 @@ import pytest
 from sklearn.ensemble import RandomForestRegressor
 
 import skdr_eval
-from skdr_eval.exceptions import PolicyInductionError
+from skdr_eval.exceptions import (
+    DataValidationError,
+    InsufficientDataError,
+    PolicyInductionError,
+)
 
 
 def test_imports():
@@ -54,6 +58,15 @@ def test_make_synth_logs_signature():
     # Check eligibility columns
     elig_cols = [col for col in logs.columns if col.endswith("_elig")]
     assert len(elig_cols) == 3
+
+
+def test_make_pairwise_synth_docstring_shapes():
+    """#113: make_pairwise_synth output matches the shapes quoted in its docstring."""
+    logs_df, op_daily_df = skdr_eval.make_pairwise_synth(
+        n_days=3, n_clients_day=100, n_ops=10
+    )
+    assert logs_df.shape == (300, 14)
+    assert op_daily_df.shape == (30, 6)
 
 
 def test_build_design_signature():
@@ -204,10 +217,10 @@ def test_evaluate_sklearn_models_signature():
 
 
 def test_evaluate_sklearn_models_empty_models_raises():
-    """Test that evaluate_sklearn_models raises ValueError for an empty models dict."""
+    """#109: an empty models dict raises a clear DataValidationError."""
     logs, _, _ = skdr_eval.make_synth_logs(n=10, n_ops=3, seed=4)
 
-    with pytest.raises(ValueError, match="models dict must not be empty"):
+    with pytest.raises(DataValidationError, match="models dict is empty"):
         skdr_eval.evaluate_sklearn_models(
             logs=logs,
             models={},
@@ -216,7 +229,7 @@ def test_evaluate_sklearn_models_empty_models_raises():
             random_state=42,
         )
 
-    with pytest.raises(ValueError, match="models dict values must not be None"):
+    with pytest.raises(DataValidationError, match="must be estimators"):
         skdr_eval.evaluate_sklearn_models(
             logs=logs,
             models={"rf": None},
@@ -224,6 +237,116 @@ def test_evaluate_sklearn_models_empty_models_raises():
             n_splits=2,
             random_state=42,
         )
+
+
+def test_evaluate_sklearn_models_single_estimator_hint():
+    """#109: passing a bare estimator (not a dict) raises with a did-you-mean hint."""
+    logs, _, _ = skdr_eval.make_synth_logs(n=200, n_ops=3, seed=42)
+
+    with pytest.raises(DataValidationError, match="did you mean"):
+        skdr_eval.evaluate_sklearn_models(
+            logs=logs,
+            models=RandomForestRegressor(random_state=42),  # bug: should be a dict
+            fit_models=True,
+            n_splits=3,
+            policy_train="pre_split",
+        )
+
+
+def test_evaluate_sklearn_models_non_estimator_value_raises():
+    """#109: a dict value lacking a fit method raises a clear type error."""
+    logs, _, _ = skdr_eval.make_synth_logs(n=200, n_ops=3, seed=42)
+
+    with pytest.raises(DataValidationError, match="must be estimators with a 'fit'"):
+        skdr_eval.evaluate_sklearn_models(
+            logs=logs,
+            models={"x": 42},
+            fit_models=True,
+            n_splits=3,
+            policy_train="pre_split",
+        )
+
+
+def test_evaluate_sklearn_models_y_col_matches_default(recwarn):
+    """#105: a custom y_col reproduces the default service_time path numerically."""
+    logs, _, _ = skdr_eval.make_synth_logs(n=400, n_ops=3, seed=42)
+    logs_renamed = logs.rename(columns={"service_time": "reward"})
+
+    art_default = skdr_eval.evaluate_sklearn_models(
+        logs=logs,
+        models={"rf": RandomForestRegressor(random_state=0)},
+        fit_models=True,
+        n_splits=3,
+        random_state=0,
+        policy_train="pre_split",
+    )
+    art_custom = skdr_eval.evaluate_sklearn_models(
+        logs=logs_renamed,
+        models={"rf": RandomForestRegressor(random_state=0)},
+        fit_models=True,
+        n_splits=3,
+        random_state=0,
+        policy_train="pre_split",
+        y_col="reward",
+    )
+
+    np.testing.assert_allclose(
+        art_custom.report["V_hat"].to_numpy(),
+        art_default.report["V_hat"].to_numpy(),
+    )
+
+
+def test_evaluate_sklearn_models_y_col_missing_column_errors():
+    """#105: requesting a y_col that is absent surfaces the missing-column error."""
+    logs, _, _ = skdr_eval.make_synth_logs(n=200, n_ops=3, seed=42)
+
+    with pytest.raises(DataValidationError, match="missing required columns"):
+        skdr_eval.evaluate_sklearn_models(
+            logs=logs,
+            models={"rf": RandomForestRegressor(random_state=0)},
+            fit_models=True,
+            n_splits=3,
+            policy_train="pre_split",
+            y_col="reward",  # not present (column is 'service_time')
+        )
+
+
+def test_pre_split_small_input_error_mentions_context():
+    """#114: a too-small pre_split input names the input count and policy_train_frac."""
+    logs, _, _ = skdr_eval.make_synth_logs(n=20, n_ops=3, seed=42)
+
+    with pytest.raises(InsufficientDataError) as excinfo:
+        skdr_eval.evaluate_sklearn_models(
+            logs=logs,
+            models={"rf": RandomForestRegressor(random_state=0)},
+            n_splits=3,
+            policy_train="pre_split",
+            policy_train_frac=0.85,
+            fit_models=True,
+        )
+    message = str(excinfo.value)
+    assert "pre_split" in message
+    assert "20 input rows" in message
+    assert "85%" in message
+
+
+def test_all_policy_train_small_input_error_unchanged():
+    """#114: with policy_train='all' the original split message is left intact."""
+    # n=10 clears build_design's min_rows=10 floor; n_splits=8 makes the
+    # time-series split (not build_design) the binding constraint.
+    logs, _, _ = skdr_eval.make_synth_logs(n=10, n_ops=3, seed=42)
+
+    with pytest.raises(InsufficientDataError) as excinfo:
+        skdr_eval.evaluate_sklearn_models(
+            logs=logs,
+            models={"rf": RandomForestRegressor(random_state=0)},
+            n_splits=8,
+            policy_train="all",
+            fit_models=True,
+        )
+    message = str(excinfo.value)
+    assert "Need at least" in message
+    assert "pre_split" not in message
 
 
 def test_induce_policy_from_sklearn_vectorized_matches_scalar_reference():

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,9 +1,36 @@
 """Tests for skdr_eval.capabilities."""
 
 import importlib
+import re
+import tomllib
+from pathlib import Path
 
 import skdr_eval
 from skdr_eval import capabilities as cap_module
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_documented_extras_are_declared_in_pyproject():
+    """#107: every 'pip install skdr-eval[<extra>]' in the README is a real extra.
+
+    Guards against doc/packaging drift such as the removed ``[choice]`` extra,
+    where the README advertised an install target that pip could not satisfy.
+    """
+    readme = (_REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    pyproject = tomllib.loads(
+        (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    declared = set(pyproject["project"]["optional-dependencies"])
+
+    documented = set(re.findall(r"(?:skdr-eval|\.)\[([a-z0-9_-]+)\]", readme))
+    assert documented, "expected at least one documented extra in the README"
+
+    undeclared = documented - declared
+    assert not undeclared, (
+        f"README documents pip extras that are not declared in pyproject.toml: "
+        f"{sorted(undeclared)} (declared: {sorted(declared)})"
+    )
 
 
 def test_get_capabilities_schema():

--- a/tests/test_public_validators.py
+++ b/tests/test_public_validators.py
@@ -40,6 +40,45 @@ def test_validate_logs_action_not_in_elig_columns():
         skdr_eval.validate_logs(logs)
 
 
+def test_validate_logs_int_action_vs_str_elig_hints_dtype():
+    """#115: int actions with str elig column names surface a dtype-cast hint."""
+    logs, _ops, _ = skdr_eval.make_synth_logs(n=100, n_ops=3, seed=42)
+    logs = logs.copy()
+    elig_cols = [c for c in logs.columns if c.endswith("_elig")]
+    ops = [c.removesuffix("_elig") for c in elig_cols]
+    mapping = {op: i for i, op in enumerate(ops)}
+    logs["action"] = logs["action"].map(mapping)
+    logs = logs.rename(
+        columns={c: f"{mapping[c.removesuffix('_elig')]}_elig" for c in elig_cols}
+    )
+
+    with pytest.raises(DataValidationError, match="dtype is") as excinfo:
+        skdr_eval.validate_logs(logs)
+    assert "astype(str)" in str(excinfo.value)
+
+
+def test_validate_logs_unrelated_action_message_has_no_dtype_hint():
+    """#115: genuinely-unrelated string actions keep the original message (no hint)."""
+    logs, _ops, _ = skdr_eval.make_synth_logs(n=50, n_ops=2, seed=4)
+    logs = logs.copy()
+    logs.loc[logs.index[0], "action"] = "op_ghost"
+    with pytest.raises(DataValidationError) as excinfo:
+        skdr_eval.validate_logs(logs)
+    assert "dtype is" not in str(excinfo.value)
+
+
+def test_validate_logs_custom_y_col():
+    """#105: validate_logs accepts a non-default reward column via y_col."""
+    logs, _ops, _ = skdr_eval.make_synth_logs(n=200, n_ops=3, seed=0)
+    renamed = logs.rename(columns={"service_time": "reward"})
+
+    # Default y_col now fails because 'service_time' is gone...
+    with pytest.raises(DataValidationError, match="missing required columns"):
+        skdr_eval.validate_logs(renamed)
+    # ...but passing the actual column name validates cleanly.
+    skdr_eval.validate_logs(renamed, y_col="reward")
+
+
 def test_validate_logs_no_feature_columns():
     logs, _ops, _ = skdr_eval.make_synth_logs(n=50, n_ops=2, seed=5)
     feature_cols = [

--- a/tests/test_public_validators.py
+++ b/tests/test_public_validators.py
@@ -3,9 +3,11 @@
 import numpy as np
 import pandas as pd
 import pytest
+from sklearn.linear_model import LinearRegression
 
 import skdr_eval
 from skdr_eval.exceptions import DataValidationError, InsufficientDataError
+from skdr_eval.validation import validate_models_dict
 
 
 def test_validate_logs_accepts_synth_output():
@@ -65,6 +67,26 @@ def test_validate_logs_unrelated_action_message_has_no_dtype_hint():
     with pytest.raises(DataValidationError) as excinfo:
         skdr_eval.validate_logs(logs)
     assert "dtype is" not in str(excinfo.value)
+
+
+def test_validate_models_dict_accepts_valid_mapping():
+    """#109: a well-formed {name: estimator} dict passes silently."""
+    validate_models_dict({"lr": LinearRegression()})
+
+
+def test_validate_models_dict_non_dict_non_estimator_has_no_hint():
+    """#109: a non-dict value without a fit method errors without a did-you-mean hint."""
+    with pytest.raises(DataValidationError) as excinfo:
+        validate_models_dict([1, 2, 3])
+    message = str(excinfo.value)
+    assert "must be a dict" in message
+    assert "did you mean" not in message
+
+
+def test_validate_models_dict_non_string_keys():
+    """#109: non-string keys raise a clear error."""
+    with pytest.raises(DataValidationError, match="keys must be strings"):
+        validate_models_dict({0: LinearRegression()})
 
 
 def test_validate_logs_custom_y_col():

--- a/tests/test_reporting_artifact.py
+++ b/tests/test_reporting_artifact.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 import math
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -37,9 +37,6 @@ from skdr_eval.reporting import (
     render_evaluation_card,
     summarize_sensitivity,
 )
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 # --------------------------------------------------------------------------- #
 # Helpers                                                                     #
@@ -466,6 +463,7 @@ def test_to_json_includes_diagnostics(tmp_path: Path):
 def test_to_html_contains_key_sections(tmp_path: Path):
     art = _run_eval()
     p = art.to_html(tmp_path / "art.html")
+    assert isinstance(p, Path)
     src = p.read_text()
     assert "<title>skdr-eval evaluation report</title>" in src
     assert "Headline results" in src
@@ -476,6 +474,34 @@ def test_to_html_contains_key_sections(tmp_path: Path):
     assert "HGB" in src
     # Schema version is rendered.
     assert SCHEMA_VERSION in src
+
+
+def test_to_json_no_arg_returns_string(tmp_path: Path):
+    """#108: to_json() with no path returns the JSON string; to_json(path) writes."""
+    art = _run_eval()
+
+    text = art.to_json()
+    assert isinstance(text, str)
+    payload = json.loads(text)
+    assert payload["schema_version"] == SCHEMA_VERSION
+
+    # The string return must match what gets written to disk.
+    written = art.to_json(tmp_path / "art.json")
+    assert isinstance(written, Path)
+    assert written.read_text() == text
+
+
+def test_to_html_no_arg_returns_string(tmp_path: Path):
+    """#108: to_html() with no path returns the HTML string; to_html(path) writes."""
+    art = _run_eval()
+
+    html = art.to_html()
+    assert isinstance(html, str)
+    assert "<title>skdr-eval evaluation report</title>" in html
+
+    written = art.to_html(tmp_path / "art.html")
+    assert isinstance(written, Path)
+    assert written.read_text() == html
 
 
 def test_export_writes_both_formats(tmp_path: Path):


### PR DESCRIPTION
# Pull Request

## 📋 Description

A single coherent pass over the **first-run correctness & documentation-drift** issues opened on 2026-05-21. Each fix addresses a place where *documented behavior did not match the code*, plus the small public-API contract gaps those mismatches exposed. The changes are individually tiny and share one implementation path (README/CONTRIBUTING/pyproject + a handful of validation/serialization tweaks), so they are cleaner to review and ship together than as 11 separate PRs.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (see **API Changes** — return-type and exception-type adjustments; intentional, no back-compat shims per maintainer direction)
- [x] 📚 Documentation update
- [ ] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test improvements
- [ ] 🔧 Build/CI improvements

## 🔗 Related Issues

- Fixes #104
- Fixes #105
- Fixes #107
- Fixes #108
- Fixes #109
- Fixes #110
- Fixes #111
- Fixes #112
- Fixes #113
- Fixes #114
- Fixes #115

## 🧪 Testing

### Test Coverage
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added integration tests if applicable — N/A (unit-level fixes)

### Manual Testing
- [x] Tested locally (`ruff`, `mypy`, full `pytest` with coverage)
- [x] Reproduced every bug before the fix and confirmed the fix resolves it
- [x] Tested edge cases (custom `y_col`, empty/non-dict `models`, `policy_train="all"` path left unchanged, unrelated-string actions keep original message)

**Test commands run:**
```bash
ruff check src/ tests/ examples/      # All checks passed!
ruff format --check src/ tests/ examples/   # 80 files already formatted
mypy src/skdr_eval/                   # Success: no issues found in 32 source files
pytest -q                             # 700 passed, 3 skipped — TOTAL coverage 93%
```

## 📝 Changes Made

### Code Changes
- **#105** `evaluate_sklearn_models` / `build_design` / `validate_logs` accept `y_col` (default `"service_time"`) so general-purpose OPE logs can name the reward column anything (`reward`, `click`, `revenue`).
- **#109** New `validate_models_dict()` in `validation.py`, called by both entry points: raises an actionable `DataValidationError` (with a *"did you mean `models={...}`?"* hint) for a bare estimator, empty dict, non-string keys, or non-estimator values — instead of a deep `AttributeError`.
- **#108** `EvaluationArtifact.to_json()` / `.to_html()` now return the serialized **string** when called with no argument and write the file (returning its `Path`) when given a `path` (matching the existing `EvaluationCard.to_json` idiom).
- **#114** With `policy_train="pre_split"`, the `InsufficientDataError` now reports the original input row count and `policy_train_frac` (was the opaque post-split count). The `policy_train="all"` message is left byte-for-byte unchanged.
- **#115** `validate_logs` adds a dtype-cast hint when `action` is int but `*_elig` column names parse as str; genuinely-unrelated string actions keep the original message.
- **#113** `make_pairwise_synth` docstring shapes corrected to `(300, 14)` / `(30, 6)`.

### Documentation
- **#104** README quickstarts (and the other runnable snippets) pass `policy_train="pre_split"` + a one-line explanation, so a copy-pasted example runs without a `DeprecationWarning`.
- **#107** Removed the undefined `[choice]` extra from README + `examples/preflight.py`; conditional logit is built-in (SciPy is a core dependency).
- **#110** README Trusted-Publishing owner → `dgenio/skdr-eval`.
- **#111** README BibTeX `version` → `0.9.0` (matches `CITATION.cff`).
- **#112** `CONTRIBUTING.md` / `DEVELOPMENT.md` → Python 3.11+ (matches `requires-python`).

### API Changes
- [ ] No API changes
- [x] Backward compatible API additions (`y_col` keyword; both default to prior behavior)
- [x] Breaking API changes (intentional; no compatibility shims per maintainer direction):
  - `to_json()` / `to_html()` with **no argument** now return a `str` (previously raised `TypeError`); calling with a `path` is unchanged (writes + returns `Path`).
  - Empty / `None`-valued `models` now raise `DataValidationError` (was `ValueError`). Existing `test_api.py` assertions were updated accordingly.

## 📚 Documentation
- [x] I have updated the documentation accordingly
- [x] I have updated docstrings for new/modified functions
- [x] I have added examples if applicable (README `y_col` usage, calling conventions)
- [x] I have updated the CHANGELOG.md

## ✅ Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `ruff check` and `ruff format`
- [x] I have run `mypy` type checking

### Testing & CI
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally (700 passed, 3 skipped)
- [ ] All CI checks pass — pending CI on this PR
- [x] Code coverage is maintained or improved (93% total, gate is 80%)

### Documentation & Communication
- [x] I have made corresponding changes to the documentation
- [x] My commit messages follow the conventional commit format
- [x] I have updated the CHANGELOG.md

## 🔍 Review Notes

### Focus Areas
- **#108 return type** is now `str | Path`. `export()` (which always writes a path) casts to `Path`; all internal callers (`cli.py`, tests) pass a path and are unaffected. The issue text suggested a *keyword-only* `path`, but that would break the positional callers — I followed the repo's own `EvaluationCard.to_json(path=None)` idiom instead (documented in the commit).
- **#114** is scoped to `evaluate_sklearn_models` (the path the issue reproduces). The pairwise entry point computes its eval slice differently; enriching it similarly is a sensible follow-up but out of scope here.

### Questions for Reviewers
- **#107**: I removed the `[choice]` docs (SciPy is core, so no extra is needed). If you'd rather *define* a `[choice]` extra instead, say so and I'll switch.

---

**Additional Context:** This group was selected by an issue-triage pass as the most coherent single-PR cluster; six already-implemented issues (#69/#86/#89/#90/#91/#93) were closed separately during that triage.

---
_Generated by [Claude Code](https://claude.ai/code/session_015d9gz1gB62tcVt5TEDoF4Z)_