### PR TITLE
feat(packaging): Python 3.10–3.14, library-grade deps, discoverability + citation metadata (#123, #152, #144, #77)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4
@@ -48,6 +48,38 @@ jobs:
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false
+
+  # Floor-deps job (#152): install the *minimum* declared dependency versions
+  # on the lowest supported Python (3.10) and run the full suite. This proves
+  # every ``>=X`` lower bound in pyproject.toml is truthful — a normal CI run
+  # resolves the latest deps and would silently mask a broken floor.
+  floor-deps:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Needed for setuptools_scm
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Install with scientific-core deps pinned to their declared floors
+      # constraints-min.txt pins numpy/pandas/scipy/scikit-learn to the floors
+      # declared in pyproject.toml, while dev/test tooling (pytest, matplotlib,
+      # …) still resolves at current versions. Flooring the test tooling itself
+      # is not the point — only the runtime scientific core.
+      run: |
+        uv pip install --system -e .[dev] --constraint constraints-min.txt
+
+    - name: Test with pytest (minimum dependency floors)
+      run: |
+        pytest -q --no-header
 
   examples-smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/deps-nightly.yml
+++ b/.github/workflows/deps-nightly.yml
@@ -1,0 +1,39 @@
+name: Nightly latest/pre-release deps
+
+# Safety net for the "no upper-bound caps" dependency policy (#152). A normal
+# CI run resolves whatever is current at the time; this scheduled job goes one
+# step further and installs the *newest* releases including pre-releases, so a
+# breaking numpy / scipy / scikit-learn / pandas release is caught early rather
+# than at a user's install time. It is allowed to fail (continue-on-error) —
+# a red run here is an early-warning signal, not a merge blocker.
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"  # Mondays 06:00 UTC
+  workflow_dispatch: {}
+
+jobs:
+  latest-deps:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # Needed for setuptools_scm
+
+    - name: Set up Python 3.14
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.14"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
+
+    - name: Install with newest deps (pre-releases allowed)
+      run: |
+        uv pip install --system --upgrade --prerelease allow -e .[dev]
+
+    - name: Test with pytest (latest/pre-release deps)
+      run: |
+        pytest -q --no-header

--- a/.github/workflows/deps-weekly.yml
+++ b/.github/workflows/deps-weekly.yml
@@ -1,4 +1,4 @@
-name: Nightly latest/pre-release deps
+name: Weekly latest/pre-release deps
 
 # Safety net for the "no upper-bound caps" dependency policy (#152). A normal
 # CI run resolves whatever is current at the time; this scheduled job goes one

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,5 @@
 line-length = 88
-target-version = "py311"
+target-version = "py310"
 extend-exclude = ["src/skdr_eval/_version.py"]
 
 [lint]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Floor-deps and nightly dependency CI** ([#152]). A `floor-deps` job
   installs the declared minimum scientific-core versions (via
   `constraints-min.txt`) and runs the suite, proving every `>=` lower bound is
-  truthful; a scheduled `deps-nightly` workflow installs the newest/pre-release
+  truthful; a scheduled `deps-weekly` workflow installs the newest/pre-release
   dependencies (`continue-on-error`) as an early-warning net for the no-cap
   policy. The policy is documented in `DEVELOPMENT.md`.
 - **`CITATION.bib` + foundational references** ([#77]). A BibTeX companion to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deterministic.
 
 ### Added
+- **Python 3.10 support** ([#123]). `requires-python` is now
+  `>=3.10,<3.15`, a `Programming Language :: Python :: 3.10` classifier is
+  added, and the CI test matrix runs 3.10–3.14. 3.11-only usages were
+  backported: `datetime.UTC` → `datetime.now(timezone.utc)` and a `tomli`
+  fallback for the bare `tomllib` import in the capabilities test. `ruff`,
+  `black`, and `mypy` now target `py310`.
+- **Floor-deps and nightly dependency CI** ([#152]). A `floor-deps` job
+  installs the declared minimum scientific-core versions (via
+  `constraints-min.txt`) and runs the suite, proving every `>=` lower bound is
+  truthful; a scheduled `deps-nightly` workflow installs the newest/pre-release
+  dependencies (`continue-on-error`) as an early-warning net for the no-cap
+  policy. The policy is documented in `DEVELOPMENT.md`.
+- **`CITATION.bib` + foundational references** ([#77]). A BibTeX companion to
+  `CITATION.cff` for one-click copy, plus a `references` block in
+  `CITATION.cff` (DR, PSIS, calibration, double machine learning) mirroring
+  `docs/methods.md`; both linked from the README citation section.
 - **Generic trace → OPE-log adapter** ([#149]). New `skdr_eval.adapters`
   package with `from_records` and `from_jsonl_trace`: map generic
   `(context, action, reward[, timestamp, propensity])` decision records —
@@ -141,6 +157,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     dependency; CPU-only.
 
 ### Changed
+- **Library-grade dependency constraints** ([#152]). The scientific core now
+  uses lower bounds only — `numpy>=1.24`, `pandas>=2.0`, `scipy>=1.10`,
+  `scikit-learn>=1.2` — with no exact pins and no speculative upper-bound caps,
+  so the library composes inside existing data-science environments.
+- **OPE-forward package metadata** ([#144]). The PyPI summary now leads with
+  "offline policy evaluation (OPE)" and the deploy/don't-deploy verdict, and
+  keywords are aligned. The canonical GitHub repository description and topics
+  are recorded in `DEVELOPMENT.md` (the repo-settings change is a manual
+  maintainer action).
 - **`doctor(kind="standard")` honours `metric_col` in the schema check**
   ([#149]). The standard preflight previously validated the logs schema with
   the hard-coded `service_time` reward column, so general-purpose OPE logs with
@@ -680,6 +705,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#148]: https://github.com/dgenio/skdr-eval/issues/148
 [#149]: https://github.com/dgenio/skdr-eval/issues/149
 [#150]: https://github.com/dgenio/skdr-eval/issues/150
+[#123]: https://github.com/dgenio/skdr-eval/issues/123
+[#144]: https://github.com/dgenio/skdr-eval/issues/144
+[#152]: https://github.com/dgenio/skdr-eval/issues/152
 
 ## [0.6.0] - 2026-05-12
 

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,11 +1,14 @@
 % BibTeX companion to CITATION.cff for one-click copy in papers.
 % Keep this file in sync with CITATION.cff (version, year, DOI) on each release.
+% The `doi` below is the placeholder concept DOI mirrored from CITATION.cff;
+% replace it with the real value after the first Zenodo-archived release.
 
 @software{santos2026skdreval,
   title   = {{skdr-eval}: Offline Policy Evaluation for {sklearn}-Compatible Models with Time-Aware Doubly Robust Estimators},
   author  = {Santos, Diogo},
   year    = {2026},
   version = {0.9.0},
+  doi     = {10.5281/zenodo.0000000},
   url     = {https://github.com/dgenio/skdr-eval},
   license = {MIT}
 }

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,51 @@
+% BibTeX companion to CITATION.cff for one-click copy in papers.
+% Keep this file in sync with CITATION.cff (version, year, DOI) on each release.
+
+@software{santos2026skdreval,
+  title   = {{skdr-eval}: Offline Policy Evaluation for {sklearn}-Compatible Models with Time-Aware Doubly Robust Estimators},
+  author  = {Santos, Diogo},
+  year    = {2026},
+  version = {0.9.0},
+  url     = {https://github.com/dgenio/skdr-eval},
+  license = {MIT}
+}
+
+% --- Foundational methods (mirror CITATION.cff references / docs/methods.md) ---
+
+@article{robins1994estimation,
+  title   = {Estimation of Regression Coefficients When Some Regressors Are Not Always Observed},
+  author  = {Robins, James M. and Rotnitzky, Andrea and Zhao, Lue Ping},
+  year    = {1994},
+  journal = {Journal of the American Statistical Association}
+}
+
+@inproceedings{dudik2011doubly,
+  title     = {Doubly Robust Policy Evaluation and Learning},
+  author    = {Dud{\'i}k, Miroslav and Langford, John and Li, Lihong},
+  year      = {2011},
+  booktitle = {Proceedings of the 28th International Conference on Machine Learning (ICML)},
+  url       = {https://arxiv.org/abs/1103.4601}
+}
+
+@article{vehtari2024pareto,
+  title   = {Pareto Smoothed Importance Sampling},
+  author  = {Vehtari, Aki and Simpson, Daniel and Gelman, Andrew and Yao, Yuling and Gabry, Jonah},
+  year    = {2024},
+  journal = {Journal of Machine Learning Research},
+  url     = {https://arxiv.org/abs/1507.02646}
+}
+
+@inproceedings{naeini2015obtaining,
+  title     = {Obtaining Well Calibrated Probabilities Using Bayesian Binning},
+  author    = {Naeini, Mahdi Pakdaman and Cooper, Gregory F. and Hauskrecht, Milos},
+  year      = {2015},
+  booktitle = {Proceedings of the 29th AAAI Conference on Artificial Intelligence}
+}
+
+@article{chernozhukov2018double,
+  title   = {Double/Debiased Machine Learning for Treatment and Structural Parameters},
+  author  = {Chernozhukov, Victor and Chetverikov, Denis and Demirer, Mert and Duflo, Esther and Hansen, Christian and Newey, Whitney and Robins, James},
+  year    = {2018},
+  journal = {The Econometrics Journal},
+  doi     = {10.1111/ectj.12097}
+}

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -55,3 +55,81 @@ preferred-citation:
   version: "0.9.0"
   year: 2026
   url: "https://github.com/dgenio/skdr-eval"
+# Foundational methods the library builds on. These mirror the citations in
+# docs/methods.md so the citation metadata and the methods note stay in sync.
+references:
+  - type: article
+    title: "Estimation of Regression Coefficients When Some Regressors Are Not Always Observed"
+    authors:
+      - family-names: "Robins"
+        given-names: "James M."
+      - family-names: "Rotnitzky"
+        given-names: "Andrea"
+      - family-names: "Zhao"
+        given-names: "Lue Ping"
+    year: 1994
+    journal: "Journal of the American Statistical Association"
+    notes: "Foundational result for doubly robust / AIPW estimation."
+  - type: conference-paper
+    title: "Doubly Robust Policy Evaluation and Learning"
+    authors:
+      - family-names: "Dudík"
+        given-names: "Miroslav"
+      - family-names: "Langford"
+        given-names: "John"
+      - family-names: "Li"
+        given-names: "Lihong"
+    year: 2011
+    collection-title: "Proceedings of the 28th International Conference on Machine Learning (ICML)"
+    url: "https://arxiv.org/abs/1103.4601"
+    notes: "The DR estimator for off-policy evaluation."
+  - type: article
+    title: "Pareto Smoothed Importance Sampling"
+    authors:
+      - family-names: "Vehtari"
+        given-names: "Aki"
+      - family-names: "Simpson"
+        given-names: "Daniel"
+      - family-names: "Gelman"
+        given-names: "Andrew"
+      - family-names: "Yao"
+        given-names: "Yuling"
+      - family-names: "Gabry"
+        given-names: "Jonah"
+    year: 2024
+    journal: "Journal of Machine Learning Research"
+    url: "https://arxiv.org/abs/1507.02646"
+    notes: "PSIS and the Pareto-k support-health diagnostic thresholds."
+  - type: conference-paper
+    title: "Obtaining Well Calibrated Probabilities Using Bayesian Binning"
+    authors:
+      - family-names: "Naeini"
+        given-names: "Mahdi Pakdaman"
+      - family-names: "Cooper"
+        given-names: "Gregory F."
+      - family-names: "Hauskrecht"
+        given-names: "Milos"
+    year: 2015
+    collection-title: "Proceedings of the 29th AAAI Conference on Artificial Intelligence"
+    notes: "Binned calibration error (ECE) used in the propensity-calibration diagnostic."
+  - type: article
+    title: "Double/Debiased Machine Learning for Treatment and Structural Parameters"
+    authors:
+      - family-names: "Chernozhukov"
+        given-names: "Victor"
+      - family-names: "Chetverikov"
+        given-names: "Denis"
+      - family-names: "Demirer"
+        given-names: "Mert"
+      - family-names: "Duflo"
+        given-names: "Esther"
+      - family-names: "Hansen"
+        given-names: "Christian"
+      - family-names: "Newey"
+        given-names: "Whitney"
+      - family-names: "Robins"
+        given-names: "James"
+    year: 2018
+    journal: "The Econometrics Journal"
+    doi: "10.1111/ectj.12097"
+    notes: "Cross-fitting / sample-splitting underpinning the time-aware crossfit design."

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -141,7 +141,9 @@ correctness allows — it must compose inside a downstream scientific stack:
   minimums via `constraints-min.txt` (`uv pip install -e .[dev] --constraint
   constraints-min.txt`) on Python 3.10 and runs the suite — this proves every
   `>=X` is truthful while the test tooling still resolves at current versions.
-  Keep `constraints-min.txt` in sync with the floors in `pyproject.toml`.
+  Keep `constraints-min.txt` in sync with the floors in `pyproject.toml`. (In
+  CI the same install runs with `--system` so it targets the runner's
+  interpreter; locally, drop `--system` and install into a virtualenv.)
 - **Scheduled `deps-weekly` job** installs the newest releases including
   pre-releases (`--prerelease allow`, `continue-on-error`) as the early-warning
   net that justifies leaving the upper end uncapped.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -121,6 +121,40 @@ git push origin feature/descriptive-name
 - **Examples**: Include usage examples in docstrings
 - **API changes**: Must update README.md
 
+### Supported Python Versions (#123)
+- **Range**: Python **3.10 – 3.14 inclusive** (`requires-python = ">=3.10,<3.15"`).
+- **Tested**: every version in the range runs the full suite in CI (`test` matrix).
+- **Floor signal**: lint/format (`ruff`), type-checking (`mypy`), and `black`
+  all target `py310`, so 3.11+-only syntax (e.g. `datetime.UTC`, bare
+  `tomllib`) is caught before it ships.
+
+### Dependency Constraint Policy (#152)
+This is a **library**, so it constrains dependencies as *loosely* as
+correctness allows — it must compose inside a downstream scientific stack:
+- **Lower bounds only** (`>=`) on the scientific core (numpy, pandas,
+  scikit-learn, scipy). Floors are the lowest versions the suite is known to
+  pass on, **not** the latest.
+- **No exact pins (`==`)** and **no speculative upper-bound caps** (`<`) in
+  install requirements. Any cap that ever becomes necessary must carry an
+  inline comment citing the specific incompatibility.
+- **`floor-deps` CI job** installs the declared minimums
+  (`uv pip install --resolution lowest-direct`) on Python 3.10 and runs the
+  suite — this proves every `>=X` is truthful.
+- **Scheduled `deps-nightly` job** installs the newest releases including
+  pre-releases (`--prerelease allow`, `continue-on-error`) as the early-warning
+  net that justifies leaving the upper end uncapped.
+
+### Repository Discoverability Metadata (#144)
+The PyPI summary (`project.description`) and `keywords` in `pyproject.toml`
+carry the canonical *"offline policy evaluation (OPE)"* phrasing. The matching
+**GitHub repository description and topics are a repo *settings* action** (not
+expressible in a PR) — a maintainer should set them once to:
+
+- **Description**: `Offline policy evaluation (OPE) for scikit-learn policies — doubly-robust estimates with honest trust diagnostics and a deploy/don't-deploy verdict.`
+- **Topics**: `offline-policy-evaluation`, `ope`, `counterfactual`,
+  `doubly-robust`, `contextual-bandits`, `causal-inference`, `scikit-learn`,
+  `recommender-systems`, `policy-evaluation`, `python`.
+
 ## 🤖 AI Agent Specific Guidelines
 
 ### Code Analysis Checklist

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -137,10 +137,12 @@ correctness allows — it must compose inside a downstream scientific stack:
 - **No exact pins (`==`)** and **no speculative upper-bound caps** (`<`) in
   install requirements. Any cap that ever becomes necessary must carry an
   inline comment citing the specific incompatibility.
-- **`floor-deps` CI job** installs the declared minimums
-  (`uv pip install --resolution lowest-direct`) on Python 3.10 and runs the
-  suite — this proves every `>=X` is truthful.
-- **Scheduled `deps-nightly` job** installs the newest releases including
+- **`floor-deps` CI job** installs the scientific core pinned to the declared
+  minimums via `constraints-min.txt` (`uv pip install -e .[dev] --constraint
+  constraints-min.txt`) on Python 3.10 and runs the suite — this proves every
+  `>=X` is truthful while the test tooling still resolves at current versions.
+  Keep `constraints-min.txt` in sync with the floors in `pyproject.toml`.
+- **Scheduled `deps-weekly` job** installs the newest releases including
   pre-releases (`--prerelease allow`, `continue-on-error`) as the early-warning
   net that justifies leaving the upper end uncapped.
 

--- a/README.md
+++ b/README.md
@@ -853,6 +853,11 @@ If you use this software in your research, please cite:
 }
 ```
 
+For one-click copy, the same entry — plus the foundational method references
+(DR, PSIS, calibration, double machine learning) — is available as
+[`CITATION.bib`](CITATION.bib) and as machine-readable
+[`CITATION.cff`](CITATION.cff).
+
 A Zenodo concept DOI is being minted on the next tagged release (see
 [`docs/zenodo.md`](docs/zenodo.md)); after that, `CITATION.cff` will carry
 the canonical DOI and replace the URL field above.

--- a/constraints-min.txt
+++ b/constraints-min.txt
@@ -1,0 +1,11 @@
+# Minimum (floor) versions of the scientific-core runtime dependencies,
+# matching the lower bounds declared in pyproject.toml (#152). The `floor-deps`
+# CI job installs the package + dev tooling under this constraint so the
+# scientific core resolves to its declared floors (proving every `>=X` is
+# truthful) while pytest/matplotlib/etc. still resolve at current versions.
+#
+# Keep these in sync with the `dependencies` lower bounds in pyproject.toml.
+numpy==1.24.0
+pandas==2.0.0
+scipy==1.10.0
+scikit-learn==1.2.0

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.11
+python_version = 3.10
 warn_return_any = True
 warn_unused_configs = True
 disallow_untyped_defs = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,7 @@ exclude_lines = [
 
 [tool.black]
 line-length = 88
-target-version = ["py310", "py311"]
+target-version = ["py310"]
 include = '\.pyi?$'
 extend-exclude = '''
 /(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "skdr-eval"
 dynamic = ["version"]
-description = "Practitioner-focused offline policy evaluation for sklearn-compatible contextual-bandit policies, with time-aware Doubly Robust (DR) and Stabilized DR (SNDR) estimators, calibrated propensities, trust diagnostics, and stakeholder evaluation cards"
+description = "Offline policy evaluation (OPE) for scikit-learn policies — time-aware doubly-robust (DR/SNDR) estimates with honest trust diagnostics and a deploy / don't-deploy verdict"
 readme = "README.md"
 license = {text = "MIT"}
 authors = [
@@ -14,6 +14,7 @@ authors = [
 keywords = [
     "offline policy evaluation",
     "ope",
+    "policy evaluation",
     "doubly robust",
     "stabilized doubly robust",
     "sndr",
@@ -29,6 +30,7 @@ keywords = [
     "service time",
     "time series",
     "scikit-learn",
+    "python",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
@@ -36,6 +38,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -45,13 +48,18 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.10,<3.15"
+# Library-grade dependency constraints (#152): lower bounds only — no exact
+# pins (``==``) and no speculative upper-bound caps. Floors are the lowest
+# versions the test suite is known to pass on (proven by the ``floor-deps``
+# CI job). The scheduled latest/pre-release CI job is the safety net that
+# justifies leaving the upper end uncapped. See DEVELOPMENT.md.
 dependencies = [
-    "numpy",
-    "pandas",
+    "numpy>=1.24",
+    "pandas>=2.0",
     "pyyaml>=5.1",
-    "scikit-learn>=1.1",
-    "scipy>=1.9",
+    "scikit-learn>=1.2",
+    "scipy>=1.10",
     "jinja2>=3.1",
     "pydantic>=2.0",
 ]
@@ -84,6 +92,7 @@ dev = [
     "coverage",
     "mypy",
     "types-PyYAML",
+    "tomli; python_version < '3.11'",
     "ruff",
     "black",
     "build",
@@ -176,7 +185,7 @@ exclude_lines = [
 
 [tool.black]
 line-length = 88
-target-version = ["py311"]
+target-version = ["py310", "py311"]
 include = '\.pyi?$'
 extend-exclude = '''
 /(
@@ -193,7 +202,7 @@ extend-exclude = '''
 '''
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.10"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true

--- a/src/skdr_eval/core.py
+++ b/src/skdr_eval/core.py
@@ -1630,7 +1630,8 @@ def _sndr_bootstrap_values(
     if w_sum > 0:
         result: np.ndarray = q_pi + (n * w_clip / w_sum) * (Y - q_hat)
         return result
-    return q_pi.copy()
+    copied: np.ndarray = q_pi.copy()
+    return copied
 
 
 def block_bootstrap_ci(

--- a/src/skdr_eval/doctor.py
+++ b/src/skdr_eval/doctor.py
@@ -124,7 +124,7 @@ class DoctorReport:
         print(self.to_text(color=use_color))
 
 
-_PYTHON_MIN: tuple[int, int] = (3, 11)
+_PYTHON_MIN: tuple[int, int] = (3, 10)
 
 
 def _check_environment() -> Check:
@@ -135,9 +135,9 @@ def _check_environment() -> Check:
             status="fail",
             message=(
                 f"Python {platform.python_version()} is below skdr-eval's "
-                f"minimum of 3.11."
+                f"minimum of 3.10."
             ),
-            fix_hint="Upgrade to Python 3.11+ (CI matrix covers 3.11-3.14).",
+            fix_hint="Upgrade to Python 3.10+ (CI matrix covers 3.10-3.14).",
             category="environment",
         )
     return Check(

--- a/src/skdr_eval/recipes/llm_reranker.py
+++ b/src/skdr_eval/recipes/llm_reranker.py
@@ -154,7 +154,8 @@ def _unit_rows(x: np.ndarray) -> np.ndarray:
     """L2-normalise each row to the unit sphere (zero rows left untouched)."""
     norms = np.linalg.norm(x, axis=1, keepdims=True)
     norms = np.where(norms > 0, norms, 1.0)
-    return x / norms
+    normalized: np.ndarray = x / norms
+    return normalized
 
 
 def make_llm_reranker_synth(

--- a/src/skdr_eval/recipes/llm_reranker.py
+++ b/src/skdr_eval/recipes/llm_reranker.py
@@ -154,8 +154,7 @@ def _unit_rows(x: np.ndarray) -> np.ndarray:
     """L2-normalise each row to the unit sphere (zero rows left untouched)."""
     norms = np.linalg.norm(x, axis=1, keepdims=True)
     norms = np.where(norms > 0, norms, 1.0)
-    normalized: np.ndarray = x / norms
-    return normalized
+    return cast("np.ndarray", x / norms)
 
 
 def make_llm_reranker_synth(

--- a/src/skdr_eval/reporting.py
+++ b/src/skdr_eval/reporting.py
@@ -33,7 +33,7 @@ import json
 import logging
 import math
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -2629,7 +2629,7 @@ def build_evaluation_artifact(
     metadata: dict[str, Any] = {
         "schema_version": SCHEMA_VERSION,
         "skdr_eval_version": _pkg_version,
-        "timestamp": datetime.now(UTC).isoformat(timespec="seconds"),
+        "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
         "evaluator": evaluator,
         "n_samples": int(n_samples),
     }

--- a/src/skdr_eval/slate/evaluate.py
+++ b/src/skdr_eval/slate/evaluate.py
@@ -127,10 +127,10 @@ def _empirical_q_hat_per_rank(
 
     if n < _MIN_IMPRESSIONS_FOR_CROSSFIT:  # nothing to hold out — use full table.
         rate = _rate(total_sum, total_cnt)
-        full: np.ndarray = np.broadcast_to(
-            rate[None, :, :], (n, slate_size, n_items)
-        ).copy()
-        return full
+        return cast(
+            "np.ndarray",
+            np.broadcast_to(rate[None, :, :], (n, slate_size, n_items)).copy(),
+        )
 
     k_folds = min(n_folds, n)
     rng = np.random.default_rng(random_state)

--- a/src/skdr_eval/slate/evaluate.py
+++ b/src/skdr_eval/slate/evaluate.py
@@ -127,7 +127,10 @@ def _empirical_q_hat_per_rank(
 
     if n < _MIN_IMPRESSIONS_FOR_CROSSFIT:  # nothing to hold out — use full table.
         rate = _rate(total_sum, total_cnt)
-        return np.broadcast_to(rate[None, :, :], (n, slate_size, n_items)).copy()
+        full: np.ndarray = np.broadcast_to(
+            rate[None, :, :], (n, slate_size, n_items)
+        ).copy()
+        return full
 
     k_folds = min(n_folds, n)
     rng = np.random.default_rng(random_state)

--- a/src/skdr_eval/trackers/__init__.py
+++ b/src/skdr_eval/trackers/__init__.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
@@ -138,7 +138,7 @@ class FileTracker:
 
     def log_metric(self, name: str, value: float, step: int | None = None) -> None:
         record: dict[str, Any] = {
-            "ts": datetime.now(UTC).isoformat(),
+            "ts": datetime.now(timezone.utc).isoformat(),
             "name": str(name),
             "value": float(value),
         }

--- a/tests/test_bootstrap_integration.py
+++ b/tests/test_bootstrap_integration.py
@@ -7,7 +7,23 @@ import pandas as pd
 from sklearn.ensemble import RandomForestRegressor
 
 import skdr_eval
-from skdr_eval.core import block_bootstrap_ci
+from skdr_eval.core import _sndr_bootstrap_values, block_bootstrap_ci
+
+
+def test_sndr_bootstrap_values_zero_weight_fallback() -> None:
+    """When the clipped weights sum to zero there is no self-normalisation to
+    apply, so the SNDR pseudo-outcomes fall back to the direct-method term
+    ``q_pi`` (a copy, leaving the input untouched)."""
+    q_pi = np.array([1.0, 2.0, 3.0])
+    w_clip = np.zeros(3)
+    Y = np.array([0.5, 0.5, 0.5])
+    q_hat = np.array([0.1, 0.2, 0.3])
+
+    out = _sndr_bootstrap_values(q_pi, w_clip, Y, q_hat)
+
+    np.testing.assert_array_equal(out, q_pi)
+    assert out is not q_pi  # returned a copy, not the original array
+
 
 # Constants for CI validation
 CI_TOLERANCE_MULTIPLIER = 2.0

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -2,8 +2,12 @@
 
 import importlib
 import re
-import tomllib
 from pathlib import Path
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
 
 import skdr_eval
 from skdr_eval import capabilities as cap_module

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import sys
+
 import numpy as np
 import pandas as pd
 
 import skdr_eval
-from skdr_eval.doctor import Check, DoctorReport, doctor
+from skdr_eval.doctor import Check, DoctorReport, _check_environment, doctor
 
 
 def _good_logs(n: int = 800):
@@ -182,3 +184,16 @@ class TestDoctorBadKwargs:
         assert any(
             "kind" in c.name.lower() or "bogus" in c.message for c in report.checks
         )
+
+
+def test_environment_check_fails_below_minimum(monkeypatch) -> None:
+    """The environment check fails when the running Python is below the
+    declared minimum. Forced here by raising the floor above the runtime so
+    the fail branch is exercised on the supported (3.10+) matrix."""
+    # ``skdr_eval.doctor`` the package attribute is shadowed by the re-exported
+    # ``doctor`` function, so reach the real module via ``sys.modules``.
+    monkeypatch.setattr(sys.modules["skdr_eval.doctor"], "_PYTHON_MIN", (3, 99))
+    check = _check_environment()
+    assert check.status == "fail"
+    assert check.category == "environment"
+    assert "below" in check.message

--- a/tests/test_slate_evaluate.py
+++ b/tests/test_slate_evaluate.py
@@ -179,3 +179,17 @@ def test_cascade_dr_qhat_is_cross_fitted_out_of_sample() -> None:
     # Out-of-sample => no leakage of the row's own click into its own q̂.
     for i in range(n):
         assert q_hat[i, 0, i] == 0.0
+
+
+def test_cascade_dr_qhat_single_impression_uses_full_table() -> None:
+    """With fewer than two impressions there is nothing to hold out, so the
+    full in-sample click-rate table is returned (broadcast over the single
+    row)."""
+    logs = pd.DataFrame({"slate": [[0, 1]], "clicks": [[1.0, 0.0]]})
+    q_hat = _empirical_q_hat_per_rank(logs, slate_size=2, n_items=3, random_state=0)
+    assert q_hat.shape == (1, 2, 3)
+    # In-sample rate: rank 0 / item 0 saw a click; rank 1 / item 1 did not.
+    assert q_hat[0, 0, 0] == 1.0
+    assert q_hat[0, 1, 1] == 0.0
+    # Unobserved (rank, item) cells stay at 0.
+    assert q_hat[0, 0, 2] == 0.0


### PR DESCRIPTION
## 📋 Description

Packaging / distribution-metadata hardening, bundled into one PR per request. Addresses four coherent, file-overlapping issues: **#123** (Python 3.10–3.14), **#152** (library-grade dependency constraints), **#144** (discoverability metadata), **#77** (citation metadata).

### Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update
- [x] 🔧 Build/CI improvements

## 🔗 Related Issues
- Closes #123
- Closes #152
- Closes #144 *(in-repo portion; GitHub description/topics is a maintainer settings action — see below)*
- Closes #77 *(in-repo portion; Zenodo DOI minting happens at the next archived release)*

## 🧪 Testing

**Test commands run (locally):**
```bash
ruff check src/ tests/ examples/         # All checks passed
ruff format --check src/ tests/ examples/ # 107 files already formatted
mypy src/skdr_eval/                       # Success: no issues (now at py310 floor)
python -m pytest -q --no-cov              # 821 passed, 3 skipped
cffconvert --validate -i CITATION.cff     # valid per schema 1.2.0
python -m build && twine check dist/*     # both artifacts PASSED (fresh toolchain)
```

**Floor-deps verification (#152), in a fresh venv:**
```bash
uv pip install -e ".[dev]" --constraint constraints-min.txt
# resolves numpy 1.24.0, pandas 2.0.0, scipy 1.10.0, scikit-learn 1.2.0 (floors held)
pytest tests/test_capabilities.py tests/test_reporting_artifact.py \
       tests/test_trackers.py tests/test_estimator_recovery_simulation.py \
       tests/test_pairwise_api.py   # 160 passed
python examples/quickstart.py        # exit 0; timestamp "...+00:00" (UTC fix verified)
```

## 📝 Changes Made

### #123 — Python 3.10–3.14
- `requires-python = ">=3.10,<3.15"`, add the `3.10` classifier, CI test matrix `3.10–3.14`.
- Backport 3.11-only usages: `datetime.UTC` → `datetime.now(timezone.utc)` (`reporting.py`, `trackers/__init__.py`); `tomllib` → `tomli` fallback in `tests/test_capabilities.py` (`tomli` added to the `dev` extra under a `python_version < '3.11'` marker).
- `ruff` / `black` / `mypy` now target `py310`, so 3.11+-only syntax is caught.

### #152 — Library-grade dependency constraints
- Lower-bounds-only scientific core: `numpy>=1.24`, `pandas>=2.0`, `scipy>=1.10`, `scikit-learn>=1.2` — no `==`, no caps.
- New `floor-deps` CI job installs the floors via `constraints-min.txt` and runs the suite; new scheduled `deps-nightly.yml` installs newest/pre-release deps (`continue-on-error`) as the no-cap safety net.
- Policy documented in `DEVELOPMENT.md`.

### #144 — Discoverability
- OPE-forward PyPI `description` + aligned `keywords`.
- Canonical GitHub description + topics recorded in `DEVELOPMENT.md`.

### #77 — Citation
- `references` block added to `CITATION.cff` (mirrors `docs/methods.md`); new `CITATION.bib`; both linked from the README.

### API Changes
- [x] No API changes

## 📚 Documentation
- [x] Updated `DEVELOPMENT.md` (Python-support + dependency-constraint + discoverability policy)
- [x] Updated `README.md` (citation files)
- [x] Updated `CHANGELOG.md`

## ✅ Checklist
- [x] Code follows the project's style guidelines; ran `ruff check`, `ruff format`, `mypy`
- [x] New and existing tests pass locally (full suite + floor-deps subset)
- [x] My commit messages follow the conventional commit format
- [x] Updated the CHANGELOG.md

## 🔍 Review Notes

### Focus Areas
- **Dependency floors** (`numpy 1.24` / `pandas 2.0` / `scipy 1.10` / `scikit-learn 1.2`): chosen as conservative, mutually-consistent, 3.10–3.11-wheel-available minimums and verified by installing under `constraints-min.txt`. The `floor-deps` CI job (on 3.10) is the authoritative check; adjust a floor + `constraints-min.txt` together if it ever fails.
- **`CITATION.cff` references** mirror the citations already in `docs/methods.md` (PSIS Pareto-k → Vehtari et al., the actual implementation source), rather than the looser list sketched in #77; only confidently-known fields are included (one DOI), validated by `cffconvert`.

### Manual follow-ups (cannot be done in a PR)
- **#144:** set the GitHub repo **description** and **topics** in repo settings (exact values recorded in `DEVELOPMENT.md`).
- **#77:** enable the GitHub→Zenodo integration and replace the `10.5281/zenodo.0000000` placeholder in `CITATION.cff`/`CITATION.bib` after the first archived release (already tracked in `docs/zenodo.md`).

## 🚀 Deployment Notes
- [x] Requires dependency updates *(raises the minimum scientific-core versions; no API change)*


---
_Generated by [Claude Code](https://claude.ai/code/session_01P214AV98cFUuQcrQk5NzFg)_