### PR TITLE
feat: offline-evaluation companion for agent/LLM policies (#149, #150, #148, #145)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,7 @@ jobs:
         python examples/use_cases/03_healthcare_cate.py
         python examples/use_cases/04_call_routing.py
         python examples/use_cases/05_logs_to_experiment_card.py
+        python examples/use_cases/06_agent_routing_policy.py
 
   docs:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deterministic.
 
 ### Added
+- **Generic trace → OPE-log adapter** ([#149]). New `skdr_eval.adapters`
+  package with `from_records` and `from_jsonl_trace`: map generic
+  `(context, action, reward[, timestamp, propensity])` decision records —
+  including JSONL agent traces — into the canonical logs schema consumed by
+  `evaluate_sklearn_models`, no hand-shaping required. Mapping context (a dict
+  of named numeric features or a flat sequence) becomes `cli_*` columns; the
+  chosen action and optional per-row `eligible_actions` define the `*_elig`
+  universe; missing timestamps synthesize a monotonic order. Logged
+  propensities are flagged via `TraceAdapterResult.had_logged_propensities`
+  (skdr-eval estimates calibrated propensities internally). Output passes
+  `validate_logs` / `doctor`.
+- **Agent routing / tool-selection example** ([#150]).
+  `examples/use_cases/06_agent_routing_policy.py` evaluates a candidate agent
+  routing policy from logged traces via the adapter, showing both a healthy
+  (`support_health=ok`) and an unhealthy (`high_risk`) regime. Wired into the
+  CI use-cases smoke job.
+- **Offline-evaluation companion guide** ([#148]). `docs/weaver-stack.md`
+  positions skdr-eval as a standalone-first, MIT companion (not core) to agent
+  stacks, with the trace-adapter seam and reciprocal cross-links.
+- **Flagship LLM-reranker OPE recipe page** ([#145]).
+  `docs/recipes/llm-reranker-ope.md` plus a Colab badge and an explicit
+  deploy/don't-deploy verdict in `examples/notebooks/10_llm_reranker_ope.ipynb`,
+  framed for the LLM/agents audience; a README "Evaluate LLM / agent policies
+  offline" section links both.
 - **Honest bootstrap SE for the LLM-reranker recipe** ([#142]).
   `evaluate_reranker_mips` gained an opt-in `n_bootstrap` (default `0`): when
   set it reports a full-pipeline bootstrap SE that refits `q̂` on each resample,
@@ -117,6 +141,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     dependency; CPU-only.
 
 ### Changed
+- **`doctor(kind="standard")` honours `metric_col` in the schema check**
+  ([#149]). The standard preflight previously validated the logs schema with
+  the hard-coded `service_time` reward column, so general-purpose OPE logs with
+  a differently-named reward (e.g. `reward`, `cost`) falsely failed. The
+  standard schema check now passes `metric_col` through to
+  `validate_logs(y_col=...)`, and the finite-outcomes check includes
+  `metric_col`. No change for the default `service_time` reward.
 - **MIPS no-embedding behaviour is now a graceful SNDR fallback** ([#136],
   [#85]). Requesting `"MIPS"` without `action_embedding=` previously raised
   `ValueError`; it now **falls back to SNDR with a `UserWarning`** (the `MIPS`
@@ -645,6 +676,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#124]: https://github.com/dgenio/skdr-eval/issues/124
 [#121]: https://github.com/dgenio/skdr-eval/issues/121
 [#125]: https://github.com/dgenio/skdr-eval/issues/125
+[#145]: https://github.com/dgenio/skdr-eval/issues/145
+[#148]: https://github.com/dgenio/skdr-eval/issues/148
+[#149]: https://github.com/dgenio/skdr-eval/issues/149
+[#150]: https://github.com/dgenio/skdr-eval/issues/150
 
 ## [0.6.0] - 2026-05-12
 

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ use-cases:
 	python examples/use_cases/03_healthcare_cate.py
 	python examples/use_cases/04_call_routing.py
 	python examples/use_cases/05_logs_to_experiment_card.py
+	python examples/use_cases/06_agent_routing_policy.py
 
 # Known-failure-mode tutorials (#134). These scripts intentionally
 # produce ``support_health=high_risk`` so a newcomer can see what a bad

--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ library actually gets used, and it does not require reading any theory first:
 - **Have logs already?** Skim [Quick Start](#quick-start) below; the standard / pairwise variants are both two screens long. The full workflow is the [logs → experiment-review card recipe](docs/recipes/logs-to-experiment-card.md).
 - **Not sure whether to trust an estimate?** Read the [report interpretation guide](docs/report-interpretation.md), the [metrics glossary](docs/metrics-glossary.md), and the [good-vs-bad support tutorial](docs/recipes/good-vs-bad-support.md).
 - **Comparing against another OPE library?** See [`docs/comparisons.md`](docs/comparisons.md) for OBP / SCOPE-RL / d3rlpy / banditml, and [`docs/methods.md`](docs/methods.md) for the methodological positioning.
-- **Looking for end-to-end examples by domain?** Browse [`examples/use_cases/`](examples/use_cases/) for runnable scripts (e-commerce ranking, ad targeting, healthcare CATE, call routing, logs→card).
+- **Looking for end-to-end examples by domain?** Browse [`examples/use_cases/`](examples/use_cases/) for runnable scripts (e-commerce ranking, ad targeting, healthcare CATE, call routing, logs→card, agent routing).
+- **Evaluating an LLM reranker or an agent routing/tool-selection policy?** See [Evaluate LLM / agent policies offline](#evaluate-llm--agent-policies-offline) below.
 
 > The `skdr-eval` CLI (`pip install 'skdr-eval[cli]'`) makes the same
 > evaluators reachable from a terminal — see [Command-line interface](#command-line-interface).
@@ -597,6 +598,42 @@ with FileTracker(root="runs/2026-05-20") as tracker:
 #   runs/2026-05-20/cards/<model>_<estimator>.card.yaml
 ```
 
+## Evaluate LLM / agent policies offline
+
+You don't need a classic tabular logging pipeline to use `skdr-eval`. If you
+have **logged LLM-reranker or agent routing / tool-selection decisions**, you
+can estimate whether a *candidate* policy would do better — offline, CPU-only,
+before an A/B test.
+
+- **LLM reranker:** *"How do I know my new reranker is actually better, without
+  shipping it?"* The [LLM-reranker OPE recipe](docs/recipes/llm-reranker-ope.md)
+  ([notebook](examples/notebooks/10_llm_reranker_ope.ipynb) ·
+  [Colab](https://colab.research.google.com/github/dgenio/skdr-eval/blob/main/examples/notebooks/10_llm_reranker_ope.ipynb))
+  evaluates a candidate reranker with embedding-**MIPS** and recovers a known
+  ground-truth value within ±2 SE.
+- **Agent routing / tool selection:** map generic `(context, action, reward)`
+  traces with the trace adapter and evaluate a candidate routing policy:
+
+  ```python
+  import skdr_eval
+
+  adapted = skdr_eval.adapters.from_jsonl_trace("agent_traces.jsonl", reward_col="cost")
+  artifact = skdr_eval.evaluate_sklearn_models(
+      logs=adapted.logs, models={"candidate": my_cost_model}, y_col=adapted.reward_col,
+  )
+  print(artifact.report[["model", "estimator", "V_hat", "support_health"]])
+  ```
+
+  See [`examples/use_cases/06_agent_routing_policy.py`](examples/use_cases/06_agent_routing_policy.py)
+  (healthy vs. `high_risk` support) and the
+  [offline-evaluation companion guide](docs/weaver-stack.md).
+
+The trace adapter (`skdr_eval.adapters.from_records` / `from_jsonl_trace`) maps
+`(context, action, reward[, timestamp, propensity])` records — including JSONL
+agent traces — into a schema-valid logs frame, so you don't hand-shape a
+DataFrame. skdr-eval estimates calibrated propensities internally; a logged
+propensity in the trace is reported but not consumed.
+
 ## Examples
 
 `examples/` ships three kinds of runnable artifacts — pick the one that
@@ -787,6 +824,19 @@ If Trusted Publishing is not configured:
    - **Repository**: `dgenio/skdr-eval`
    - **Workflow**: `release.yml`
    - **Environment**: `release`
+
+## Ecosystem
+
+`skdr-eval` is **standalone-first and MIT-licensed**, with no runtime dependency
+on any other framework. It also serves as an optional **offline-evaluation
+companion** to agent stacks (e.g. the Weaver stack): those systems produce
+logged agent decisions, and `skdr-eval` answers *"would this candidate
+routing/tool-selection policy actually perform better, from these logs, before
+we ship it?"* — including the honest *"your logs don't support that question
+yet"* answer.
+
+See [`docs/weaver-stack.md`](docs/weaver-stack.md) for the companion guide,
+positioning boundary, and cross-links.
 
 ## Citation
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,6 +27,14 @@ exported from the top-level `skdr_eval` package.
 
 ::: skdr_eval.get_capabilities
 
+## Input adapters
+
+::: skdr_eval.adapters.from_records
+
+::: skdr_eval.adapters.from_jsonl_trace
+
+::: skdr_eval.adapters.TraceAdapterResult
+
 ## Synthetic data
 
 ::: skdr_eval.make_synth_logs

--- a/docs/recipes/llm-reranker-ope.md
+++ b/docs/recipes/llm-reranker-ope.md
@@ -1,0 +1,68 @@
+# Recipe: evaluate an LLM reranker offline
+
+**How do you know a new LLM reranker is actually better — without shipping it?**
+
+You run a production reranker that, for each query, picks one candidate from a
+pool and observes a reward (click / dwell / purchase). You have a *new* reranker
+and want to estimate its value **offline**, from logged decisions and
+pre-computed embeddings — **CPU-only, no runtime LLM dependency** — before you
+risk an A/B test.
+
+This is the single best on-ramp for the LLM/agents audience into trustworthy
+offline policy evaluation. It runs end-to-end in well under two minutes.
+
+> **Runnable notebook:**
+> [`examples/notebooks/10_llm_reranker_ope.ipynb`](https://github.com/dgenio/skdr-eval/blob/main/examples/notebooks/10_llm_reranker_ope.ipynb)
+> · [Open in Colab](https://colab.research.google.com/github/dgenio/skdr-eval/blob/main/examples/notebooks/10_llm_reranker_ope.ipynb)
+
+## Why MIPS
+
+The action space (the candidate pool) is large, so per-candidate overlap is
+hopeless. **MIPS** (Marginalized IPS) fixes this: the candidate *embeddings*
+carry the structure of the action space, so common support only needs to hold
+over the embedding, not the raw candidate id.
+
+## The shape of the workflow
+
+```python
+from skdr_eval.recipes import (
+    make_llm_reranker_synth,
+    induce_reranker_policy,
+    evaluate_reranker_mips,
+)
+
+# 1. Logs with a known ground-truth target value (for this recipe's proof).
+logs, candidate_embeddings, truth = make_llm_reranker_synth(
+    n_queries=2000, candidates_per_query=20, embed_dim=16, seed=7
+)
+
+# 2. The candidate (new) reranker, as a per-decision target-policy matrix.
+policy_probs = induce_reranker_policy(logs, candidate_embeddings)
+
+# 3. Evaluate offline with MIPS.
+result = evaluate_reranker_mips(logs, candidate_embeddings, policy_probs)
+print(result.V_hat, result.support_health)
+```
+
+## Read the verdict, not just the number
+
+On the synthetic dataset MIPS recovers the closed-form target value within
+±2 SE — that is the *ground-truth recovery* proof. On real logs you won't have a
+ground truth, so the deciding signal is the **trust verdict**:
+
+- check **ESS**, **Pareto-k**, and the **embedding-sufficiency** diagnostic;
+- `support_health == "ok"` → the offline estimate is usable decision evidence;
+- otherwise → the embeddings/logs don't yet support the comparison, and the
+  number is not deployment evidence.
+
+Offline evaluation is decision *support*, not a replacement for an online A/B
+test.
+
+## Generalizing to agent / tool-selection policies
+
+The same machinery evaluates an LLM **tool-selection / routing** policy: map
+your agent traces with the [trace adapter](../weaver-stack.md)
+(`skdr_eval.adapters.from_jsonl_trace`) and evaluate the candidate routing
+policy — see the
+[agent-routing example](https://github.com/dgenio/skdr-eval/blob/main/examples/use_cases/06_agent_routing_policy.py)
+and the [offline-evaluation companion guide](../weaver-stack.md).

--- a/docs/weaver-stack.md
+++ b/docs/weaver-stack.md
@@ -1,0 +1,78 @@
+# skdr-eval as an offline-evaluation companion
+
+`skdr-eval` is a **standalone, MIT-licensed** off-policy evaluation library for
+scikit-learn-compatible policies. It predates the Weaver agent stack, targets a
+different audience (ML/DS doing offline policy evaluation), and has **no runtime
+dependency on any Weaver repository**. It is a *companion*, not a member, of
+that stack.
+
+There is, however, one genuine and valuable seam between them.
+
+## The seam
+
+The Weaver stack produces **logged agent decisions** — routing and
+tool-selection traces of the form `(context, action, reward)`. `skdr-eval`
+answers a question those logs raise but the runtime cannot:
+
+> *"Would this candidate routing/tool-selection policy actually perform better,
+> from these logs, before we ship it?"*
+
+That is exactly offline policy evaluation: estimate a candidate policy's value
+from logged decisions, and — just as importantly — report **whether the logs
+even support the question** (`support_health`, ESS, Pareto-k) so you don't act
+on an estimate the data can't justify.
+
+`skdr-eval` is reached **when you want to evaluate a logged agent/decision
+policy offline**, not as part of the runtime request path.
+
+## How to use it from an agent stack
+
+1. **Map your traces.** Use the generic trace adapter to turn
+   `(context, action, reward[, timestamp, propensity])` records — including
+   JSONL agent traces — into a schema-valid logs frame:
+
+   ```python
+   import skdr_eval
+
+   adapted = skdr_eval.adapters.from_jsonl_trace("agent_traces.jsonl", reward_col="cost")
+   skdr_eval.validate_logs(adapted.logs, y_col=adapted.reward_col)
+   ```
+
+   See the trace-adapter entry in the [API reference](api.md) and the
+   end-to-end [agent-routing example](https://github.com/dgenio/skdr-eval/blob/main/examples/use_cases/06_agent_routing_policy.py).
+
+2. **Evaluate a candidate policy.** Feed the adapted logs to
+   `evaluate_sklearn_models` and read the trust verdict first:
+
+   ```python
+   artifact = skdr_eval.evaluate_sklearn_models(
+       logs=adapted.logs, models={"candidate": my_regressor}, y_col=adapted.reward_col,
+   )
+   print(artifact.report[["model", "estimator", "V_hat", "support_health"]])
+   ```
+
+3. **Act on the verdict, not just the number.** `support_health == "ok"` means
+   the logs support the comparison; `high_risk` means improve exploration /
+   logging before trusting the estimate.
+
+## Positioning boundary
+
+- **Standalone-first.** `skdr-eval` installs and runs with no Weaver package
+  present.
+- **License.** `skdr-eval` is MIT; it is intentionally *not* folded into the
+  Apache-2.0 Weaver core, to keep its standalone ML credibility intact.
+- **Companion, not core.** The relationship is reciprocal cross-linking, not a
+  code dependency in either direction.
+
+## Cross-links
+
+These live in sibling repositories; coordinate the back-links there:
+
+- agent-kernel — issue #96 (offline-evaluation hook).
+- ChainWeaver — `examples/skdr_policy_eval_flow.py`.
+- contextweaver — `eval_artifact_profile`.
+
+Related building blocks in this repo: the
+[logs → experiment-review card recipe](recipes/logs-to-experiment-card.md), the
+[LLM-reranker OPE recipe](recipes/llm-reranker-ope.md), and the trace adapter
+(`skdr_eval.adapters`).

--- a/examples/notebooks/10_llm_reranker_ope.ipynb
+++ b/examples/notebooks/10_llm_reranker_ope.ipynb
@@ -18,7 +18,11 @@
     "so common support only needs to hold over the *embedding*, not the raw\n",
     "candidate id.\n",
     "\n",
-    "This recipe runs end-to-end in well under two minutes on CPU."
+    "This recipe runs end-to-end in well under two minutes on CPU.\n",
+    "\n",
+    "👉 [Open in Colab](https://colab.research.google.com/github/dgenio/skdr-eval/blob/main/examples/notebooks/10_llm_reranker_ope.ipynb)\n",
+    "\n",
+    "*The fastest way for an LLM/agents practitioner to see trustworthy offline policy evaluation: estimate a new reranker's value from logged decisions and embeddings, CPU-only, and recover a known ground-truth value.*"
    ]
   },
   {
@@ -191,7 +195,9 @@
     "- MIPS recovered the closed-form target value within ±2 SE.\n",
     "- Offline evaluation is decision support, **not** a replacement for an online\n",
     "  A/B test — use the support diagnostics (ESS, Pareto-k, embedding\n",
-    "  sufficiency) to decide whether the estimate is trustworthy enough to act on."
+    "  sufficiency) to decide whether the estimate is trustworthy enough to act on.\n",
+    "- **The deliverable is a deploy / don't-deploy verdict, not just a number.** Lead with `support_health`: `ok` means the estimate is usable evidence for an A/B-test decision; `high_risk` means improve logging / embeddings before trusting it.\n",
+    "- The same workflow generalizes to **LLM tool-selection / routing** policies — map agent traces with `skdr_eval.adapters` and see `examples/use_cases/06_agent_routing_policy.py`."
    ]
   }
  ],

--- a/examples/use_cases/06_agent_routing_policy.py
+++ b/examples/use_cases/06_agent_routing_policy.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Evaluate a candidate agent routing / tool-selection policy from logged traces.
+
+The companion story made concrete (#150): you have **logged agent decisions** —
+for each request, the route/tool the agent chose and what it cost (latency +
+failure penalty) — and you want to know whether a *candidate* routing policy
+would be cheaper, **before** you ship it.
+
+The trace is a list of generic ``(context, action, reward)`` records, exactly
+the shape an agent framework (e.g. the Weaver stack) emits. We map it into the
+skdr-eval log schema with :func:`skdr_eval.adapters.from_records` (#149), then
+evaluate the candidate policy with DR / SNDR and read the trust verdict.
+
+``reward`` here is a **cost** (lower is better), which matches the
+policy-induction convention in :func:`skdr_eval.induce_policy_from_sklearn`
+(it up-weights actions with lower predicted outcome).
+
+We run two regimes on the same problem:
+
+* **healthy** — the logging agent explored enough, so the candidate is
+  supported by the logs and ``support_health == "ok"``: the offline estimate
+  is usable decision evidence.
+* **unhealthy** — the logging agent was near-deterministic, so overlap is poor
+  and ``support_health == "high_risk"``: the honest answer is "your logs don't
+  support this question yet", not a number to act on.
+
+See ``docs/weaver-stack.md`` (#148) for where this fits, and
+``examples/notebooks/06_good_vs_bad_support.ipynb`` (#121) for the same
+good-vs-bad-support lesson on the standard API.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import HistGradientBoostingRegressor, RandomForestRegressor
+
+import skdr_eval
+
+ROUTES = ["route_fast", "route_smart", "route_cheap"]
+
+
+def make_agent_traces(
+    n: int = 6000, seed: int = 11, explore: float = 0.6
+) -> list[dict]:
+    """Synthesize logged agent routing decisions as generic trace records.
+
+    Each record carries a ``context`` (request features), the ``action`` the
+    logging agent chose, the observed ``reward`` (cost; lower is better) and a
+    ``timestamp``. ``explore`` is the epsilon of the epsilon-greedy logging
+    agent: high exploration keeps every route's logged probability healthy.
+    """
+    rng = np.random.RandomState(seed)
+    req_tokens = rng.uniform(0.0, 1.0, n)  # normalized prompt size
+    priority = rng.uniform(0.0, 1.0, n)  # request priority
+    retrieval = rng.normal(0.0, 1.0, n)  # retrieval-confidence signal
+
+    n_routes = len(ROUTES)
+    # True per-route cost as a function of request features (lower is better).
+    cost = np.stack(
+        [
+            6.0 + 5.0 * req_tokens + 1.0 * priority,  # fast: cheap on small reqs
+            5.0
+            + 1.0 * req_tokens
+            - 2.0 * retrieval,  # smart: best when retrieval helps
+            7.0 - 1.0 * priority + 2.0 * req_tokens,  # cheap: steady, mediocre
+        ],
+        axis=1,
+    )
+    greedy = cost.argmin(axis=1)
+    behavior = np.full((n, n_routes), explore / n_routes)
+    behavior[np.arange(n), greedy] += 1.0 - explore
+    actions = np.array([rng.choice(n_routes, p=behavior[i]) for i in range(n)])
+    observed_cost = np.maximum(
+        cost[np.arange(n), actions] + rng.normal(0.0, 0.5, n), 0.1
+    )
+
+    ts = pd.Timestamp("2024-01-01") + pd.to_timedelta(np.arange(n) * 5, unit="s")
+    records: list[dict] = []
+    for i in range(n):
+        records.append(
+            {
+                "context": {
+                    "req_tokens": float(req_tokens[i]),
+                    "priority": float(priority[i]),
+                    "retrieval": float(retrieval[i]),
+                },
+                "action": ROUTES[actions[i]],
+                "reward": float(observed_cost[i]),
+                "timestamp": ts[i].isoformat(),
+            }
+        )
+    return records
+
+
+def evaluate_regime(name: str, explore: float) -> str:
+    """Adapt one trace regime and evaluate the candidate routing policy."""
+    print(
+        f"\n{'=' * 64}\n{name.upper()} regime (logging explore={explore})\n{'=' * 64}"
+    )
+
+    # 1. Logged agent decisions arrive as generic trace records.
+    trace = make_agent_traces(explore=explore)
+
+    # 2. Map the trace into the skdr-eval log schema (no hand-shaping).
+    adapted = skdr_eval.adapters.from_records(trace, reward_col="cost")
+    print(f"   adapter: {adapted.summary()}")
+
+    # 3. Candidate routing policies: any sklearn-compatible cost regressor.
+    models = {
+        "RandomForest": RandomForestRegressor(
+            n_estimators=120, max_depth=8, random_state=11
+        ),
+        "HistGradientBoosting": HistGradientBoostingRegressor(
+            max_iter=120, max_depth=6, random_state=11
+        ),
+    }
+
+    # 4. Evaluate with DR / SNDR on the adapted logs (cost: lower is better).
+    artifact = skdr_eval.evaluate_sklearn_models(
+        logs=adapted.logs,
+        models=models,
+        n_splits=3,
+        y_col=adapted.reward_col,
+        outcome_estimator="hgb",
+        random_state=11,
+        policy_train="pre_split",
+        policy_train_frac=0.8,
+        baseline="logged",
+    )
+
+    cols = [
+        c
+        for c in ("model", "estimator", "V_hat", "ESS", "support_health")
+        if c in artifact.report.columns
+    ]
+    print(artifact.report[cols].round(4).to_string(index=False))
+
+    health = set(artifact.report["support_health"])
+    if "ok" in health:
+        verdict = "DEPLOY-CANDIDATE: support is healthy; estimate is usable evidence."
+    else:
+        verdict = (
+            "DO-NOT-TRUST-YET: poor support; improve agent exploration / logging "
+            "before treating the offline estimate as deployment evidence."
+        )
+    print(f"   verdict: {verdict}")
+    return "ok" if "ok" in health else "high_risk"
+
+
+def main() -> None:
+    print("skdr-eval: evaluate a candidate agent routing policy from logged traces")
+    healthy = evaluate_regime("healthy", explore=0.6)
+    unhealthy = evaluate_regime("unhealthy", explore=0.03)
+
+    print(f"\n{'=' * 64}")
+    print("Summary")
+    print(f"{'=' * 64}")
+    print(f"   healthy regime   -> support_health includes '{healthy}'")
+    print(f"   unhealthy regime -> support_health includes '{unhealthy}'")
+    print(
+        "\nThe point of offline evaluation for agent policies is not just the "
+        "number — it is knowing when the logs cannot answer the question."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,9 +85,12 @@ nav:
   - Recipes:
       - Logs → experiment-review card: recipes/logs-to-experiment-card.md
       - Good vs bad support: recipes/good-vs-bad-support.md
+      - LLM-reranker OPE: recipes/llm-reranker-ope.md
   - Comparisons:
       - vs OBP / SCOPE-RL / d3rlpy: comparisons.md
       - Slate vs pairwise vs standard: slate-vs-pairwise-vs-standard.md
+  - Ecosystem:
+      - Offline-evaluation companion: weaver-stack.md
   - Project:
       - Launch readiness checklist: LAUNCH_CHECKLIST.md
       - Citing & DOI: zenodo.md

--- a/src/skdr_eval/__init__.py
+++ b/src/skdr_eval/__init__.py
@@ -2,6 +2,7 @@
 
 import importlib
 
+from . import adapters as adapters
 from . import estimators as estimators
 from . import slate as slate
 from ._simulation import CoverageResult, simulate_coverage

--- a/src/skdr_eval/adapters/__init__.py
+++ b/src/skdr_eval/adapters/__init__.py
@@ -1,0 +1,19 @@
+"""Input adapters that map external data into the skdr-eval log schema (#149).
+
+Today this hosts the generic decision-trace adapter, which maps
+``(context, action, reward[, timestamp, propensity])`` records — including
+JSONL agent traces — into the canonical single-action logs frame consumed by
+:func:`skdr_eval.evaluate_sklearn_models`.
+
+Public API:
+
+* :func:`from_records` — adapt an in-memory iterable of decision records.
+* :func:`from_jsonl_trace` — adapt a JSONL trace file (one record per line).
+* :class:`TraceAdapterResult` — the adapted logs plus mapping metadata.
+"""
+
+from __future__ import annotations
+
+from .trace import TraceAdapterResult, from_jsonl_trace, from_records
+
+__all__ = ["TraceAdapterResult", "from_jsonl_trace", "from_records"]

--- a/src/skdr_eval/adapters/trace.py
+++ b/src/skdr_eval/adapters/trace.py
@@ -1,0 +1,422 @@
+"""Generic decision-trace → OPE-log adapter (#149).
+
+Maps generic ``(context, action, reward[, timestamp, propensity])`` decision
+traces — e.g. JSONL agent traces — into the canonical single-action logs schema
+consumed by :func:`skdr_eval.evaluate_sklearn_models` and validated by
+:func:`skdr_eval.validate_logs`.
+
+This lowers the on-ramp for *every* user with decision logs in a non-skdr
+format: instead of hand-shaping a DataFrame with ``cli_*`` feature columns,
+``*_elig`` eligibility columns, an ``action`` column and a reward column, you
+describe where those fields live in your records and the adapter builds a
+schema-valid frame.
+
+Propensity handling
+-------------------
+skdr-eval estimates (calibrated) logging propensities internally from the logged
+actions and features, so a logged ``propensity`` value in the trace is
+*informational*: it is surfaced via
+:attr:`TraceAdapterResult.had_logged_propensities` and a one-time warning, not
+consumed by the DR/SNDR estimators. The no-logged-propensity case is the default
+and requires nothing extra.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from ..exceptions import DataValidationError, InsufficientDataError
+from ..validation import validate_logs
+
+logger = logging.getLogger("skdr_eval")
+
+__all__ = ["TraceAdapterResult", "from_jsonl_trace", "from_records"]
+
+# Sentinel distinguishing "key absent" from "value is None".
+_MISSING = object()
+
+
+@dataclass(frozen=True)
+class TraceAdapterResult:
+    """Result of adapting a decision trace into OPE logs.
+
+    Attributes
+    ----------
+    logs : pd.DataFrame
+        Schema-valid logs frame (passes :func:`skdr_eval.validate_logs` with
+        ``y_col=reward_col``). Feed this straight to
+        :func:`skdr_eval.evaluate_sklearn_models`.
+    actions : list[str]
+        Sorted action vocabulary (the eligible-operator universe).
+    feature_names : list[str]
+        Context-feature column names emitted into ``logs`` (all carry
+        ``feature_prefix``).
+    reward_col : str
+        Name of the reward/outcome column in ``logs``. Pass this as ``y_col``
+        to :func:`skdr_eval.evaluate_sklearn_models`.
+    n_records : int
+        Number of trace records mapped.
+    had_logged_propensities : bool
+        True when at least one record carried a logged propensity. Logged
+        propensities are *not* consumed by the estimators (skdr-eval calibrates
+        its own); this flag lets callers note the gap.
+    synthesized_timestamps : bool
+        True when no usable timestamp was found and a monotonic integer order
+        was synthesized into ``arrival_ts``.
+    """
+
+    logs: pd.DataFrame
+    actions: list[str]
+    feature_names: list[str]
+    reward_col: str
+    n_records: int
+    had_logged_propensities: bool
+    synthesized_timestamps: bool
+
+    def summary(self) -> str:
+        """One-line human-readable summary of the adaptation."""
+        ts = "synthesized" if self.synthesized_timestamps else "from trace"
+        prop = "present (re-estimated)" if self.had_logged_propensities else "absent"
+        return (
+            f"{self.n_records} records -> logs[{len(self.logs.columns)} cols]; "
+            f"{len(self.actions)} actions; {len(self.feature_names)} features; "
+            f"timestamps {ts}; logged propensities {prop}"
+        )
+
+
+def _context_to_features(
+    context: Any,
+    feature_keys: list[str] | None,
+    feature_len: int | None,
+    record_index: int,
+) -> list[float]:
+    """Extract a numeric feature vector from one record's context.
+
+    ``feature_keys``/``feature_len`` encode the schema fixed by the first
+    record; subsequent records must match it. Raises ``DataValidationError`` on
+    any mismatch or non-numeric value, naming the offending record.
+    """
+    if isinstance(context, Mapping):
+        if feature_keys is None:  # pragma: no cover - schema fixed by caller
+            raise DataValidationError("context schema not initialised")
+        if set(context.keys()) != set(feature_keys):
+            raise DataValidationError(
+                f"record {record_index}: context keys {sorted(context.keys())} "
+                f"differ from the first record's keys {sorted(feature_keys)}"
+            )
+        values = [context[k] for k in feature_keys]
+    elif isinstance(context, list | tuple | np.ndarray):
+        seq = list(context)
+        if feature_len is not None and len(seq) != feature_len:
+            raise DataValidationError(
+                f"record {record_index}: context length {len(seq)} differs from "
+                f"the first record's length {feature_len}"
+            )
+        values = seq
+    else:
+        raise DataValidationError(
+            f"record {record_index}: context must be a mapping or a sequence of "
+            f"numeric features, got {type(context).__name__}"
+        )
+
+    out: list[float] = []
+    for j, v in enumerate(values):
+        try:
+            out.append(float(v))
+        except (TypeError, ValueError) as exc:
+            label = feature_keys[j] if feature_keys is not None else f"index {j}"
+            raise DataValidationError(
+                f"record {record_index}: context feature {label!r} is not "
+                f"numeric (got {v!r})"
+            ) from exc
+    return out
+
+
+def from_records(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    context_key: str = "context",
+    action_key: str = "action",
+    reward_key: str = "reward",
+    timestamp_key: str | None = "timestamp",
+    propensity_key: str | None = "propensity",
+    eligible_actions_key: str | None = "eligible_actions",
+    feature_prefix: str = "cli_",
+    reward_col: str = "reward",
+    validate: bool = True,
+) -> TraceAdapterResult:
+    """Map generic decision-trace records into a schema-valid logs frame.
+
+    Each record is a mapping carrying at least a context, an action and a
+    reward. Context may be a mapping of named numeric features
+    (``{"tokens": 812, "priority": 1}``) or a flat numeric sequence; either way
+    it becomes ``feature_prefix``-prefixed columns. The chosen ``action`` and
+    the (optional) per-record ``eligible_actions`` define the eligible-operator
+    universe and the ``*_elig`` columns.
+
+    Parameters
+    ----------
+    records : iterable of mapping
+        The decision trace. Materialised once; must be non-empty.
+    context_key, action_key, reward_key : str
+        Record keys for the context, chosen action and observed reward.
+    timestamp_key : str or None, default ``"timestamp"``
+        Record key for a timestamp (numeric or anything ``pd.to_datetime`` can
+        parse). When ``None``, or when any record lacks a usable value, a
+        monotonic integer order is synthesized into ``arrival_ts``.
+    propensity_key : str or None, default ``"propensity"``
+        Record key for a logged propensity. Logged propensities are *not* used
+        by the estimators (skdr-eval calibrates its own); presence is reported
+        via :attr:`TraceAdapterResult.had_logged_propensities`.
+    eligible_actions_key : str or None, default ``"eligible_actions"``
+        Record key for the per-row list of eligible actions. When absent for a
+        row, every action in the global vocabulary is treated as eligible there.
+    feature_prefix : str, default ``"cli_"``
+        Prefix for emitted feature columns. Keep ``"cli_"`` or ``"st_"`` so the
+        downstream design matrix (:func:`skdr_eval.build_design`) recognises
+        them.
+    reward_col : str, default ``"reward"``
+        Name of the emitted reward column; pass as ``y_col`` downstream.
+    validate : bool, default True
+        Run :func:`skdr_eval.validate_logs` (with ``cli_pref=feature_prefix``,
+        ``y_col=reward_col``) on the result.
+
+    Returns
+    -------
+    TraceAdapterResult
+
+    Raises
+    ------
+    InsufficientDataError
+        If ``records`` is empty.
+    DataValidationError
+        On a missing key, a non-numeric/inconsistent context, or a chosen
+        action that is not in its own row's eligible set.
+    """
+    rows = list(records)
+    if not rows:
+        raise InsufficientDataError("trace has no records")
+
+    first_ctx = rows[0].get(context_key, _MISSING)
+    if first_ctx is _MISSING:
+        raise DataValidationError(f"record 0: missing context key {context_key!r}")
+    feature_keys: list[str] | None = None
+    feature_len: int | None = None
+    if isinstance(first_ctx, Mapping):
+        feature_keys = list(first_ctx.keys())
+        feature_names = [f"{feature_prefix}{k}" for k in feature_keys]
+    elif isinstance(first_ctx, list | tuple | np.ndarray):
+        feature_len = len(list(first_ctx))
+        feature_names = [f"{feature_prefix}{i}" for i in range(feature_len)]
+    else:
+        raise DataValidationError(
+            f"record 0: context must be a mapping or a sequence of numeric "
+            f"features, got {type(first_ctx).__name__}"
+        )
+    if not feature_names:
+        raise DataValidationError("record 0: context has no features")
+
+    feature_matrix: list[list[float]] = []
+    actions: list[str] = []
+    rewards: list[float] = []
+    raw_timestamps: list[Any] = []
+    eligible_per_row: list[list[str] | None] = []
+    had_propensities = False
+    have_all_timestamps = timestamp_key is not None
+
+    for i, rec in enumerate(rows):
+        ctx = rec.get(context_key, _MISSING)
+        if ctx is _MISSING:
+            raise DataValidationError(
+                f"record {i}: missing context key {context_key!r}"
+            )
+        feature_matrix.append(_context_to_features(ctx, feature_keys, feature_len, i))
+
+        if action_key not in rec:
+            raise DataValidationError(f"record {i}: missing action key {action_key!r}")
+        actions.append(str(rec[action_key]))
+
+        if reward_key not in rec:
+            raise DataValidationError(f"record {i}: missing reward key {reward_key!r}")
+        try:
+            rewards.append(float(rec[reward_key]))
+        except (TypeError, ValueError) as exc:
+            raise DataValidationError(
+                f"record {i}: reward {rec[reward_key]!r} is not numeric"
+            ) from exc
+
+        if propensity_key is not None and rec.get(propensity_key) is not None:
+            had_propensities = True
+
+        if timestamp_key is not None:
+            ts = rec.get(timestamp_key)
+            raw_timestamps.append(ts)
+            if ts is None:
+                have_all_timestamps = False
+
+        if (
+            eligible_actions_key is not None
+            and rec.get(eligible_actions_key) is not None
+        ):
+            eligible_per_row.append([str(a) for a in rec[eligible_actions_key]])
+        else:
+            eligible_per_row.append(None)
+
+    n = len(rows)
+
+    # Action vocabulary: observed actions plus any declared eligible actions.
+    vocab: set[str] = set(actions)
+    for elig in eligible_per_row:
+        if elig is not None:
+            vocab.update(elig)
+    action_vocab = sorted(vocab)
+
+    # Eligibility matrix: declared set per row, else all-eligible. The chosen
+    # action must be eligible on its own row (validate_logs enforces this too,
+    # but we raise here with the originating record index).
+    elig_matrix = np.zeros((n, len(action_vocab)), dtype=np.int8)
+    col_of = {a: j for j, a in enumerate(action_vocab)}
+    for i, elig in enumerate(eligible_per_row):
+        allowed = elig if elig is not None else action_vocab
+        for a in allowed:
+            elig_matrix[i, col_of[a]] = 1
+        if elig is not None and actions[i] not in elig:
+            raise DataValidationError(
+                f"record {i}: chosen action {actions[i]!r} is not in its "
+                f"eligible set {sorted(elig)}"
+            )
+
+    features = np.asarray(feature_matrix, dtype=float)
+    if not np.all(np.isfinite(features)):
+        bad_col = int(np.argmax(~np.isfinite(features).all(axis=0)))
+        raise DataValidationError(
+            f"context feature {feature_names[bad_col]!r} contains non-finite values"
+        )
+
+    # Timestamps: parse when present for every row, else synthesize order.
+    synthesized = True
+    arrival_ts: np.ndarray | pd.Series
+    if have_all_timestamps and raw_timestamps:
+        if all(
+            isinstance(t, (int, float)) and not isinstance(t, bool)
+            for t in raw_timestamps
+        ):
+            arrival_ts = np.asarray(raw_timestamps, dtype=float)
+            synthesized = False
+        else:
+            parsed = pd.to_datetime(pd.Series(raw_timestamps), errors="coerce")
+            if parsed.isna().any():
+                raise DataValidationError(
+                    f"trace {timestamp_key!r} values could not all be parsed as "
+                    "timestamps; drop the key to synthesize order instead"
+                )
+            arrival_ts = parsed
+            synthesized = False
+    else:
+        arrival_ts = np.arange(n, dtype=np.int64)
+
+    data: dict[str, Any] = {"arrival_ts": arrival_ts}
+    for j, name in enumerate(feature_names):
+        data[name] = features[:, j]
+    for a in action_vocab:
+        data[f"{a}_elig"] = elig_matrix[:, col_of[a]]
+    data["action"] = actions
+    data[reward_col] = rewards
+    logs = pd.DataFrame(data)
+
+    if had_propensities:
+        logger.warning(
+            "trace carried logged propensities under %r; skdr-eval estimates "
+            "calibrated propensities internally, so the logged values are "
+            "informational and not consumed by the DR/SNDR estimators.",
+            propensity_key,
+        )
+
+    if validate:
+        validate_logs(logs, cli_pref=feature_prefix, y_col=reward_col)
+
+    return TraceAdapterResult(
+        logs=logs,
+        actions=action_vocab,
+        feature_names=feature_names,
+        reward_col=reward_col,
+        n_records=n,
+        had_logged_propensities=had_propensities,
+        synthesized_timestamps=synthesized,
+    )
+
+
+def from_jsonl_trace(
+    path: str | Path,
+    *,
+    encoding: str = "utf-8",
+    context_key: str = "context",
+    action_key: str = "action",
+    reward_key: str = "reward",
+    timestamp_key: str | None = "timestamp",
+    propensity_key: str | None = "propensity",
+    eligible_actions_key: str | None = "eligible_actions",
+    feature_prefix: str = "cli_",
+    reward_col: str = "reward",
+    validate: bool = True,
+) -> TraceAdapterResult:
+    """Read a JSONL decision trace and adapt it via :func:`from_records`.
+
+    Each non-blank line must be a single JSON object (one decision record).
+    See :func:`from_records` for the mapping keyword arguments.
+
+    Parameters
+    ----------
+    path : str or pathlib.Path
+        Path to the ``.jsonl`` file (one JSON object per line).
+    encoding : str, default ``"utf-8"``
+        File encoding.
+
+    Returns
+    -------
+    TraceAdapterResult
+
+    Raises
+    ------
+    InsufficientDataError
+        If the file holds no records.
+    DataValidationError
+        If a line is not valid JSON, or on any :func:`from_records` error.
+    """
+    records: list[Mapping[str, Any]] = []
+    with Path(path).open(encoding=encoding) as fh:
+        for lineno, line in enumerate(fh, start=1):
+            if not line.strip():
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise DataValidationError(
+                    f"{path}:{lineno}: not valid JSON ({exc})"
+                ) from exc
+            if not isinstance(obj, Mapping):
+                raise DataValidationError(
+                    f"{path}:{lineno}: each line must be a JSON object, got "
+                    f"{type(obj).__name__}"
+                )
+            records.append(obj)
+    return from_records(
+        records,
+        context_key=context_key,
+        action_key=action_key,
+        reward_key=reward_key,
+        timestamp_key=timestamp_key,
+        propensity_key=propensity_key,
+        eligible_actions_key=eligible_actions_key,
+        feature_prefix=feature_prefix,
+        reward_col=reward_col,
+        validate=validate,
+    )

--- a/src/skdr_eval/adapters/trace.py
+++ b/src/skdr_eval/adapters/trace.py
@@ -16,7 +16,7 @@ Propensity handling
 skdr-eval estimates (calibrated) logging propensities internally from the logged
 actions and features, so a logged ``propensity`` value in the trace is
 *informational*: it is surfaced via
-:attr:`TraceAdapterResult.had_logged_propensities` and a one-time warning, not
+:attr:`TraceAdapterResult.had_logged_propensities` and a logged warning, not
 consumed by the DR/SNDR estimators. The no-logged-propensity case is the default
 and requires nothing extra.
 """

--- a/src/skdr_eval/adapters/trace.py
+++ b/src/skdr_eval/adapters/trace.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections import Counter
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -114,6 +115,11 @@ def _context_to_features(
             )
         values = [context[k] for k in feature_keys]
     elif isinstance(context, list | tuple | np.ndarray):
+        if isinstance(context, np.ndarray) and context.ndim == 0:
+            raise DataValidationError(
+                f"record {record_index}: context must be a mapping or a sequence "
+                "of numeric features, got a 0-d array"
+            )
         seq = list(context)
         if feature_len is not None and len(seq) != feature_len:
             raise DataValidationError(
@@ -214,6 +220,11 @@ def from_records(
         feature_keys = list(first_ctx.keys())
         feature_names = [f"{feature_prefix}{k}" for k in feature_keys]
     elif isinstance(first_ctx, list | tuple | np.ndarray):
+        if isinstance(first_ctx, np.ndarray) and first_ctx.ndim == 0:
+            raise DataValidationError(
+                "record 0: context must be a mapping or a sequence of numeric "
+                "features, got a 0-d array"
+            )
         feature_len = len(list(first_ctx))
         feature_names = [f"{feature_prefix}{i}" for i in range(feature_len)]
     else:
@@ -322,6 +333,26 @@ def from_records(
             synthesized = False
     else:
         arrival_ts = np.arange(n, dtype=np.int64)
+
+    # Guard against silent column overwrites: the emitted frame stacks
+    # arrival_ts, the feature columns, one ``*_elig`` column per action, the
+    # action column and the reward column into one namespace. A pathological
+    # reward_col (e.g. "action") or a feature/eligibility name clash would
+    # otherwise overwrite an earlier column without warning.
+    column_order = [
+        "arrival_ts",
+        *feature_names,
+        *(f"{a}_elig" for a in action_vocab),
+        "action",
+        reward_col,
+    ]
+    counts = Counter(column_order)
+    clashes = sorted(name for name, count in counts.items() if count > 1)
+    if clashes:
+        raise DataValidationError(
+            f"output column name collision on {clashes}: choose a distinct "
+            "reward_col / feature_prefix so emitted columns stay unique"
+        )
 
     data: dict[str, Any] = {"arrival_ts": arrival_ts}
     for j, name in enumerate(feature_names):

--- a/src/skdr_eval/doctor.py
+++ b/src/skdr_eval/doctor.py
@@ -173,9 +173,9 @@ def _check_optional_extras() -> Check:
     )
 
 
-def _check_logs_schema(logs: pd.DataFrame, *, strict: bool) -> Check:
+def _check_logs_schema(logs: pd.DataFrame, *, metric_col: str, strict: bool) -> Check:
     try:
-        validate_logs(logs, strict=strict)
+        validate_logs(logs, y_col=metric_col, strict=strict)
     except (DataValidationError, InsufficientDataError) as exc:
         return Check(
             name="schema",
@@ -443,8 +443,10 @@ def doctor(
     op_daily_df : pd.DataFrame, optional
         Required when ``kind="pairwise"``; ignored otherwise.
     metric_col : str, default ``"service_time"``
-        Pairwise metric column name. Used both by the pairwise validator and
-        by the finite-outcomes check.
+        Name of the reward/outcome column. Used by the standard and pairwise
+        schema validators (as ``validate_logs(y_col=...)`` in standard mode) and
+        by the finite-outcomes check. Pass your own column name for
+        general-purpose OPE logs whose reward is not ``"service_time"``.
     n_splits : int, default 3
         CV split count used by the sample-size floor heuristic.
     strict : bool, default False
@@ -486,9 +488,9 @@ def doctor(
         )
         outcome_cols: tuple[str, ...] = (metric_col,)
     else:
-        checks.append(_check_logs_schema(logs, strict=strict))
+        checks.append(_check_logs_schema(logs, metric_col=metric_col, strict=strict))
         checks.append(_check_no_duplicates(logs, key_cols=["client_id", "arrival_ts"]))
-        outcome_cols = ("service_time", "reward", "y")
+        outcome_cols = tuple(dict.fromkeys((metric_col, "service_time", "reward", "y")))
 
     checks.append(_check_finite_outcomes(logs, outcome_cols=outcome_cols))
     checks.append(_check_positivity(logs))

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -79,6 +79,14 @@ class TestDoctorChecks:
         assert not report.ok
         assert any(c.name == "schema" and c.status == "fail" for c in report.checks)
 
+    def test_standard_schema_honors_custom_metric_col(self):
+        # General-purpose OPE logs whose reward column is not "service_time"
+        # must pass the standard schema check when metric_col names it (#149).
+        logs = _good_logs().rename(columns={"service_time": "reward"})
+        report = doctor(logs, metric_col="reward")
+        assert report.ok
+        assert any(c.name == "schema" and c.status == "pass" for c in report.checks)
+
     def test_small_sample_size_fails(self):
         logs = _good_logs(n=100)  # well below 500 floor
         report = doctor(logs)

--- a/tests/test_trace_adapter.py
+++ b/tests/test_trace_adapter.py
@@ -172,3 +172,96 @@ def test_from_jsonl_trace_rejects_bad_json(tmp_path) -> None:
     path.write_text('{"context": {"x": 1.0}, "action": "a", "reward": 1.0}\nnot json\n')
     with pytest.raises(DataValidationError, match="not valid JSON"):
         from_jsonl_trace(path)
+
+
+def test_from_jsonl_trace_rejects_non_object_line(tmp_path) -> None:
+    path = tmp_path / "arr.jsonl"
+    path.write_text("[1, 2, 3]\n")
+    with pytest.raises(DataValidationError, match="must be a JSON object"):
+        from_jsonl_trace(path)
+
+
+def test_summary_is_descriptive() -> None:
+    res = from_records(_mapping_records(n=5))
+    summary = res.summary()
+    assert "5 records" in summary
+    assert "timestamps from trace" in summary
+    assert "logged propensities absent" in summary
+
+
+def test_numeric_timestamps_are_used_not_synthesized() -> None:
+    records = [
+        {"context": {"x": 1.0}, "action": "a", "reward": 1.0, "timestamp": 10},
+        {"context": {"x": 2.0}, "action": "a", "reward": 2.0, "timestamp": 20},
+    ]
+    res = from_records(records)
+    assert res.synthesized_timestamps is False
+    assert res.logs["arrival_ts"].tolist() == [10.0, 20.0]
+
+
+def test_unparseable_timestamps_raise() -> None:
+    records = [
+        {"context": {"x": 1.0}, "action": "a", "reward": 1.0, "timestamp": "nope"},
+        {"context": {"x": 2.0}, "action": "a", "reward": 2.0, "timestamp": "nah"},
+    ]
+    with pytest.raises(DataValidationError, match="could not all be parsed"):
+        from_records(records)
+
+
+def test_non_finite_context_raises() -> None:
+    records = [{"context": {"x": float("inf")}, "action": "a", "reward": 1.0}]
+    with pytest.raises(DataValidationError, match="non-finite"):
+        from_records(records, timestamp_key=None)
+
+
+def test_first_record_missing_context_raises() -> None:
+    with pytest.raises(DataValidationError, match="record 0: missing context key"):
+        from_records([{"action": "a", "reward": 1.0}], timestamp_key=None)
+
+
+def test_scalar_context_raises() -> None:
+    records = [{"context": 5, "action": "a", "reward": 1.0}]
+    with pytest.raises(DataValidationError, match="must be a mapping or a sequence"):
+        from_records(records, timestamp_key=None)
+
+
+def test_empty_context_has_no_features_raises() -> None:
+    records = [{"context": {}, "action": "a", "reward": 1.0}]
+    with pytest.raises(DataValidationError, match="context has no features"):
+        from_records(records, timestamp_key=None)
+
+
+def test_later_record_missing_context_raises() -> None:
+    records = [
+        {"context": {"x": 1.0}, "action": "a", "reward": 1.0},
+        {"action": "b", "reward": 2.0},
+    ]
+    with pytest.raises(DataValidationError, match="record 1: missing context key"):
+        from_records(records, timestamp_key=None)
+
+
+def test_missing_action_key_raises() -> None:
+    records = [{"context": {"x": 1.0}, "reward": 1.0}]
+    with pytest.raises(DataValidationError, match="missing action key"):
+        from_records(records, timestamp_key=None)
+
+
+def test_non_numeric_reward_raises() -> None:
+    records = [{"context": {"x": 1.0}, "action": "a", "reward": "high"}]
+    with pytest.raises(DataValidationError, match=r"reward .* is not numeric"):
+        from_records(records, timestamp_key=None)
+
+
+def test_sequence_length_mismatch_raises() -> None:
+    records = [
+        {"context": [1.0, 2.0], "action": "a", "reward": 1.0},
+        {"context": [1.0], "action": "b", "reward": 2.0},
+    ]
+    with pytest.raises(DataValidationError, match="context length 1 differs"):
+        from_records(records, timestamp_key=None)
+
+
+def test_sequence_non_numeric_element_raises() -> None:
+    records = [{"context": [1.0, "x"], "action": "a", "reward": 1.0}]
+    with pytest.raises(DataValidationError, match=r"index 1.* is not numeric"):
+        from_records(records, timestamp_key=None)

--- a/tests/test_trace_adapter.py
+++ b/tests/test_trace_adapter.py
@@ -1,0 +1,174 @@
+"""Tests for the generic trace -> OPE-log adapter (#149)."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+from sklearn.linear_model import LinearRegression
+
+import skdr_eval
+from skdr_eval.adapters import TraceAdapterResult, from_jsonl_trace, from_records
+from skdr_eval.exceptions import DataValidationError, InsufficientDataError
+
+
+def _mapping_records(n: int = 60, seed: int = 0) -> list[dict]:
+    """A small agent-style trace with mapping contexts and explicit timestamps."""
+    rng = np.random.RandomState(seed)
+    actions = ["route_fast", "route_smart", "route_cheap"]
+    records = []
+    for i in range(n):
+        ctx = {
+            "tokens": float(rng.randint(64, 1024)),
+            "priority": float(rng.randint(0, 3)),
+        }
+        a = actions[rng.randint(len(actions))]
+        records.append(
+            {
+                "context": ctx,
+                "action": a,
+                "reward": float(rng.normal(10.0, 1.0)),
+                "timestamp": f"2024-01-01T00:{i % 60:02d}:00",
+            }
+        )
+    return records
+
+
+def test_from_records_mapping_context_is_schema_valid() -> None:
+    res = from_records(_mapping_records())
+    assert isinstance(res, TraceAdapterResult)
+    # Round-trips through the public preflight with the adapter's reward column.
+    skdr_eval.validate_logs(res.logs, y_col=res.reward_col)
+    assert res.feature_names == ["cli_tokens", "cli_priority"]
+    assert res.actions == ["route_cheap", "route_fast", "route_smart"]
+    assert res.n_records == 60
+    assert res.synthesized_timestamps is False
+    assert res.had_logged_propensities is False
+    # One elig column per action, all eligible (no per-row eligibility given).
+    for a in res.actions:
+        assert (res.logs[f"{a}_elig"] == 1).all()
+
+
+def test_from_records_sequence_context_indexes_features() -> None:
+    records = [
+        {"context": [0.1, 0.2, 0.3], "action": "a", "reward": 1.0},
+        {"context": [0.4, 0.5, 0.6], "action": "b", "reward": 2.0},
+    ]
+    res = from_records(records, timestamp_key=None)
+    assert res.feature_names == ["cli_0", "cli_1", "cli_2"]
+    assert res.synthesized_timestamps is True
+    # Synthesized order is a monotonic integer range.
+    assert res.logs["arrival_ts"].tolist() == [0, 1]
+
+
+def test_missing_timestamp_synthesizes_order() -> None:
+    records = _mapping_records(n=10)
+    del records[3]["timestamp"]  # one row lacks a timestamp -> synthesize all
+    res = from_records(records)
+    assert res.synthesized_timestamps is True
+    assert res.logs["arrival_ts"].tolist() == list(range(10))
+
+
+def test_per_row_eligibility_is_honored() -> None:
+    records = [
+        {
+            "context": {"x": 1.0},
+            "action": "a",
+            "reward": 1.0,
+            "eligible_actions": ["a", "b"],
+        },
+        {
+            "context": {"x": 2.0},
+            "action": "c",
+            "reward": 2.0,
+            "eligible_actions": ["c"],
+        },
+    ]
+    res = from_records(records, timestamp_key=None)
+    assert res.actions == ["a", "b", "c"]
+    # Row 0: a, b eligible; c not.
+    assert res.logs.loc[0, "a_elig"] == 1
+    assert res.logs.loc[0, "b_elig"] == 1
+    assert res.logs.loc[0, "c_elig"] == 0
+    # Row 1: only c eligible.
+    assert res.logs.loc[1, "c_elig"] == 1
+    assert res.logs.loc[1, "a_elig"] == 0
+
+
+def test_chosen_action_not_eligible_raises() -> None:
+    records = [
+        {
+            "context": {"x": 1.0},
+            "action": "a",
+            "reward": 1.0,
+            "eligible_actions": ["b", "c"],
+        },
+    ]
+    with pytest.raises(DataValidationError, match="not in its eligible set"):
+        from_records(records, timestamp_key=None)
+
+
+def test_logged_propensities_are_flagged_not_consumed() -> None:
+    records = _mapping_records(n=12)
+    for r in records:
+        r["propensity"] = 0.33
+    res = from_records(records)
+    assert res.had_logged_propensities is True
+    # The logged propensity must NOT leak into the logs frame.
+    assert "propensity" not in res.logs.columns
+
+
+def test_non_numeric_context_raises() -> None:
+    records = [{"context": {"x": "high"}, "action": "a", "reward": 1.0}]
+    with pytest.raises(DataValidationError, match=r"not .*numeric"):
+        from_records(records, timestamp_key=None)
+
+
+def test_inconsistent_context_keys_raise() -> None:
+    records = [
+        {"context": {"x": 1.0}, "action": "a", "reward": 1.0},
+        {"context": {"y": 2.0}, "action": "b", "reward": 2.0},
+    ]
+    with pytest.raises(DataValidationError, match="differ from the first record"):
+        from_records(records, timestamp_key=None)
+
+
+def test_missing_reward_key_raises() -> None:
+    records = [{"context": {"x": 1.0}, "action": "a"}]
+    with pytest.raises(DataValidationError, match="missing reward key"):
+        from_records(records, timestamp_key=None)
+
+
+def test_empty_trace_raises() -> None:
+    with pytest.raises(InsufficientDataError, match="no records"):
+        from_records([])
+
+
+def test_adapter_output_feeds_evaluate_sklearn_models() -> None:
+    res = from_records(_mapping_records(n=400, seed=3))
+    artifact = skdr_eval.evaluate_sklearn_models(
+        logs=res.logs,
+        models={"linear": LinearRegression()},
+        n_splits=3,
+        y_col=res.reward_col,
+        policy_train="pre_split",
+    )
+    assert "V_hat" in artifact.report.columns
+    assert (artifact.report["model"] == "linear").any()
+
+
+def test_from_jsonl_trace_roundtrip(tmp_path) -> None:
+    records = _mapping_records(n=20)
+    path = tmp_path / "trace.jsonl"
+    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+    res = from_jsonl_trace(path)
+    assert res.n_records == 20
+    skdr_eval.validate_logs(res.logs, y_col=res.reward_col)
+
+
+def test_from_jsonl_trace_rejects_bad_json(tmp_path) -> None:
+    path = tmp_path / "bad.jsonl"
+    path.write_text('{"context": {"x": 1.0}, "action": "a", "reward": 1.0}\nnot json\n')
+    with pytest.raises(DataValidationError, match="not valid JSON"):
+        from_jsonl_trace(path)

--- a/tests/test_trace_adapter.py
+++ b/tests/test_trace_adapter.py
@@ -265,3 +265,27 @@ def test_sequence_non_numeric_element_raises() -> None:
     records = [{"context": [1.0, "x"], "action": "a", "reward": 1.0}]
     with pytest.raises(DataValidationError, match=r"index 1.* is not numeric"):
         from_records(records, timestamp_key=None)
+
+
+def test_zero_dim_array_context_raises() -> None:
+    # A 0-d ndarray satisfies isinstance(..., np.ndarray) but is not iterable;
+    # it must surface as a DataValidationError, not a raw TypeError.
+    records = [{"context": np.array(5.0), "action": "a", "reward": 1.0}]
+    with pytest.raises(DataValidationError, match="0-d array"):
+        from_records(records, timestamp_key=None)
+
+
+def test_reward_col_colliding_with_structural_column_raises() -> None:
+    # reward_col="action" would silently overwrite the action column; the
+    # adapter must reject the collision instead of emitting a corrupt frame.
+    records = [{"context": {"x": 1.0}, "action": "a", "reward": 1.0}]
+    with pytest.raises(DataValidationError, match="column name collision"):
+        from_records(records, timestamp_key=None, reward_col="action")
+
+
+def test_feature_prefix_collision_with_action_raises() -> None:
+    # An empty feature_prefix lets a context key named "action" collide with
+    # the structural action column.
+    records = [{"context": {"action": 1.0}, "action": "a", "reward": 1.0}]
+    with pytest.raises(DataValidationError, match="column name collision"):
+        from_records(records, timestamp_key=None, feature_prefix="")


### PR DESCRIPTION
# Pull Request

## 📋 Description

Implements the recommended coherent issue group: a generic decision-trace → OPE-log adapter, a runnable agent-routing example built on it, a Weaver-stack companion positioning guide, and the promotion of the LLM-reranker recipe into a flagship, audience-targeted artifact. Together these turn the "evaluate logged agent/LLM decisions offline" story from prose into something a user can `pip install` and run.

### Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update
- [x] 🔧 Build/CI improvements

## 🔗 Related Issues
- Closes #149 — generic trace → OPE-log adapter
- Closes #150 — agent routing/tool-selection example
- Closes #148 — offline-evaluation companion positioning
- Closes #145 — flagship LLM-reranker OPE artifact

## 🧪 Testing

### Test Coverage
- [x] Added tests that prove the feature works (`tests/test_trace_adapter.py`, 13 cases; +1 `tests/test_doctor.py` case)
- [x] New and existing unit tests pass locally

**Test commands run:**
```bash
ruff check src/ tests/ examples/          # All checks passed!
ruff format --check src/ tests/ examples/ # 107 files already formatted
mypy src/skdr_eval/                       # Success: no issues found in 37 source files
python -m pytest tests/test_trace_adapter.py tests/test_doctor.py \
  tests/test_public_validators.py tests/test_api.py -q   # 91 passed
python examples/use_cases/06_agent_routing_policy.py     # healthy=ok, unhealthy=high_risk
mkdocs build --strict                                    # exit 0
python -m pytest --nbmake examples/notebooks/10_llm_reranker_ope.ipynb  # 1 passed
```

## 📝 Changes Made

### Code Changes
- **`skdr_eval.adapters`** (new package): `from_records`, `from_jsonl_trace`, `TraceAdapterResult`. Maps `(context, action, reward[, timestamp, propensity])` records into the canonical `cli_*` / `*_elig` / `action` / reward schema; reuses `validate_logs`. Mapping or sequence context → features; chosen action + optional per-row `eligible_actions` → eligibility; missing timestamps synthesize a monotonic order; logged propensities are **flagged, not consumed** (skdr-eval calibrates its own).
- **`doctor(kind="standard")`** now threads `metric_col` into the schema check (`validate_logs(y_col=metric_col)`) and the finite-outcomes check, so general-purpose OPE logs whose reward isn't `service_time` pass the preflight. No change for the default.
- **`examples/use_cases/06_agent_routing_policy.py`** (new): adapts logged agent traces and evaluates a candidate routing policy, demonstrating a healthy (`support_health=ok`) and an unhealthy (`high_risk`) regime. Added to the CI use-cases-smoke job and `make use-cases`.

### Documentation
- `docs/weaver-stack.md` — companion positioning (standalone-first, MIT, no runtime dependency), the trace-adapter seam, reciprocal cross-links.
- `docs/recipes/llm-reranker-ope.md` + Colab badge and deploy/don't-deploy verdict in notebook 10; README "Evaluate LLM / agent policies offline" + "Ecosystem" sections.
- Adapters documented in the API reference; mkdocs nav updated; `CHANGELOG.md` updated.

### API Changes
- [x] Backward compatible API additions (new `skdr_eval.adapters` namespace; `doctor` change is behaviour-compatible for the default reward column).

## 📚 Documentation
- [x] Updated docs, docstrings, examples, and `CHANGELOG.md`.

## ✅ Checklist
- [x] Follows style guidelines; `ruff check` / `ruff format` / `mypy` clean
- [x] Self-reviewed; new and existing tests pass locally
- [x] Conventional-commit messages
- [x] CHANGELOG updated

## 🔍 Review Notes

### Focus Areas
- **Propensity handling.** skdr-eval estimates calibrated propensities internally and has no logged-propensity input, so the adapter reports `had_logged_propensities` and warns rather than feeding logged values to DR/SNDR. Confirm this is the desired contract.
- **`doctor` standard schema check.** Previously hard-coded `service_time`; now honours `metric_col`. This is a small behaviour change that was needed for the adapter's "passes doctor" acceptance criterion (Mode B).
- **Cross-repo links (#148, #150).** The companion guide references sibling repos (agent-kernel #96, ChainWeaver, contextweaver) that live outside this repo; back-links there need separate coordination.

### Mode B notes
Per the agreed scope (Mode B, one PR for the whole group): the `doctor` `metric_col` plumbing is a small adjacent improvement included because the adapter's acceptance criteria require `doctor` to pass on non-`service_time` reward columns.

## 📸 Examples

```python
import skdr_eval

adapted = skdr_eval.adapters.from_jsonl_trace("agent_traces.jsonl", reward_col="cost")
skdr_eval.validate_logs(adapted.logs, y_col=adapted.reward_col)
artifact = skdr_eval.evaluate_sklearn_models(
    logs=adapted.logs, models={"candidate": my_cost_model}, y_col=adapted.reward_col,
)
print(artifact.report[["model", "estimator", "V_hat", "support_health"]])
```

## 🚀 Deployment Notes
- [x] No special deployment considerations

---

https://claude.ai/code/session_01HviHo22E7UBUt5Cgxt481F

---
_Generated by [Claude Code](https://claude.ai/code/session_01HviHo22E7UBUt5Cgxt481F)_