### PR TITLE
fix(pairwise): normalize elig_mask value type at ingestion (#155, #158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `skdr_eval.pairwise.LARGE_DATA_ROW_THRESHOLD` rows.
 
 ### Fixed
+- **Pairwise `elig_mask` value type normalized at ingestion** ([#155], [#158]).
+  Every eligibility consumer across `core`/`pairwise` only special-cased
+  `(list, tuple)` and silently treated any other container as "every operator
+  eligible". Two real inputs hit that fallback: a `set` mask — which
+  `validate_pairwise_inputs` explicitly permits — produced incorrect, *less
+  restrictive* eligibility (shifting `V_hat`/`SE`/`ESS`/`match_rate`, ~7% off
+  in the audit) ([#155]); and the `np.ndarray` cells that `coerce_to_pandas`
+  yields for Polars/PyArrow inputs broke the pandas-equivalence promised by #72
+  on the pairwise path ([#158]). `PairwiseDesign.from_dataframes` now
+  canonicalizes each `elig_mask` cell to a Python `list` once at ingestion
+  (`ndarray` → `tolist()`, `set`/`frozenset` → sorted, `tuple` → `list`;
+  `NaN`/`None`/scalars left untouched so the missing-mask fallback still
+  applies), so every downstream consumer is correct without patching each site.
+  Regression tests assert a `set` mask matches the identical `list` mask
+  (`standard` and `large_data` modes) and that a restrictive mask actually
+  changes `V_hat` vs all-eligible, and `test_pairwise_polars_inputs` now asserts
+  exact pandas/Polars `V_hat` equivalence.
 - **DR/SNDR importance weight now includes the target policy** ([#106]). The
   estimator computed the importance weight as `1/e(A|x)` (inverse logging
   propensity) instead of the textbook doubly-robust ratio `π(A|x)/e(A|x)`.
@@ -586,6 +603,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#70]: https://github.com/dgenio/skdr-eval/issues/70
 [#71]: https://github.com/dgenio/skdr-eval/issues/71
 [#72]: https://github.com/dgenio/skdr-eval/issues/72
+[#155]: https://github.com/dgenio/skdr-eval/issues/155
+[#158]: https://github.com/dgenio/skdr-eval/issues/158
 [#67]: https://github.com/dgenio/skdr-eval/issues/67
 [#69]: https://github.com/dgenio/skdr-eval/issues/69
 [#77]: https://github.com/dgenio/skdr-eval/issues/77

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,9 @@ addopts = [
     "--cov-report=html",
     "--cov-report=xml",
 ]
+markers = [
+    "slow: marks tests as slow to run (deselect with '-m \"not slow\"')",
+]
 
 [tool.coverage.run]
 source = ["src"]

--- a/src/skdr_eval/pairwise.py
+++ b/src/skdr_eval/pairwise.py
@@ -16,6 +16,41 @@ from .exceptions import DataValidationError
 logger = logging.getLogger("skdr_eval")
 
 
+def _normalize_elig_cell(value: Any) -> Any:
+    """Coerce an eligibility-mask cell to a canonical Python ``list``.
+
+    ``validate_pairwise_inputs`` blesses ``set`` masks (#155) and
+    ``coerce_to_pandas`` yields ``np.ndarray`` cells for Polars/PyArrow inputs
+    (#158), but every downstream eligibility consumer across ``core``/
+    ``pairwise`` only special-cases ``(list, tuple)`` (or
+    ``(list, tuple, np.ndarray)``) and silently treats anything else as "every
+    operator eligible". A validator-permitted ``set`` therefore produces
+    incorrect (less restrictive) eligibility, and an ``ndarray`` breaks the
+    pandas/Polars ``V_hat`` equivalence promised by #72. Normalizing every
+    container type to ``list`` once, here at ingestion, makes all consumers
+    correct without patching each site individually (a partial patch is worse
+    than none — it makes some paths honor the mask while others still do not).
+
+    ``ndarray`` is unpacked with ``.tolist()`` so its elements become native
+    Python scalars, matching a pandas-native list cell byte-for-byte; ``set``/
+    ``frozenset`` are sorted for a deterministic order (eligibility is
+    membership-based, so order does not affect ``V_hat``, but a stable order
+    keeps the stored design reproducible). Non-container cells (``NaN``,
+    ``None``, scalars) are returned unchanged so the existing
+    "missing mask ⇒ all eligible" fallback still applies.
+    """
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, (set, frozenset)):
+        try:
+            return sorted(value)
+        except TypeError:
+            return list(value)
+    if isinstance(value, tuple):
+        return list(value)
+    return value
+
+
 @dataclass
 class PairwiseDesign:
     """Design for pairwise (client, operator) evaluation.
@@ -72,6 +107,14 @@ class PairwiseDesign:
         # writes in estimate_propensity_pairwise would use label values as
         # positional offsets, silently corrupting data or raising IndexError.
         logs_df = logs_df.reset_index(drop=True)
+
+        # Normalize the eligibility-mask column to a canonical list once, so
+        # every downstream consumer (which already handles `list`) is correct
+        # regardless of whether the caller supplied list/tuple/set values or a
+        # frame whose object cells arrived as np.ndarray via coerce_to_pandas
+        # (Polars/PyArrow). See `_normalize_elig_cell` (#155, #158).
+        if elig_col is not None and elig_col in logs_df.columns:
+            logs_df[elig_col] = logs_df[elig_col].map(_normalize_elig_cell)
 
         # Extract feature columns
         cli_features = [col for col in logs_df.columns if col.startswith("cli_")]

--- a/src/skdr_eval/pairwise.py
+++ b/src/skdr_eval/pairwise.py
@@ -45,7 +45,13 @@ def _normalize_elig_cell(value: Any) -> Any:
         try:
             return sorted(value)
         except TypeError:
-            return list(value)
+            # Mixed / unorderable element types cannot be sorted directly.
+            # Fall back to a deterministic order keyed on ``repr`` rather than
+            # ``list(value)`` (whose iteration order is arbitrary and can vary
+            # across runs / Python versions) so the stored design stays
+            # reproducible. Order does not affect eligibility — it is
+            # membership-based — but a stable order keeps results byte-stable.
+            return sorted(value, key=repr)
     if isinstance(value, tuple):
         return list(value)
     return value

--- a/tests/sim_studies/test_elig_mask_recovery.py
+++ b/tests/sim_studies/test_elig_mask_recovery.py
@@ -36,6 +36,7 @@ import os
 
 import numpy as np
 import pandas as pd
+import pytest
 from sklearn.base import BaseEstimator, RegressorMixin
 
 from skdr_eval import evaluate_pairwise_models
@@ -152,6 +153,7 @@ def _v_hat(logs_df: pd.DataFrame, op_daily_df: pd.DataFrame, seed: int) -> float
     return float(row["V_hat"].iloc[0])
 
 
+@pytest.mark.slow
 def test_elig_mask_recovers_constrained_value_across_value_types() -> None:
     """list/set/ndarray masks all recover the analytic constrained value V*.
 

--- a/tests/sim_studies/test_elig_mask_recovery.py
+++ b/tests/sim_studies/test_elig_mask_recovery.py
@@ -1,0 +1,201 @@
+"""Eligibility-mask value-type recovery simulation (#155, #158).
+
+The equivalence tests in ``tests/test_frame_inputs.py`` prove that ``list`` /
+``set`` / ``np.ndarray`` eligibility masks agree, but agreement alone can hide a
+wrong ``list`` path. This is the ground-truth recovery proof the repo's
+statistical-integrity rules require for a change that alters eligibility
+interpretation: on a controlled pairwise DGP with an analytic *constrained*
+optimum ``V*_restricted`` (the value of routing each client to its best
+**eligible** operator), the induced-policy DR estimate recovers
+``V*_restricted`` — and does so identically whether the mask is a ``list``, a
+``set``, or an ``np.ndarray``.
+
+The DGP is deliberately eligibility-sensitive: each client's eligible set is a
+strict random subset, so the unconstrained optimum ``V*_full`` (best operator
+overall) is strictly better (lower service time) than ``V*_restricted``. An
+evaluator that ignored eligibility — the pre-fix bug, which treated
+``set``/``ndarray`` masks as "every operator eligible" — would induce the
+*unconstrained* argmin policy and pull the estimate toward ``V*_full``. So
+"closer to ``V*_restricted`` than to ``V*_full``" is simultaneously the recovery
+signal and the guard against the bug (verified to fail when the normalization is
+removed).
+
+A near-oracle outcome model (the true ``mu``, exposed as a fitted sklearn
+regressor) is used only to *induce* the policy, so the induced policy is exactly
+"best eligible operator" with an analytic value; the DR estimate itself still
+relies on the evaluator's own estimated propensities and cross-fit outcome
+model.
+
+Gated by ``SIM_REPS`` (default 10 for CI, since each rep runs a full pairwise
+evaluation; set ``SIM_REPS=50`` locally for a thorough check).
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pandas as pd
+from sklearn.base import BaseEstimator, RegressorMixin
+
+from skdr_eval import evaluate_pairwise_models
+
+SIM_REPS = int(os.environ.get("SIM_REPS", "10"))
+
+# Outcome surface: mu(client, operator) = BASE - SPREAD * (x . z). SPREAD sets
+# operator differentiation; large enough that constrained vs unconstrained
+# routing are clearly different policies.
+BASE = 50.0
+SPREAD = 8.0
+N = 2000
+N_OPS = 5
+
+
+class _OracleRegressor(RegressorMixin, BaseEstimator):
+    """Exposes the true ``mu`` as a fitted regressor (induction only).
+
+    The pairwise evaluator builds candidate-pair features as
+    ``[cli_x0, cli_x1, op_z0, op_z1]``; this returns the exact mean outcome so
+    the induced (argmin, ``direction="min"``) policy routes each client to its
+    lowest-``mu`` **eligible** operator. ``__sklearn_is_fitted__`` lets it pass
+    the evaluator's ``check_is_fitted`` guard under ``fit_models=False`` without
+    a real fit step.
+    """
+
+    def __sklearn_is_fitted__(self) -> bool:
+        return True
+
+    def fit(self, X: object, y: object = None) -> _OracleRegressor:
+        return self
+
+    def predict(self, X: object) -> np.ndarray:
+        arr = np.asarray(X, dtype=float)
+        return BASE - SPREAD * (arr[:, 0] * arr[:, 2] + arr[:, 1] * arr[:, 3])
+
+
+def _build_problem(seed: int) -> tuple[pd.DataFrame, pd.DataFrame, float, float]:
+    """Build ``(logs_df, op_daily_df, V*_restricted, V*_full)`` for one rep.
+
+    One day, ``N_OPS`` operators, continuous ``service_time`` to minimize.
+    Each client gets a strict random eligible subset (each operator eligible
+    w.p. 0.6, at least two), and is logged uniformly over that subset — so the
+    excluded operators are genuinely chosen by *other* clients, making the
+    propensity estimate sensitive to whether eligibility is honored.
+    """
+    rng = np.random.default_rng(seed)
+    x = rng.normal(size=(N, 2))  # client features
+    z = rng.normal(size=(N_OPS, 2))  # per-operator features (fixed for the day)
+    mu = BASE - SPREAD * (x @ z.T)  # (N, N_OPS) mean outcome
+
+    op_ids = [f"op_{j:03d}" for j in range(N_OPS)]
+    client_ids = [f"client_{i:06d}" for i in range(N)]
+
+    elig_bool = rng.random((N, N_OPS)) < 0.6
+    for i in range(N):
+        if elig_bool[i].sum() < 2:
+            elig_bool[i, rng.choice(N_OPS, size=2, replace=False)] = True
+
+    # Logging policy: uniform over each client's eligible set (full overlap on
+    # the eligible support, the canonical OPE recovery setup).
+    actions = np.array([rng.choice(np.flatnonzero(elig_bool[i])) for i in range(N)])
+    y = mu[np.arange(N), actions] + rng.normal(scale=1.0, size=N)
+
+    # Analytic optima. V*_restricted routes to the best *eligible* operator;
+    # V*_full to the best operator overall (always at least as good → lower).
+    masked = np.where(elig_bool, mu, np.inf)
+    best_elig = masked.argmin(axis=1)
+    v_star_restricted = float(mu[np.arange(N), best_elig].mean())
+    v_star_full = float(mu[np.arange(N), mu.argmin(axis=1)].mean())
+
+    elig_names = [[op_ids[j] for j in np.flatnonzero(elig_bool[i])] for i in range(N)]
+    logs_df = pd.DataFrame(
+        {
+            "arrival_day": "day_00",
+            "client_id": client_ids,
+            "operator_id": [op_ids[j] for j in actions],
+            "cli_x0": x[:, 0],
+            "cli_x1": x[:, 1],
+            "op_z0": z[actions, 0],
+            "op_z1": z[actions, 1],
+            "elig_mask": elig_names,
+            "service_time": y,
+        }
+    )
+    op_daily_df = pd.DataFrame(
+        {
+            "operator_id": op_ids,
+            "arrival_day": "day_00",
+            "op_z0": z[:, 0],
+            "op_z1": z[:, 1],
+        }
+    )
+    return logs_df, op_daily_df, v_star_restricted, v_star_full
+
+
+def _v_hat(logs_df: pd.DataFrame, op_daily_df: pd.DataFrame, seed: int) -> float:
+    artifact = evaluate_pairwise_models(
+        logs_df=logs_df,
+        op_daily_df=op_daily_df,
+        models={"oracle": _OracleRegressor()},
+        metric_col="service_time",
+        task_type="regression",
+        direction="min",
+        n_splits=3,
+        fit_models=False,
+        policy_train="all",
+        propensity="multinomial",
+        random_state=seed,
+    )
+    report = artifact.report
+    row = report[(report["model"] == "oracle") & (report["estimator"] == "DR")]
+    assert len(row) == 1
+    return float(row["V_hat"].iloc[0])
+
+
+def test_elig_mask_recovers_constrained_value_across_value_types() -> None:
+    """list/set/ndarray masks all recover the analytic constrained value V*.
+
+    Three checks:
+
+    1. **Eligibility sensitivity:** the DGP's constrained optimum is strictly
+       worse than the unconstrained one, so eligibility genuinely matters.
+    2. **Recovery (direction-robust):** the induced-policy DR estimate is closer
+       to ``V*_restricted`` than to ``V*_full`` (an evaluator that dropped the
+       mask would induce the unconstrained argmin and fail this), and the median
+       relative bias vs ``V*_restricted`` is small.
+    3. **Value-type equivalence:** ``list`` / ``set`` / ``np.ndarray`` masks
+       produce a byte-identical estimate, so all three recover the same V*.
+    """
+    rel_biases: list[float] = []
+    for rep, seed in enumerate(range(70_000, 70_000 + SIM_REPS)):
+        logs_df, op_daily_df, v_restricted, v_full = _build_problem(seed)
+
+        # 1. The DGP is eligibility-sensitive (restricting raises the optimum).
+        assert v_restricted > v_full + 0.5
+
+        v_list = _v_hat(logs_df, op_daily_df, seed)
+        rel_biases.append((v_list - v_restricted) / abs(v_restricted))
+
+        # 2. Recovery direction: closer to the constrained optimum than to the
+        #    unconstrained one (the pre-fix bug pulled this toward V*_full).
+        assert abs(v_list - v_restricted) < abs(v_list - v_full)
+
+        # 3. Value-type equivalence (checked on the first rep to keep the
+        #    simulation's wall-clock dominated by the recovery loop).
+        if rep == 0:
+            logs_set = logs_df.copy()
+            logs_set["elig_mask"] = logs_set["elig_mask"].map(set)
+            logs_arr = logs_df.copy()
+            logs_arr["elig_mask"] = logs_arr["elig_mask"].map(np.asarray)
+
+            v_set = _v_hat(logs_set, op_daily_df, seed)
+            v_arr = _v_hat(logs_arr, op_daily_df, seed)
+            assert v_set == v_list
+            assert v_arr == v_list
+            # Each value-type also recovers the constrained optimum.
+            assert abs(v_set - v_restricted) < abs(v_set - v_full)
+            assert abs(v_arr - v_restricted) < abs(v_arr - v_full)
+
+    # Aggregate recovery: median bias small for an extreme argmin target under
+    # the full estimated-propensity + cross-fit-outcome pipeline.
+    assert abs(float(np.median(rel_biases))) < 0.15, float(np.median(rel_biases))

--- a/tests/test_frame_inputs.py
+++ b/tests/test_frame_inputs.py
@@ -57,6 +57,22 @@ def _evaluate_pairwise(
     )
 
 
+# Eligibility feeds the DR weights, so an unhonored mask perturbs the support
+# diagnostics (ESS / match_rate / SE), not just the point estimate. Asserting
+# the full set of eligibility-sensitive report columns makes the equivalence
+# regressions harder to satisfy while still being wrong on diagnostics.
+_ELIG_SENSITIVE_COLS = ["V_hat", "SE_if", "ESS", "match_rate"]
+
+
+def _assert_pairwise_report_equiv(
+    art_a: skdr_eval.EvaluationArtifact, art_b: skdr_eval.EvaluationArtifact
+) -> None:
+    pd.testing.assert_frame_equal(
+        art_a.report[_ELIG_SENSITIVE_COLS].reset_index(drop=True),
+        art_b.report[_ELIG_SENSITIVE_COLS].reset_index(drop=True),
+    )
+
+
 class TestCoerceToPandas:
     def test_pandas_passthrough_is_identity(self) -> None:
         df = pd.DataFrame({"a": [1, 2, 3]})
@@ -133,10 +149,7 @@ def test_pairwise_polars_inputs() -> None:
     )
     art_pd = _evaluate_pairwise(logs_df, op_daily_df)
     art_pl = _evaluate_pairwise(pl.from_pandas(logs_df), pl.from_pandas(op_daily_df))
-    pd.testing.assert_series_equal(
-        art_pd.report["V_hat"].reset_index(drop=True),
-        art_pl.report["V_hat"].reset_index(drop=True),
-    )
+    _assert_pairwise_report_equiv(art_pd, art_pl)
 
 
 def _with_set_masks(logs_df: pd.DataFrame) -> pd.DataFrame:
@@ -167,10 +180,7 @@ class TestPairwiseEligMaskTypeEquivalence:
         art_set = _evaluate_pairwise(
             _with_set_masks(logs_df), op_daily_df, execution_mode=execution_mode
         )
-        pd.testing.assert_series_equal(
-            art_list.report["V_hat"].reset_index(drop=True),
-            art_set.report["V_hat"].reset_index(drop=True),
-        )
+        _assert_pairwise_report_equiv(art_list, art_set)
 
     def test_restrictive_mask_is_actually_honored(self) -> None:
         # Guard against a silent "all eligible" fallback: dropping the mask

--- a/tests/test_frame_inputs.py
+++ b/tests/test_frame_inputs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import time
 
+import numpy as np
 import pandas as pd
 import pytest
 from sklearn.ensemble import HistGradientBoostingRegressor
@@ -29,6 +30,30 @@ def _evaluate(logs: object) -> skdr_eval.EvaluationArtifact:
         n_splits=3,
         random_state=0,
         policy_train="pre_split",
+    )
+
+
+def _evaluate_pairwise(
+    logs_df: object,
+    op_daily_df: object,
+    *,
+    elig_col: str | None = "elig_mask",
+    execution_mode: str = "auto",
+) -> skdr_eval.EvaluationArtifact:
+    models = {"HGB": HistGradientBoostingRegressor(max_iter=20, random_state=0)}
+    return skdr_eval.evaluate_pairwise_models(
+        logs_df=logs_df,
+        op_daily_df=op_daily_df,
+        models=models,
+        metric_col="service_time",
+        task_type="regression",
+        direction="min",
+        n_splits=3,
+        fit_models=True,
+        policy_train="pre_split",
+        random_state=0,
+        elig_col=elig_col,
+        execution_mode=execution_mode,
     )
 
 
@@ -92,26 +117,75 @@ class TestArrowInputEquivalence:
 
 @requires_polars
 def test_pairwise_polars_inputs() -> None:
+    """Polars pairwise input must match the pandas path V_hat exactly (#158).
+
+    ``coerce_to_pandas`` turns the list-valued ``elig_mask`` cells into
+    ``np.ndarray`` via ``.to_pandas()``; the pairwise eligibility consumers are
+    sensitive to ``list`` vs ``ndarray``, so without renormalization V_hat
+    diverged from a pandas-native input (contradicting #72's equivalence
+    claim). ``PairwiseDesign.from_dataframes`` now canonicalizes the cells back
+    to ``list`` at ingestion, restoring exact equivalence.
+    """
     import polars as pl  # noqa: PLC0415
 
     logs_df, op_daily_df = skdr_eval.make_pairwise_synth(
         n_days=3, n_clients_day=120, n_ops=4, seed=3
     )
-    models = {"HGB": HistGradientBoostingRegressor(max_iter=20, random_state=0)}
-    art = skdr_eval.evaluate_pairwise_models(
-        logs_df=pl.from_pandas(logs_df),
-        op_daily_df=pl.from_pandas(op_daily_df),
-        models=models,
-        metric_col="service_time",
-        task_type="regression",
-        direction="min",
-        n_splits=3,
-        fit_models=True,
-        policy_train="pre_split",
-        random_state=0,
+    art_pd = _evaluate_pairwise(logs_df, op_daily_df)
+    art_pl = _evaluate_pairwise(pl.from_pandas(logs_df), pl.from_pandas(op_daily_df))
+    pd.testing.assert_series_equal(
+        art_pd.report["V_hat"].reset_index(drop=True),
+        art_pl.report["V_hat"].reset_index(drop=True),
     )
-    assert not art.report.empty
-    assert "V_hat" in art.report.columns
+
+
+def _with_set_masks(logs_df: pd.DataFrame) -> pd.DataFrame:
+    """Re-express each list-valued ``elig_mask`` cell as an (unordered) set."""
+    out = logs_df.copy()
+    out["elig_mask"] = out["elig_mask"].map(set)
+    return out
+
+
+class TestPairwiseEligMaskTypeEquivalence:
+    """A set-valued elig_mask must be honored identically to a list (#155).
+
+    ``validate_pairwise_inputs`` blesses ``set`` masks, but most eligibility
+    consumers only special-case ``(list, tuple)`` and silently fell back to
+    "every operator eligible" for a ``set`` — producing incorrect, less
+    restrictive eligibility. Normalizing at ingestion makes a ``set`` mask
+    produce the same V_hat as the identical mask expressed as a ``list``.
+    """
+
+    @pytest.mark.parametrize("execution_mode", ["standard", "large_data"])
+    def test_set_mask_matches_list_mask(self, execution_mode: str) -> None:
+        logs_df, op_daily_df = skdr_eval.make_pairwise_synth(
+            n_days=3, n_clients_day=120, n_ops=5, seed=7
+        )
+        art_list = _evaluate_pairwise(
+            logs_df, op_daily_df, execution_mode=execution_mode
+        )
+        art_set = _evaluate_pairwise(
+            _with_set_masks(logs_df), op_daily_df, execution_mode=execution_mode
+        )
+        pd.testing.assert_series_equal(
+            art_list.report["V_hat"].reset_index(drop=True),
+            art_set.report["V_hat"].reset_index(drop=True),
+        )
+
+    def test_restrictive_mask_is_actually_honored(self) -> None:
+        # Guard against a silent "all eligible" fallback: dropping the mask
+        # (elig_col=None ⇒ every operator eligible) must change V_hat, proving
+        # the restriction is honored rather than ignored. ~80% of operators are
+        # eligible per row in the synthetic data, so the masks are restrictive.
+        logs_df, op_daily_df = skdr_eval.make_pairwise_synth(
+            n_days=3, n_clients_day=120, n_ops=5, seed=7
+        )
+        art_restricted = _evaluate_pairwise(logs_df, op_daily_df)
+        art_all_elig = _evaluate_pairwise(logs_df, op_daily_df, elig_col=None)
+        assert not np.allclose(
+            art_restricted.report["V_hat"].to_numpy(),
+            art_all_elig.report["V_hat"].to_numpy(),
+        )
 
 
 @requires_polars
@@ -126,9 +200,9 @@ def test_polars_input_on_par_with_pandas() -> None:
     per-row conversion regression is caught without CI timing flakiness. Run
     with ``-s`` to see the reported timings.
 
-    NOTE: the *pairwise* path is intentionally not benchmarked here — its
-    list-valued ``elig_mask`` column does not round-trip faithfully through
-    Polars/PyArrow today (tracked by #158); use pandas for pairwise input.
+    NOTE: the *pairwise* path is not benchmarked here — its V_hat equivalence
+    across pandas/Polars input is covered by ``test_pairwise_polars_inputs``
+    (the list-valued ``elig_mask`` round-trip fixed in #158).
     """
     import polars as pl  # noqa: PLC0415
 

--- a/tests/test_frame_inputs.py
+++ b/tests/test_frame_inputs.py
@@ -13,6 +13,7 @@ from sklearn.ensemble import HistGradientBoostingRegressor
 import skdr_eval
 from skdr_eval._frames import coerce_to_pandas
 from skdr_eval.exceptions import DataValidationError, OptionalDependencyError
+from skdr_eval.pairwise import _normalize_elig_cell
 
 _HAS_POLARS = importlib.util.find_spec("polars") is not None
 _HAS_PYARROW = importlib.util.find_spec("pyarrow") is not None
@@ -71,6 +72,56 @@ def _assert_pairwise_report_equiv(
         art_a.report[_ELIG_SENSITIVE_COLS].reset_index(drop=True),
         art_b.report[_ELIG_SENSITIVE_COLS].reset_index(drop=True),
     )
+
+
+class TestNormalizeEligCell:
+    """`_normalize_elig_cell` canonicalizes every container type to `list`.
+
+    Unit-level coverage of each branch (the integration equivalence tests below
+    exercise the ndarray/set paths end-to-end, but the tuple branch and the
+    unorderable-set fallback are only reachable here).
+    """
+
+    def test_ndarray_becomes_list_of_python_scalars(self) -> None:
+        out = _normalize_elig_cell(np.array(["op_2", "op_5"]))
+        assert out == ["op_2", "op_5"]
+        assert isinstance(out, list)
+        assert all(isinstance(x, str) for x in out)  # tolist() → native str
+
+    def test_set_is_sorted_deterministically(self) -> None:
+        assert _normalize_elig_cell({"op_5", "op_2", "op_1"}) == [
+            "op_1",
+            "op_2",
+            "op_5",
+        ]
+
+    def test_frozenset_is_sorted_deterministically(self) -> None:
+        assert _normalize_elig_cell(frozenset({3, 1, 2})) == [1, 2, 3]
+
+    def test_unorderable_set_uses_repr_keyed_fallback(self) -> None:
+        # Mixed types are not mutually orderable (`int` vs `str` raise TypeError
+        # under `sorted`); the fallback must still be deterministic.
+        value = {1, "a", 2, "b"}
+        out = _normalize_elig_cell(value)
+        assert isinstance(out, list)
+        assert sorted(out, key=repr) == out  # deterministic, repr-keyed
+        assert set(out) == value  # no elements lost
+        # Stable across calls regardless of set construction order.
+        assert _normalize_elig_cell({"b", 2, "a", 1}) == out
+
+    def test_tuple_becomes_list(self) -> None:
+        out = _normalize_elig_cell(("op_0", "op_1"))
+        assert out == ["op_0", "op_1"]
+        assert isinstance(out, list)
+
+    def test_list_passthrough_unchanged(self) -> None:
+        value = ["op_0", "op_1"]
+        assert _normalize_elig_cell(value) is value
+
+    @pytest.mark.parametrize("value", [float("nan"), None, "scalar", 3])
+    def test_non_container_passthrough(self, value: object) -> None:
+        # Left untouched so the missing-mask "all eligible" fallback still fires.
+        assert _normalize_elig_cell(value) is value
 
 
 class TestCoerceToPandas:


### PR DESCRIPTION
## 📋 Description

Pairwise eligibility consumers across `core`/`pairwise` only special-cased `(list, tuple)` (or `(list, tuple, np.ndarray)`) and silently treated **any other container** as "every operator eligible". Two *permitted* inputs hit that silent fallback:

- **#155** — a `set` mask, which `validate_pairwise_inputs` explicitly blesses, produced **incorrect, less-restrictive** eligibility (shifting `V_hat`/`SE`/`ESS`/`match_rate`, ~7% off in the audit).
- **#158** — the `np.ndarray` cells that `coerce_to_pandas` yields for Polars/PyArrow inputs broke the pandas-equivalence promised by #72 on the **pairwise** path (the sklearn path was already equivalent).

Both are the **same root cause** — type-sensitive `elig_mask` consumption — so both issues independently recommended the **same single-point fix**: normalize the value type once at ingestion rather than patching ~8 call sites (a partial patch is worse than none).

`PairwiseDesign.from_dataframes` now canonicalizes each `elig_mask` cell to a Python `list` once: `ndarray` → `tolist()`, `set`/`frozenset` → sorted, `tuple` → `list`; `NaN`/`None`/scalars are left untouched so the existing missing-mask "all eligible" fallback still applies. Every downstream consumer already handles `list`, so all paths (`standard` + `large_data`, propensity / candidate-pair / pre-split) become correct without touching the statistical call sites.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🔗 Related Issues
- Fixes #155
- Fixes #158
- Related to #72

## 🧪 Testing

**Test commands run:**
```bash
ruff check src/ tests/ examples/        # All checks passed!
ruff format --check ...                  # 2 files already formatted
mypy src/skdr_eval/                      # Success: no issues found in 43 source files
python -m pytest tests/test_frame_inputs.py tests/test_pairwise_api.py   # 52 passed
python -m pytest                         # 895 passed, 9 skipped (full suite)
```

- [x] New and existing unit tests pass locally with my changes
- [x] Tested edge cases (`set`/`ndarray`/`tuple` cells, all-eligible baseline)

### Verified the tests catch the bug
With the normalization line disabled, the three new assertions fail (`test_pairwise_polars_inputs`, `test_set_mask_matches_list_mask[standard]`, `test_set_mask_matches_list_mask[large_data]`) with V_hat diverging 100%; they pass with the fix in place.

## 📝 Changes Made

### Code Changes
- `src/skdr_eval/pairwise.py` — add `_normalize_elig_cell` helper; apply it to the `elig_col` column in `PairwiseDesign.from_dataframes` (the sole ingestion route; downstream of `coerce_to_pandas`).
- `tests/test_frame_inputs.py` — upgrade `test_pairwise_polars_inputs` from non-emptiness to exact pandas/Polars `V_hat` equivalence (#158); add `TestPairwiseEligMaskTypeEquivalence` asserting `set` ≡ `list` in `standard` and `large_data` modes and that a restrictive mask actually changes `V_hat` vs all-eligible (#155); refresh the stale #158 caveat.
- `CHANGELOG.md` — `### Fixed` entry.

### API Changes
- [x] No API changes (behavioral bug fix only; list-mask inputs are unaffected).

## 📚 Documentation
- [x] I have updated the CHANGELOG.md
- [x] Docstrings added for the new helper. README documents only the `elig_col` *name* (unchanged); `examples/quickstart_pairwise.py` uses list masks (unaffected), so no example/README change is warranted.

## ✅ Checklist
- [x] `ruff check` and `ruff format` clean
- [x] `mypy` clean
- [x] Full suite green (895 passed, 9 skipped)
- [x] New tests fail without the fix, pass with it

## 🔍 Review Notes

### Focus Areas
- **Order sensitivity:** `set` → `sorted()` reorders elements vs the original list, but eligibility is membership-based — pair-construction order derives from `day_ops`, not from `elig_mask` order — so `V_hat` is invariant to mask order. The `set ≡ list` equivalence test confirms this empirically.
- **Statistical-logic change:** this alters eligibility (a `V_hat` input). The equivalence tests act as the proof: the already-validated `list` path is ground truth, and the fix makes `set`/`ndarray` paths reproduce it exactly while a restrictive mask provably differs from all-eligible.

https://claude.ai/code/session_01WajZY9ttk9RPs5kxyVNvaA

---
_Generated by [Claude Code](https://claude.ai/code/session_01WajZY9ttk9RPs5kxyVNvaA)_