### PR TITLE
docs: add practitioner guides, API stability policy, and estimator extension docs

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -1,0 +1,87 @@
+# What skdr-eval claims (and what it does not)
+
+A receipts-first page. Every claim below links to something you can run — a
+command, an example script, a test, or a notebook — so you can check it
+yourself rather than take our word for it. The companion non-claims section is
+just as important: it states, explicitly, what offline evaluation cannot do.
+
+## Estimator scope
+
+`skdr-eval` evaluates **one-shot contextual-bandit policies** from logged
+decisions. It ships a doubly-robust estimator family and a slate family.
+
+| Claim | Estimators | Receipt |
+|---|---|---|
+| DR and Stabilized DR (SNDR) on sklearn-compatible policies | `DR`, `SNDR` | `examples/quickstart.py`; `tests/test_dr_sndr_smoke.py` |
+| MRDR / SWITCH-DR / DRos / MIPS via a composable strategy seam | `MRDR`, `SWITCH-DR`, `DRos`, `MIPS` | `build_strategy(...)`; `tests/test_estimators_extended.py`, `tests/test_mips_api.py` |
+| Slate / top-K off-policy evaluation | `slate_standard_ips`, `pseudo_inverse_ips`, `reward_interaction_ips`, `slate_cascade_dr` | `tests/test_slate_coverage.py` |
+| Pairwise / autoscaling evaluation | `evaluate_pairwise_models` | `examples/use_cases/04_call_routing.py` |
+| Estimators recover a known ground-truth value on synthetic DGPs | all | `tests/test_estimator_recovery_simulation.py`, `tests/sim_studies/` |
+
+See [Choosing an estimator](docs/choosing-an-estimator.md) for which one to
+run and [methods](docs/methods.md) for the math.
+
+## Supported logged-data assumptions
+
+The estimates are valid under the standard OPE assumptions; they are stated,
+not hidden:
+
+- **Unconfoundedness** — the logged action's propensity is explainable from
+  the recorded context.
+- **Overlap** — the candidate policy only takes actions the logging policy
+  also took with positive probability. When this fails, `support_health`
+  reports `high_risk`.
+- **Stable data-generating process** across the log window (time-aware splits
+  and moving-block bootstrap respect the temporal correlation).
+- **Useful nuisance models** — the propensity and outcome models are not
+  arbitrarily misspecified.
+
+Receipt: the assumption tags travel with every artifact
+(`DEFAULT_ASSUMPTION_TAGS`) and are printed on the card; see
+[estimands & assumptions](docs/concepts/estimands-and-assumptions.md).
+
+## Trust diagnostics
+
+The differentiator is that `skdr-eval` tells you when **not** to trust the
+estimate. Each diagnostic has a receipt.
+
+| Diagnostic | What it catches | Receipt |
+|---|---|---|
+| `support_health` (`ok` / `caution` / `high_risk`) | poor overlap, low ESS, low match-rate | `docs/recipes/good-vs-bad-support.md`; `tests/test_diagnostics_trust.py` |
+| PSIS Pareto-k | heavy-tailed importance weights (variance may not exist) | `tests/test_diagnostics_trust.py` |
+| Effective sample size (ESS) and tail mass | a few rows dominating the estimate | `report` columns `ESS`, `tail_mass` |
+| Propensity calibration (ECE / Brier) | miscalibrated logging-policy model | `evaluate_propensity_diagnostics`; `tests/test_propensity_diagnostics.py` |
+| Clip-grid sensitivity | estimate that moves with the clip threshold | `summarize_sensitivity`; `tests/test_reporting_artifact.py` |
+| Deploy / don't-deploy verdict | turning all of the above into a decision | `EvaluationArtifact.recommendation(...)`; `tests/test_card_schema.py` |
+
+The CLI turns the verdict into a CI gate: `skdr-eval evaluate` exits with code
+`3` when any model's verdict is `do_not_deploy`.
+
+## Reproducible examples
+
+| Want to see... | Run |
+|---|---|
+| The 10-minute quickstart | `python examples/quickstart.py` |
+| Preflight on your own logs | `skdr-eval doctor your_logs.parquet --json` |
+| A good vs. bad support contrast | `python examples/use_cases/06_agent_routing_policy.py` |
+| Coming from Open Bandit Pipeline | `python examples/obp_interop.py` |
+| What a bad evaluation looks like | `make known-failures` |
+| Coverage of the bootstrap CI | `make coverage-sim` |
+
+## Non-claims (read these)
+
+- **Offline evaluation does not replace an online experiment.** A green
+  `skdr-eval` verdict is evidence that a candidate is *worth* an A/B test, not
+  proof it will win one. See the [rollout checklist](docs/rollout-checklist.md).
+- **No method can fix no-overlap logs.** If the candidate only takes actions
+  the logging policy never explored, there is no counterfactual signal in the
+  data; `skdr-eval` returns `support_health = high_risk` rather than a
+  confident number.
+- **Not for sequential / reinforcement-learning problems.** State transitions
+  and long horizons are out of scope — use SCOPE-RL or d3rlpy
+  (see [comparisons](docs/comparisons.md)).
+- **Logged propensities are reported, not consumed (yet).** `skdr-eval`
+  estimates calibrated propensities internally; first-class use of a logged
+  `pscore` is tracked in issue #167.
+- **Diagnostics are signals, not proofs.** They help you decide whether an
+  estimate is worth acting on; they do not certify it is correct.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,18 @@ We follow **GitHub Flow**: short-lived feature branches off `main`, merged back 
 - **Type hints**: All functions must have type annotations
 - **README**: Keep examples up-to-date
 - **CHANGELOG**: Document all changes
+- **Public API**: Any name added to `skdr_eval.__all__` must also be recorded
+  in [`docs/api-stability.md`](docs/api-stability.md) — a test enforces this.
+
+## 🧭 Paths to contribute
+
+- **Add an estimator** (the highest-value research contribution): start with
+  the [architecture tour](docs/architecture.md), then follow the
+  [write-your-own-estimator guide](docs/extending/add-an-estimator.md). A new
+  estimator needs a simulation proof under `tests/sim_studies/`.
+- **Improve docs / examples**: docs live in [`docs/`](docs/); runnable
+  examples in [`examples/`](examples/).
+- **Triage good-first-issues**: see the issue tracker labels.
 
 ## 🔍 Code Review Guidelines
 

--- a/README.md
+++ b/README.md
@@ -126,11 +126,16 @@ library actually gets used, and it does not require reading any theory first:
 - **Full documentation:** **[skdr-eval.readthedocs.io](https://skdr-eval.readthedocs.io/)** (built from [`docs/`](docs/) with MkDocs Material).
 - **Just want to see it work?** Click any "Open in Colab" badge above.
 - **First time here?** Follow [First 10 minutes](#first-10-minutes-understand-what-skdr-eval-does) above.
-- **Have logs already?** Skim [Quick Start](#quick-start) below; the standard / pairwise variants are both two screens long. The full workflow is the [logs → experiment-review card recipe](docs/recipes/logs-to-experiment-card.md).
+- **Have logs already?** Skim [Quick Start](#quick-start) below; the standard / pairwise variants are both two screens long. The full workflow is the [Daily Driver guide](docs/daily-driver.md) (and the [logs → experiment-review card recipe](docs/recipes/logs-to-experiment-card.md)).
 - **Not sure whether to trust an estimate?** Read the [report interpretation guide](docs/report-interpretation.md), the [metrics glossary](docs/metrics-glossary.md), and the [good-vs-bad support tutorial](docs/recipes/good-vs-bad-support.md).
-- **Comparing against another OPE library?** See [`docs/comparisons.md`](docs/comparisons.md) for OBP / SCOPE-RL / d3rlpy / banditml, and [`docs/methods.md`](docs/methods.md) for the methodological positioning.
+- **Which estimator should I run?** See the [estimator selection guide](docs/choosing-an-estimator.md).
+- **What does it actually claim?** Read [`CLAIMS.md`](CLAIMS.md) — receipts for every claim, plus the explicit non-claims.
+- **Going to production?** Work through the [production rollout checklist](docs/rollout-checklist.md) before any online test.
+- **Comparing against another OPE library?** See [`docs/comparisons.md`](docs/comparisons.md) for OBP / SCOPE-RL / d3rlpy / banditml, the [methodological positioning](docs/methods.md), and the runnable [coming-from-OBP interop guide](docs/recipes/obp-interop.md).
 - **Looking for end-to-end examples by domain?** Browse [`examples/use_cases/`](examples/use_cases/) for runnable scripts (e-commerce ranking, ad targeting, healthcare CATE, call routing, logs→card, agent routing).
-- **Evaluating an LLM reranker or an agent routing/tool-selection policy?** See [Evaluate LLM / agent policies offline](#evaluate-llm--agent-policies-offline) below.
+- **Evaluating an LLM reranker or an agent routing/tool-selection policy?** See the [agent routing & tool-selection guide](docs/agent-routing.md) and [Evaluate LLM / agent policies offline](#evaluate-llm--agent-policies-offline) below.
+- **Building a pipeline on the API?** Check the [public API, stability policy & road to 1.0](docs/api-stability.md).
+- **Want to add an estimator?** Start with the [architecture tour](docs/architecture.md) and the [write-your-own-estimator guide](docs/extending/add-an-estimator.md).
 
 > The `skdr-eval` CLI (`pip install 'skdr-eval[cli]'`) makes the same
 > evaluators reachable from a terminal — see [Command-line interface](#command-line-interface).
@@ -652,8 +657,10 @@ before an A/B test.
   print(artifact.report[["model", "estimator", "V_hat", "support_health"]])
   ```
 
-  See [`examples/use_cases/06_agent_routing_policy.py`](examples/use_cases/06_agent_routing_policy.py)
-  (healthy vs. `high_risk` support) and the
+  See the [agent routing & tool-selection guide](docs/agent-routing.md) for
+  the full conceptual walkthrough (actions, rewards, support, and when OPE is
+  the wrong tool), [`examples/use_cases/06_agent_routing_policy.py`](examples/use_cases/06_agent_routing_policy.py)
+  (healthy vs. `high_risk` support), and the
   [offline-evaluation companion guide](docs/weaver-stack.md).
 
 The trace adapter (`skdr_eval.adapters.from_records` / `from_jsonl_trace`) maps

--- a/docs/agent-routing.md
+++ b/docs/agent-routing.md
@@ -1,0 +1,115 @@
+# Evaluating agent routing and tool-selection policies offline
+
+`skdr-eval` is an offline policy evaluation library, and an LLM-agent's
+routing and tool-selection choices are exactly the kind of **one-shot logged
+decision** it was built for. If your agent stack records which tool, model, or
+route it picked and what that cost, you can ask the counterfactual question —
+*"would this candidate routing policy have done better?"* — **before** you ship
+it.
+
+This page is the conceptual landing page for that use case. The runnable
+version is
+[`examples/use_cases/06_agent_routing_policy.py`](https://github.com/dgenio/skdr-eval/blob/main/examples/use_cases/06_agent_routing_policy.py),
+and the broader story is in the
+[offline-evaluation companion guide](weaver-stack.md).
+
+!!! warning "Offline evaluation does not replace online validation."
+    A green verdict says a candidate routing policy is *worth* an online test,
+    not that it is safe to ship. And for genuinely **sequential / long-horizon**
+    agents (multi-step plans where each action changes the state the next one
+    sees), single-step OPE is the wrong tool — see the limitations below.
+
+## What a logged agent decision looks like
+
+Each logged decision is a `(context, action, outcome, time)` tuple:
+
+- **context** — request features available at decision time: prompt size,
+  detected intent, user tier, conversation length, retrieved-context size.
+- **action** — the discrete choice the agent made.
+- **outcome / reward** — what you observed afterward.
+- **time** — when the decision happened (used for time-aware splits).
+
+### Example actions
+
+- selected **tool** (search vs. calculator vs. code-exec);
+- selected **model / route** (fast-cheap vs. smart-expensive);
+- **handoff target** (which downstream agent);
+- **escalation choice** (auto-resolve vs. ask-human);
+- **policy branch** (allow / deny / ask, for a guardrail policy).
+
+### Example rewards / outcomes
+
+success, resolution, latency, cost (tokens/$), safety violation (as a
+penalty), or human-correction events. Costs work as negative rewards — lower
+is better — matching the policy-induction convention in
+`induce_policy_from_sklearn`.
+
+## What support / overlap means here
+
+The estimate is only trustworthy where the *logging* agent actually explored.
+If your production agent almost always picks `route_smart`, your logs carry
+little signal about a candidate that leans on `route_cheap` — there is no
+counterfactual evidence for the actions it would newly take. `skdr-eval`
+reports this honestly as `support_health = high_risk` rather than returning a
+confident number. A logging agent that explores (even a little ε-greedy
+jitter) keeps every route's logged probability healthy and makes offline
+evaluation possible.
+
+## How DR/SNDR diagnostics apply before rollout
+
+The workflow is the standard one (see the [Daily Driver guide](daily-driver.md)):
+
+1. Map traces to logs with `skdr_eval.adapters.from_records` /
+   `from_jsonl_trace`.
+2. Wrap the candidate routing policy as a scikit-learn-compatible model.
+3. Run `evaluate_sklearn_models` and read **support health before V̂**.
+4. Use the verdict (`deploy` / `ab_test` / `insufficient_evidence` /
+   `do_not_deploy`) to decide whether the candidate earns an online test.
+
+```python
+import skdr_eval
+
+adapted = skdr_eval.adapters.from_jsonl_trace("agent_traces.jsonl", reward_col="cost")
+artifact = skdr_eval.evaluate_sklearn_models(
+    logs=adapted.logs,
+    models={"router_v2": candidate_router},
+    y_col="cost",
+    fit_models=True,
+    policy_train="pre_split",
+)
+print(artifact.warnings[["model", "estimator", "support_health"]])
+```
+
+## Relation to the agent ecosystem
+
+In an agent stack such as the Weaver stack, the upstream components produce the
+logs this page consumes:
+
+- **contextweaver** routing logs → the `(context, action)` for model/route
+  selection;
+- **AgentFence** allow / deny / ask decisions → a guardrail-policy action with
+  a safety-violation outcome;
+- **agent-kernel** `ActionTrace` records → the per-decision trace mapped via
+  `from_records`.
+
+`skdr-eval` is the **offline evaluation layer** for those governance
+decisions — it does not run the agent or route traffic; it judges a candidate
+policy from the logs the stack already emits. See
+[weaver-stack.md](weaver-stack.md) for the end-to-end companion story.
+
+## When OPE is the wrong tool for agents
+
+- **Sequential / long-horizon plans** — when an action changes the state the
+  next action sees, you need reinforcement-learning OPE (SCOPE-RL / d3rlpy),
+  not single-step contextual-bandit DR. See [comparisons](comparisons.md).
+- **No exploration in the logs** — a near-deterministic logging agent leaves
+  no overlap; gather exploratory logs first.
+- **Reward you cannot measure offline** — if the outcome only exists after a
+  human interacts live, offline evaluation cannot estimate it.
+
+## See also
+
+- [`examples/use_cases/06_agent_routing_policy.py`](https://github.com/dgenio/skdr-eval/blob/main/examples/use_cases/06_agent_routing_policy.py)
+- [Offline-evaluation companion (Weaver stack)](weaver-stack.md)
+- [LLM-reranker OPE recipe](recipes/llm-reranker-ope.md)
+- [The Daily Driver guide](daily-driver.md)

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -1,0 +1,153 @@
+# Public API, stability policy, and the road to 1.0
+
+`skdr-eval` is pre-1.0 and the API still moves, but "pre-1.0" should not mean
+"anything can break without warning." This page is the contract: which names
+are public, how they change, how the serialized artifact/card schemas are
+versioned, and what 1.0 will require.
+
+If you are building a pipeline on `skdr-eval`, depend only on the names listed
+here. Everything else — modules and attributes prefixed with `_`, anything not
+in this inventory — is internal and may change at any time.
+
+## What "public" means
+
+The public API is exactly the set of names re-exported from the top-level
+`skdr_eval` namespace (its `__all__`), plus the two documented subpackages
+`skdr_eval.estimators` and `skdr_eval.slate` and the `skdr_eval.adapters` /
+`skdr_eval.datasets` entry points referenced in this documentation.
+
+- **Public** — importable as `skdr_eval.<name>` and listed in the inventory
+  below. Covered by the deprecation policy.
+- **Private** — any module or attribute whose name starts with `_`
+  (`skdr_eval.core` internals, `skdr_eval._simulation`, `_frames`, etc.) and
+  anything not in the inventory. No stability guarantee.
+
+A test (`tests/test_api.py::test_public_api_inventory_documents_every_export`)
+fails if a name is added to `skdr_eval.__all__` without being recorded in the
+inventory below, so this contract cannot drift silently.
+
+## Deprecation policy
+
+`skdr-eval` follows [SemVer 2.0.0](https://semver.org/). While pre-1.0 the
+project treats the **minor** version as the breaking-change signal (0.x.0),
+and applies this discipline to every public name:
+
+1. A public name slated for removal or signature change emits a
+   `DeprecationWarning` for **at least one minor release** before the change
+   lands, with the warning naming the replacement.
+2. The deprecation is recorded in `CHANGELOG.md` and the relevant
+   `RELEASE_NOTES_*.md`.
+3. The old behavior keeps working (possibly alongside the new one) for that
+   deprecation window.
+
+The precedent is the `policy_train` parameter of `evaluate_sklearn_models`:
+calling it without an explicit `policy_train` emits a `DeprecationWarning`
+pointing at the `"pre_split"` / `"all"` choices rather than silently changing
+the default. New deprecations follow that shape.
+
+## Schema versioning
+
+The serialized artifact and card carry their own version numbers, independent
+of the package version, so downstream consumers of the JSON/YAML can detect
+incompatibilities:
+
+- `skdr_eval.SCHEMA_VERSION` — version of the `EvaluationArtifact` JSON schema
+  (`ArtifactSchema`). Bumped when the serialized report/warnings/sensitivity/
+  diagnostics payload changes shape.
+- `skdr_eval.CARD_SCHEMA_VERSION` — version of the machine-readable
+  `EvaluationCard` schema.
+
+Both follow SemVer for the *payload*: a minor bump adds fields (old readers
+keep working); a major bump may remove or rename fields. The current values
+are exported as constants and embedded in every artifact's `metadata` and on
+every card.
+
+## Road to 1.0
+
+1.0 means "the public surface below is frozen under SemVer and safe to build
+production pipelines on." Concrete, trackable criteria:
+
+- [ ] First-class logged-propensity support (#167) decided in or out of the
+      1.0 surface.
+- [ ] Public API inventory frozen — no planned renames of the names below.
+- [ ] No open correctness-class bugs against the estimators or validators.
+- [ ] Every public name has a docstring rendered in the
+      [API reference](api.md) and a one-line entry here.
+- [ ] Artifact/card schema versions stable for one full minor cycle with no
+      breaking payload change.
+
+This is a living checklist; the milestone tracking it is **1.0 readiness**.
+
+## Public API inventory
+
+The names below are the supported public surface. Visualization helpers
+(`plot_*`, `create_dashboard`) are only present when the optional `[viz]`
+extra is installed.
+
+<!-- api-inventory:start -->
+
+### Top-level functions
+
+`attach_warnings` `block_bootstrap_ci` `bootstrap_confidence_interval`
+`build_design` `build_evaluation_artifact` `build_strategy` `chi_square_test`
+`create_dashboard` `create_model_ensemble` `doctor` `dr_value_with_clip`
+`dr_value_with_strategy` `embedding_sufficiency_diagnostic`
+`evaluate_external_policies` `evaluate_pairwise_models`
+`evaluate_propensity_diagnostics` `evaluate_sklearn_models`
+`evaluate_slate_models` `export_results` `fit_outcome_crossfit`
+`fit_propensity_timecal` `gate_diagnostics` `get_capabilities`
+`get_default_config` `get_model_recommendations` `induce_policy_from_sklearn`
+`kolmogorov_smirnov_test` `load_artifact_json` `load_config_from_file`
+`load_criteo_counterfactual` `load_movielens_ope` `load_obd`
+`make_pairwise_synth` `make_slate_synth` `make_synth_logs`
+`mann_whitney_u_test` `median_bandwidth` `merge_configs` `mips_value`
+`multiple_comparison_correction` `per_action_propensity_diagnostics`
+`permutation_test` `plot_calibration_curve` `plot_diagnostics_summary`
+`plot_dr_results` `plot_propensity_distribution` `plot_roc_curve`
+`power_analysis` `pseudo_inverse_ips` `render_evaluation_card`
+`reward_interaction_ips` `sample_size_calculation` `save_config_to_file`
+`simulate_autoscaling_scenario` `simulate_coverage` `slate_cascade_dr`
+`slate_standard_ips` `summarize_sensitivity` `t_test` `validate_config`
+`validate_logs` `validate_pairwise_inputs`
+
+### Classes and dataclasses
+
+`ArtifactSchema` `BaselineBlock` `Check` `ClipTransform` `ConfigManager`
+`CoverageResult` `CoverageSimBlock` `DRResult` `DRosShrinkTransform`
+`DatasetBundle` `Design` `DiagnosticGate` `DiagnosticsBlock` `DoctorReport`
+`EmbeddingSufficiencyReport` `EstimandBlock` `EstimatorStrategy`
+`EvaluationArtifact` `EvaluationCard` `EvaluationConfig` `FileTracker`
+`GateResult` `HeadlineBlock` `IdentityTransform` `MIPSTransform`
+`MRDRWeightedLoss` `MSEOutcomeLoss` `ModelConfig` `ModelEvaluator`
+`ModelFactory` `ModelSelector` `NullTracker` `OutcomeLoss` `PairwiseDesign`
+`PerActionDiagnostics` `PropensityDiagnostics` `ProvenanceBlock` `Reason`
+`Recommendation` `RecommendationPolicy` `SensitivityBlock` `SlateGroundTruth`
+`SlateResult` `StatisticalTest` `SupportHealthThresholds` `SwitchTauTransform`
+`Tracker` `TransformContext` `TrustBlock` `VisualizationConfig`
+`WeightTransform`
+
+### Exceptions
+
+`BootstrapError` `ConfigurationError` `ConvergenceError` `DataValidationError`
+`DatasetError` `EstimationError` `InsufficientDataError` `MemoryError`
+`ModelValidationError` `OptionalDependencyError` `OutcomeModelError`
+`PairwiseEvaluationError` `PolicyInductionError` `PropensityScoreError`
+`SkdrEvalError` `VersionError`
+
+### Constants
+
+`CARD_SCHEMA_VERSION` `DEFAULT_ASSUMPTION_TAGS` `DEFAULT_ESTIMAND_SUMMARY`
+`DEFAULT_ESTIMAND_TEX` `HAS_VISUALIZATION` `SCHEMA_VERSION`
+
+### Subpackages
+
+`estimators` `slate`
+
+<!-- api-inventory:end -->
+
+## See also
+
+- [API reference](api.md) — rendered docstrings for every public name.
+- [Choosing an estimator](choosing-an-estimator.md) — which estimator to run.
+- [Architecture tour](architecture.md) — how the pieces fit together.
+- `CONTRIBUTING.md` — public-name additions must update this inventory.

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -141,7 +141,7 @@ extra is installed.
 
 ### Subpackages
 
-`estimators` `slate`
+`adapters` `datasets` `estimators` `slate`
 
 <!-- api-inventory:end -->
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,108 @@
+# Architecture tour
+
+This is a contributor-facing map of how an evaluation flows through
+`skdr-eval`, one stop per module. It is the companion to the
+[write-your-own-estimator guide](extending/add-an-estimator.md): read this to
+understand the pipeline, read that to extend it.
+
+For the *public* names each stage exposes, see the
+[API stability page](api-stability.md). For the statistical invariants the
+pipeline must preserve, see `docs/agent-context/invariants.md`.
+
+## The pipeline at a glance
+
+```mermaid
+flowchart LR
+    L[logs DataFrame] --> D[build_design]
+    D --> P[fit_propensity_timecal]
+    D --> Q[fit_outcome_crossfit]
+    D --> POL[induce_policy_from_sklearn]
+    P --> E[estimator strategy<br/>dr_value_with_strategy]
+    Q --> E
+    POL --> E
+    E --> DIAG[diagnostics + warnings]
+    DIAG --> ART[EvaluationArtifact]
+    ART --> CARD[card / HTML report]
+```
+
+## Stage by stage
+
+**1. Validation — `validation.py`.** `validate_logs` /
+`validate_pairwise_inputs` are the front door for arbitrary user data: schema,
+eligibility columns, finite rewards, time ordering. `doctor.py` wraps these in
+a non-raising preflight battery (`DoctorReport`).
+
+**2. Design matrices — `core.py::build_design`.** Turns a logs frame into the
+`Design` dataclass: `X_base` (context features), `X_obs` (context + action
+one-hot), `X_phi` (propensity-model features), the action vector `A`, outcomes
+`Y`, timestamps `ts`, and the eligibility matrix `elig`.
+
+**3. Propensity nuisance — `core.py::fit_propensity_timecal`.** Cross-fitted,
+time-calibrated logging-policy propensities, respecting temporal order
+(time-series splits, not random folds). Calibration quality is later surfaced
+as ECE/Brier in the diagnostics.
+
+**4. Outcome nuisance — `core.py::fit_outcome_crossfit`.** Cross-fitted outcome
+model `q̂`. Accepts a `sample_weight` hook — this is the seam `MRDRWeightedLoss`
+uses to fit the variance-minimizing MRDR outcome model.
+
+**5. Policy induction — `core.py::induce_policy_from_sklearn`.** Converts a
+scikit-learn candidate model into a target-policy probability matrix over
+eligible actions (vectorized; fails loud on non-finite predictions per the
+invariants).
+
+**6. Estimator — `estimators/`.** The strategy seam. A
+`EstimatorStrategy(name, weight_transform, outcome_loss, self_normalised)`
+pairs a `WeightTransform` (how raw `1/π` becomes a working weight) with an
+`OutcomeLoss` (the cross-fit sample weights). `dr_value_with_strategy(...)`
+runs the DR computation and returns a `DRResult` (V̂, SE, ESS, tail mass,
+Pareto-k, …). Built-ins:
+
+| Module | Provides |
+|---|---|
+| `estimators/protocols.py` | `WeightTransform`, `OutcomeLoss`, `EstimatorStrategy`, `TransformContext` |
+| `estimators/weight_transforms.py` | `ClipTransform`, `IdentityTransform`, `SwitchTauTransform`, `DRosShrinkTransform`, `MIPSTransform` |
+| `estimators/outcome_losses.py` | `MSEOutcomeLoss`, `MRDRWeightedLoss` |
+| `estimators/core.py` | `dr_value_with_strategy` |
+| `estimators/__init__.py` | `build_strategy` (named-strategy factory) |
+| `estimators/mips.py` | `mips_value`, `embedding_sufficiency_diagnostic` |
+
+**7. Diagnostics & warnings — `diagnostics.py`, `reporting.py`.** Per-action
+propensity diagnostics, support-health classification (`ok` / `caution` /
+`high_risk`) from ESS, tail mass, match-rate, Pareto-k, and calibration, plus
+the clip-grid sensitivity sweep.
+
+**8. Artifact & card — `reporting.py`.** Everything lands in a single
+versioned `EvaluationArtifact` (`report`, `detailed`, `warnings`,
+`sensitivity`, `diagnostics`, `metadata`). It exports to JSON
+(`SCHEMA_VERSION`), HTML, and a stakeholder `EvaluationCard`
+(`CARD_SCHEMA_VERSION`) carrying the deploy/don't-deploy `Recommendation`.
+
+**9. CLI — `cli.py`.** A thin Typer wrapper exposing `doctor`,
+`validate-schema`, `evaluate`, `pairwise`, `card`, and `version`, with stable
+exit codes for CI gates (`3` = a `do_not_deploy` verdict).
+
+## Adjacent surfaces
+
+- **`adapters/`** — map external data in: the generic trace adapter
+  (`from_records`, `from_jsonl_trace`) and GBDT model wrappers.
+- **`slate/`** — the ranked-list estimator family and its synthetic generator.
+- **`pairwise.py`** — the call-routing / autoscaling layer the project grew
+  from.
+- **`datasets/`** — public-dataset loaders (`load_obd`; Criteo/MovieLens stubs).
+- **`trackers/`** — `NullTracker` / `FileTracker` plus optional MLflow / W&B /
+  Aim seams.
+
+## Where the invariants bind
+
+The statistical invariants in `docs/agent-context/invariants.md` are enforced
+at specific stages: fail-loud on non-finite predictions (stage 5), strictly
+positive matched propensities (stage 6), and the simulation-proof requirement
+for any change to estimation logic (stages 3–6). Any contribution touching
+those stages must keep the corresponding `tests/sim_studies/` proof green.
+
+## See also
+
+- [Write your own estimator](extending/add-an-estimator.md)
+- [API stability & inventory](api-stability.md)
+- [Methods (DR / SNDR)](methods.md)

--- a/docs/choosing-an-estimator.md
+++ b/docs/choosing-an-estimator.md
@@ -1,0 +1,100 @@
+# Choosing an estimator
+
+`skdr-eval` ships a family of estimators — `DR`, `SNDR`, `MRDR`, `SWITCH-DR`,
+`DRos`, `MIPS`, plus four slate estimators. This page answers the two
+questions that matter in practice: **which one should I run**, and **when
+should I care that they disagree?**
+
+If you only remember one thing: start with **SNDR**. It is the
+variance-stabilized default and the right first estimator for almost every
+contextual-bandit evaluation. Reach for the others when a specific diagnostic
+tells you to.
+
+## Decision flowchart
+
+```mermaid
+flowchart TD
+    A[Logged decisions] --> B{Ranked list / slate?}
+    B -- yes --> S[Slate estimators:<br/>slate_standard_ips,<br/>pseudo_inverse_ips,<br/>reward_interaction_ips,<br/>slate_cascade_dr]
+    B -- no --> C{Very large<br/>action space<br/>with embeddings?}
+    C -- yes --> M[MIPS]
+    C -- no --> D{Heavy-tailed<br/>importance weights?<br/>HIGH_PARETO_K / EXTREME_CLIP}
+    D -- yes --> E[SWITCH-DR or DRos]
+    D -- no --> F{Variance-dominated?<br/>low ESS}
+    F -- yes --> G[SNDR or MRDR]
+    F -- no --> H[SNDR<br/>the default]
+```
+
+## Estimator reference
+
+Each row ties the estimator to the diagnostic that exposes its characteristic
+failure mode. Claims here are no stronger than the
+[statistical validation matrix](statistical-validation-matrix.md) demonstrates.
+
+| Estimator | Assumes / does | Shines when | Failure mode | Diagnostic that guards it |
+|---|---|---|---|---|
+| **DR** | doubly-robust baseline; hard-clipped IPS weights + outcome model | overlap is healthy and you want the canonical estimate | heavy weight tails inflate variance | ESS, `tail_mass`, PSIS Pareto-k |
+| **SNDR** | self-normalized DR (default) | almost always — stabilizes the weight normalization | small residual bias from self-normalization | clip-grid sensitivity |
+| **MRDR** | more-robust DR; outcome model fit with `w²` weights to minimize DR variance | variance-dominated regimes | needs a flexible outcome model | ESS, calibration (ECE/Brier) |
+| **SWITCH-DR** | zeroes the IPS term above a weight threshold `tau` | a few extreme weights dominate | bias from the switched-off tail | `tail_mass`, sensitivity to `tau` |
+| **DRos** | optimistic shrinkage `w·λ/(w²+λ)` | heavy tails, want a smooth alternative to hard switching | bias controlled by `λ` choice | sensitivity sweep over `λ` |
+| **MIPS** | marginalizes over an action **embedding** sufficient statistic | huge action sets where direct overlap is hopeless | embedding insufficiency | `embedding_sufficiency_diagnostic` |
+
+Build any of them by name:
+
+```python
+import skdr_eval
+
+strategy = skdr_eval.build_strategy("SWITCH-DR", tau=5.0)
+# DR / SNDR / MRDR / SWITCH-DR / DRos / MIPS  (case-insensitive)
+```
+
+The high-level evaluators report DR and SNDR by default; the strategy seam
+(`skdr_eval.estimators`) is how the rest plug in — see
+[architecture](architecture.md) and the
+[write-your-own-estimator guide](extending/add-an-estimator.md).
+
+## Running several estimators at once
+
+Running more than one estimator is the cheapest robustness check you have: if
+they agree, the estimate is not an artifact of one estimator's bias profile.
+
+```python
+artifact = skdr_eval.evaluate_sklearn_models(
+    logs=logs,
+    models={"candidate": model},
+    y_col="reward",
+    fit_models=True,
+    policy_train="pre_split",
+)
+# artifact.report has one row per (model, estimator); DR and SNDR by default.
+print(artifact.report[["model", "estimator", "V_hat", "SE_if", "ESS"]])
+```
+
+## When estimators disagree
+
+Disagreement is information, not noise:
+
+- **DR vs. SNDR diverge** → the self-normalization is doing real work, which
+  points at unstable importance weights. Check ESS and `tail_mass`; consider
+  SWITCH-DR or DRos.
+- **DR/SNDR vs. MRDR diverge** → the outcome model matters more than you
+  thought. Check calibration (ECE/Brier) and the outcome-model fit.
+- **MIPS disagrees with the discrete estimators** → the embedding may not be a
+  sufficient statistic; run `embedding_sufficiency_diagnostic`.
+- **Any estimator moves sharply across the clip grid** → the estimate is
+  dominated by a handful of weights. Treat the result as low-trust regardless
+  of which estimator looks best.
+
+The honest reading of large, unexplained disagreement is "the logs do not pin
+this estimate down" — which is exactly the
+[support-health](report-interpretation.md) story.
+
+## See also
+
+- [Methods (DR / SNDR)](methods.md) — the math behind the family.
+- [Metrics glossary](metrics-glossary.md) — every diagnostic column.
+- [Slate vs pairwise vs standard](slate-vs-pairwise-vs-standard.md) — when to
+  use the slate estimators.
+- [Statistical validation matrix](statistical-validation-matrix.md) — the
+  evidence each claim rests on.

--- a/docs/daily-driver.md
+++ b/docs/daily-driver.md
@@ -1,0 +1,145 @@
+# The Daily Driver guide: logs → evaluation → decision
+
+This is the practical, end-to-end workflow for an analyst or ML team using
+`skdr-eval` as a routine pre-deployment check. It assumes you already have
+logged decisions and a candidate policy; if you are new to the concepts, read
+the [quickstart](getting-started/quickstart.md) first.
+
+The loop is always the same five stages. Each one has an off-ramp: a point
+where the honest answer might be "stop, the logs don't support this."
+
+```
+logs → 1. preflight → 2. wrap candidate → 3. evaluate → 4. read the card → 5. decide
+```
+
+## 1. Preflight your logs with `doctor`
+
+Before any estimation, check the data is even shaped for OPE. The
+[`doctor`](api.md) preflight runs a non-raising battery of schema,
+time-ordering, support, and missingness checks.
+
+```python
+import skdr_eval
+
+report = skdr_eval.doctor(logs, kind="standard", metric_col="reward")
+print(report.to_text())          # human-readable
+report_json = report.to_dict()    # machine-readable for CI
+```
+
+Or from the command line (text or `--json`):
+
+```bash
+skdr-eval doctor your_logs.parquet --json
+```
+
+**Off-ramp:** if `doctor` reports schema failures or no eligibility structure,
+fix the data before going further — a clean estimate on malformed logs is
+worse than no estimate.
+
+## 2. Wrap your candidate policy
+
+`skdr-eval` evaluates any policy you can express as a scikit-learn-compatible
+model (`fit` / `predict`). A candidate is just a dict of named models:
+
+```python
+from sklearn.ensemble import HistGradientBoostingRegressor
+
+models = {"candidate_v2": HistGradientBoostingRegressor(random_state=0)}
+```
+
+If your decisions come from agent traces or another framework rather than a
+tidy table, map them first with the
+[trace adapter](datasets.md) (`skdr_eval.adapters.from_records` /
+`from_jsonl_trace`).
+
+## 3. Run the evaluation
+
+```python
+artifact = skdr_eval.evaluate_sklearn_models(
+    logs=logs,
+    models=models,
+    y_col="reward",
+    fit_models=True,
+    n_splits=3,
+    policy_train="pre_split",   # explicit: avoids the deprecation warning
+    random_state=0,
+)
+```
+
+The returned `EvaluationArtifact` bundles everything: `artifact.report` (the
+headline V̂ / SE / ESS table), `artifact.warnings` (per-row `support_health`),
+`artifact.sensitivity` (the clip-grid sweep), and `artifact.diagnostics`
+(calibration / overlap). See the
+[metrics glossary](metrics-glossary.md) for every column.
+
+## 4. Read the card before the number
+
+The single most important habit: **check support health before you look at
+V̂.** A better-looking estimate on unsupported logs is a trap.
+
+```python
+# Per-(model, estimator) trust verdict.
+rec = artifact.recommendation("candidate_v2", estimator="SNDR")
+print(rec.verdict)   # "deploy" | "ab_test" | "do_not_deploy" | "insufficient_evidence"
+
+# Stakeholder-ready card (HTML report + machine-readable YAML/JSON).
+artifact.to_html("report.html")
+artifact.save_card("candidate_v2", estimator="SNDR", path="card.yaml")
+```
+
+Work top-down, exactly as in the
+[report interpretation guide](report-interpretation.md):
+
+1. **`support_health`** — `high_risk` means stop; the logs do not support the
+   question.
+2. **Warning codes** — `LOW_ESS`, `HIGH_PARETO_K`, `EXTREME_CLIP`,
+   `MISCAL_PROP`, … each points at a specific failure mode.
+3. **Sensitivity** — does V̂ move when the clip threshold changes? A stable
+   estimate is a trustworthy one.
+4. **Calibration & overlap** — is the propensity model believable?
+
+## 5. Make the decision
+
+Map the verdict to an action:
+
+| Verdict | What it means | Next step |
+|---|---|---|
+| `deploy` | strong, well-supported improvement | proceed to a confirmatory A/B test |
+| `ab_test` | promising and supported, uncertain magnitude | design the A/B test (see below) |
+| `insufficient_evidence` | supported but no separation from baseline | gather more logs or accept no change |
+| `do_not_deploy` | poor support or a regression | do **not** ship; fix logging/overlap first |
+
+For CI gates, the CLI exits with code `3` on any `do_not_deploy`, so a
+policy-change PR can be blocked automatically:
+
+```bash
+skdr-eval evaluate logs.parquet --model candidate_v2.pkl || echo "gate failed"
+```
+
+## When not to trust the estimate
+
+- `support_health == "high_risk"` — overlap or ESS is too low to trust V̂.
+- V̂ swings across the clip grid — the estimate is dominated by a few extreme
+  weights, not the data.
+- The propensity model is miscalibrated (`MISCAL_PROP`) — the importance
+  weights are built on a shaky base.
+- The candidate proposes actions the logging policy never took — there is no
+  counterfactual to learn from.
+
+In all of these, the right move is to improve the logs (more exploration,
+better instrumentation) — not to reach for a different estimator.
+
+## From offline evidence to an online test
+
+A good offline verdict is the *start* of validation, not the end. When the
+verdict is `deploy` or `ab_test`, move to a canary or A/B test; the
+[production rollout checklist](rollout-checklist.md) walks through sizing,
+monitoring, and rollback. Offline evaluation tells you what is *worth*
+testing online — it does not replace the test.
+
+## See also
+
+- [Report interpretation guide](report-interpretation.md)
+- [Choosing an estimator](choosing-an-estimator.md)
+- [Production rollout checklist](rollout-checklist.md)
+- [What skdr-eval claims](https://github.com/dgenio/skdr-eval/blob/main/CLAIMS.md)

--- a/docs/extending/add-an-estimator.md
+++ b/docs/extending/add-an-estimator.md
@@ -1,0 +1,154 @@
+# Write your own estimator
+
+`skdr-eval`'s estimator family is built on a strategy seam so a new
+doubly-robust variant is a small dataclass, not a fork of the core. This guide
+walks from a blank `WeightTransform` to a working, tested estimator. The
+worked code lives in
+[`examples/extending/custom_estimator.py`](https://github.com/dgenio/skdr-eval/blob/main/examples/extending/custom_estimator.py)
+and is exercised by `tests/test_extending_example.py`, so it cannot rot.
+
+Read the [architecture tour](../architecture.md) first if you have not — this
+guide assumes you know where the estimator stage sits in the pipeline.
+
+## The seam
+
+An estimator is an `EstimatorStrategy`: a named pairing of two protocols.
+
+- **`WeightTransform`** — maps the raw inverse-propensity weight `1/π` into the
+  *working* importance weight used inside the DR pseudo-outcome. It receives a
+  `TransformContext` (logging propensity `pi_obs`, the `matched` mask,
+  `policy_probs`, observed actions `A`, eligibility, …) and returns a
+  non-negative `(n,)` array with zeros on unmatched rows.
+- **`OutcomeLoss`** — emits the per-sample weights for the outcome-model
+  cross-fit. Constant weights recover ordinary MSE; `w²` recovers MRDR.
+
+Both are *structural* protocols: you do not subclass anything, you just
+implement `__call__`.
+
+## Step 1 — implement the weight transform
+
+Our example estimator, **SoftClipDR**, replaces the hard clip `min(1/π, c)`
+with a smooth saturating transform `c · tanh(w / c)`:
+
+```python
+from dataclasses import dataclass
+import numpy as np
+from skdr_eval.estimators.protocols import TransformContext
+
+
+@dataclass(frozen=True)
+class SoftClipTransform:
+    """Smooth saturating importance weight: c * tanh(w / c)."""
+
+    clip: float = 10.0
+    name: str = "soft_clip"
+
+    def __call__(self, context: TransformContext) -> np.ndarray:
+        n = context.pi_obs.shape[0]
+        pi_target_obs = context.policy_probs[np.arange(n), context.A.astype(int)]
+        w_raw = np.zeros_like(context.pi_obs, dtype=np.float64)
+        safe = context.matched & (context.pi_obs > 0)
+        w_raw[safe] = pi_target_obs[safe] / context.pi_obs[safe]
+        return self.clip * np.tanh(w_raw / self.clip)
+```
+
+The two rules the protocol requires: **non-negative output** and **zeros on
+unmatched rows** (where `matched` is `False` or `pi_obs == 0`). Everything
+else is your estimator's design.
+
+## Step 2 — pair it into a strategy
+
+```python
+from skdr_eval.estimators import EstimatorStrategy, MSEOutcomeLoss
+
+strategy = EstimatorStrategy(
+    name="SoftClipDR",                    # appears in the report 'estimator' column
+    weight_transform=SoftClipTransform(clip=10.0),
+    outcome_loss=MSEOutcomeLoss(),        # standard MSE cross-fit
+    self_normalised=False,                # True would make it self-normalized
+)
+```
+
+## Step 3 — run it through the estimator core
+
+Feed the strategy the same nuisance matrices the high-level evaluator builds:
+
+```python
+import skdr_eval
+from skdr_eval.estimators import dr_value_with_strategy
+from sklearn.ensemble import HistGradientBoostingRegressor
+
+logs, ops_all, _ = skdr_eval.make_synth_logs(n=4000, n_ops=4, seed=0)
+design = skdr_eval.build_design(logs)
+propensities, _ = skdr_eval.fit_propensity_timecal(
+    design.X_phi, design.A, design.ts, n_splits=3, random_state=0
+)
+q_hat, _ = skdr_eval.fit_outcome_crossfit(
+    design.X_obs, design.Y, n_splits=3, random_state=0
+)
+model = HistGradientBoostingRegressor(random_state=0).fit(design.X_obs, design.Y)
+policy_probs = skdr_eval.induce_policy_from_sklearn(
+    model, design.X_base, list(ops_all), design.elig
+)
+
+result = dr_value_with_strategy(
+    propensities=propensities,
+    policy_probs=policy_probs,
+    Y=design.Y,
+    q_hat=q_hat,
+    A=design.A,
+    elig=design.elig,
+    strategy=strategy,
+)
+print(result.V_hat, result.SE_if, result.ESS)
+```
+
+That is a complete, working estimator — no library edit required.
+
+## Step 4 (optional) — make it resolvable by name
+
+To let `build_strategy("SoftClipDR")` (and therefore the high-level
+evaluators) resolve your estimator, add a branch to
+`skdr_eval.estimators.build_strategy` — a one-clause library change:
+
+```python
+# in src/skdr_eval/estimators/__init__.py, inside build_strategy(...)
+if canonical == "SOFTCLIPDR":
+    return EstimatorStrategy(
+        name="SoftClipDR",
+        weight_transform=SoftClipTransform(clip=clip),
+        outcome_loss=MSEOutcomeLoss(),
+        self_normalised=False,
+    )
+```
+
+Keep the shipped estimator list curated: only add names you intend to support
+and validate. A community estimator can live in `examples/` indefinitely
+without being registered.
+
+## Step 5 — the simulation proof (required for library inclusion)
+
+Per `docs/agent-context/invariants.md`, **any change to estimation logic must
+ship a simulation that recovers a known ground-truth value.** If you are
+proposing your estimator for the library, add a proof under
+`tests/sim_studies/` that constructs a DGP with a known policy value and
+asserts your estimator recovers it within tolerance, mirroring the existing
+estimator-recovery simulations. The bar is the same one the shipped DR/SNDR/
+MRDR/SWITCH-DR/DRos estimators clear.
+
+## Checklist for a library-grade estimator
+
+- [ ] `WeightTransform` (and/or `OutcomeLoss`) implemented as a frozen
+      dataclass with a `name`.
+- [ ] Non-negative weights, zeros on unmatched rows.
+- [ ] Registered in `build_strategy` (if it should resolve by name).
+- [ ] Simulation proof in `tests/sim_studies/` recovering a known value.
+- [ ] Glossary / methods entry and a row in
+      [choosing an estimator](../choosing-an-estimator.md).
+- [ ] Public names added to the [API inventory](../api-stability.md).
+
+## See also
+
+- [Architecture tour](../architecture.md)
+- [Choosing an estimator](../choosing-an-estimator.md)
+- [API stability & inventory](../api-stability.md)

--- a/docs/extending/add-an-estimator.md
+++ b/docs/extending/add-an-estimator.md
@@ -33,7 +33,7 @@ with a smooth saturating transform `c · tanh(w / c)`:
 ```python
 from dataclasses import dataclass
 import numpy as np
-from skdr_eval.estimators.protocols import TransformContext
+from skdr_eval.estimators import TransformContext
 
 
 @dataclass(frozen=True)

--- a/docs/recipes/obp-interop.md
+++ b/docs/recipes/obp-interop.md
@@ -1,0 +1,114 @@
+# Coming from Open Bandit Pipeline (OBP)
+
+[Open Bandit Pipeline](https://github.com/st-tech/zr-obp) (OBP) is the
+reference research library for off-policy evaluation. If you already have a
+dataset prepared the OBP way — logged bandit feedback with `context`,
+`action`, `reward`, and a logged propensity `pscore` — this guide maps it onto
+the `skdr-eval` log schema, runs the same DR estimator, and shows what
+`skdr-eval` adds on top of the point estimate.
+
+For where the two libraries sit relative to each other, see
+[comparisons](../comparisons.md). This page makes that positioning *runnable*.
+
+The companion script is
+[`examples/obp_interop.py`](https://github.com/dgenio/skdr-eval/blob/main/examples/obp_interop.py).
+It runs offline on synthetic OBP-shaped feedback (no OBP dependency) and can
+also load a real Open Bandit Dataset slice with `--obd`.
+
+!!! note "OBP stays a notebook-only dependency"
+    Nothing in `skdr-eval` imports `obp`. The same-data DR cross-check against
+    `obp.ope` belongs in your own notebook behind an optional import; the
+    library and the example script never need OBP on the runtime path.
+
+## Field mapping
+
+OBP's `bandit_feedback` dict maps onto the `skdr-eval` log schema like this:
+
+| OBP term | skdr-eval log schema | Notes |
+|---|---|---|
+| `context` (`n × dim` array) | `cli_*` feature columns | one column per context dimension |
+| `action` (`n` ints) | `action` | integer action index `0..n_actions-1` |
+| `reward` (`n` floats) | `reward` (the `y_col`) | the outcome being evaluated |
+| `pscore` (`n` floats) | `propensity` | logged action probability — see below |
+| `position` | *(no equivalent)* | `skdr-eval` is single-slot; use the [slate API](../slate-vs-pairwise-vs-standard.md) for ranked lists |
+| *(none)* | `arrival_ts` | `skdr-eval` is time-aware; OBP is not |
+
+!!! warning "Logged propensities are reported, not consumed (yet)"
+    `skdr-eval` estimates its own calibrated propensities internally, so the
+    logged `pscore` is recorded by the adapter (`had_logged_propensities`) but
+    is **not** used by the DR/SNDR estimators today. First-class logged
+    propensities are tracked in issue #167. OBP, by contrast, uses `pscore`
+    directly.
+
+## Mapping the data
+
+The generic [trace adapter](../datasets.md) does the work — map each row of
+the OBP feedback dict into a record, then `from_records` produces a
+schema-valid logs frame:
+
+```python
+import skdr_eval
+
+# `feedback` is an obp-style dict: context, action, reward, pscore arrays.
+records = [
+    {
+        "context": feedback["context"][i].tolist(),
+        "action": int(feedback["action"][i]),
+        "reward": float(feedback["reward"][i]),
+        "propensity": float(feedback["pscore"][i]),
+    }
+    for i in range(len(feedback["action"]))
+]
+adapted = skdr_eval.adapters.from_records(records)
+print(adapted.had_logged_propensities)  # True — recorded, not consumed
+```
+
+## Running DR/SNDR with trust diagnostics
+
+```python
+from sklearn.ensemble import HistGradientBoostingRegressor
+
+artifact = skdr_eval.evaluate_sklearn_models(
+    logs=adapted.logs,
+    models={"hgb": HistGradientBoostingRegressor(random_state=0)},
+    fit_models=True,
+    n_splits=3,
+    random_state=0,
+    policy_train="pre_split",
+    y_col="reward",
+)
+print(artifact.report[["model", "estimator", "V_hat", "SE_if", "ESS"]])
+print(artifact.warnings[["model", "estimator", "support_health"]])
+```
+
+You get the DR and SNDR point estimates OBP would also give you — plus the
+`support_health` verdict, PSIS Pareto-k, ESS, calibration, and clip-grid
+sensitivity that turn the estimate into a *decision*.
+
+## Same-data DR cross-check (optional, in your notebook)
+
+To convince yourself the estimators agree on the shared estimand, run OBP's DR
+on the same frame in a notebook where `obp` is installed:
+
+```python
+# Notebook-only; requires `pip install obp`.
+from obp.ope import OffPolicyEvaluation, DoublyRobust
+# ... build OBP's bandit_feedback and action_dist, then compare its DR
+# estimate to artifact.report's V_hat for the DR row.
+```
+
+The point of the comparison is not a winner: it is to show the **point
+estimate is the commodity** and the trust diagnostics are what `skdr-eval`
+adds.
+
+## What's out of scope
+
+- A general-purpose OBP adapter class in the library (revisit if demand shows
+  up).
+- Benchmark MSE tables across estimators — tracked in #94.
+
+## See also
+
+- [Comparisons: OBP / SCOPE-RL / d3rlpy / banditml](../comparisons.md)
+- [Datasets, inputs & adapters](../datasets.md) — `load_obd` and the trace adapter
+- [Choosing an estimator](../choosing-an-estimator.md)

--- a/docs/rollout-checklist.md
+++ b/docs/rollout-checklist.md
@@ -1,0 +1,98 @@
+# Production rollout checklist: offline → online
+
+A green `skdr-eval` verdict means a candidate policy is *worth testing* — not
+that it is safe to ship to 100% of traffic. This checklist is the bridge from
+an offline estimate to a controlled online rollout. Work through it in order;
+each gate has a clear stop condition.
+
+!!! warning "Offline evaluation informs the rollout decision; it does not replace the online experiment."
+    Every step below assumes a confirmatory online test (canary or A/B) is
+    still on the path to full deployment. Skipping it is the single most
+    common way offline wins fail in production.
+
+## Gate 1 — Support health is `ok`
+
+Before anything else, confirm the offline estimate is even trustworthy.
+
+- [ ] `artifact.warnings` shows `support_health == "ok"` for the candidate and
+      estimator you intend to act on.
+- [ ] No `high_risk` warning codes (`POOR_OVERLAP`, `LOW_ESS` at the severe
+      threshold, `HIGH_PARETO_K ≥ 0.7`, severe `MISCAL_PROP`).
+- [ ] Match-rate is high enough that the estimate reflects the candidate's
+      actual action distribution.
+
+**Stop if** `support_health` is `high_risk`: the logs do not support the
+counterfactual. Improve logging/exploration before considering rollout.
+
+## Gate 2 — Uncertainty interval excludes "no improvement"
+
+- [ ] The confidence interval on the V̂ delta vs. baseline is on the right
+      side of zero (the candidate is better, accounting for direction —
+      lower is better for cost/latency, higher for reward).
+- [ ] The interval is *useful*, not just signed: a barely-significant interval
+      that includes a negligible effect is not a deployment case.
+- [ ] You used the influence-function SE (`SE_if`) and/or the moving-block
+      bootstrap CI (`block_bootstrap_ci`), not a naive i.i.d. interval, given
+      time-correlated logs.
+
+**Stop if** the interval includes no-improvement: treat the verdict as
+`insufficient_evidence` and gather more data.
+
+## Gate 3 — Sensitivity is stable
+
+- [ ] V̂ does not swing materially across the clip grid
+      (`artifact.sensitivity` / `summarize_sensitivity`). A decision-stable
+      estimate survives reasonable changes to the clip threshold.
+- [ ] If two estimators disagree (e.g. DR vs. SNDR), you understand why — see
+      [choosing an estimator](choosing-an-estimator.md#when-estimators-disagree).
+
+**Stop if** the estimate is an artifact of a particular clip value.
+
+## Gate 4 — Stakeholder review with the card
+
+- [ ] Generate the stakeholder card (`artifact.save_card(...)` or
+      `artifact.to_html(...)`) and review it with whoever owns the metric.
+- [ ] The card's verdict, support health, and assumptions are acceptable to
+      the decision-maker — not just the data scientist.
+- [ ] The estimand and assumption tags on the card match how the policy will
+      actually be deployed.
+
+## Gate 5 — Design the online test
+
+Use the offline estimate to size the confirmatory experiment:
+
+- [ ] Target effect size taken from the offline V̂ delta (use the conservative
+      end of the CI).
+- [ ] Per-arm sample size and expected duration computed from traffic and
+      reward variance (the statistical helpers `power_analysis` /
+      `sample_size_calculation` give a starting point).
+- [ ] Randomization unit and guardrail metrics defined.
+- [ ] Start as a **canary** (small traffic slice) before a full A/B split when
+      the action has real-world cost or safety implications.
+
+## Gate 6 — Monitoring and rollback
+
+- [ ] Primary metric and guardrail metrics instrumented for the live test.
+- [ ] Support health re-checked on *fresh* logs once the candidate is serving
+      a slice of traffic (the candidate's own decisions change the log
+      distribution).
+- [ ] Pre-committed rollback criteria: a metric threshold and a maximum
+      observation window after which a non-improving or regressing arm is
+      reverted.
+- [ ] An owner and an on-call path for the rollback.
+
+## Quick reference: verdict → rollout posture
+
+| Offline verdict | Rollout posture |
+|---|---|
+| `deploy` | Proceed to a confirmatory A/B test, then ramp. |
+| `ab_test` | Design and run an A/B test; do not ramp without it. |
+| `insufficient_evidence` | Do not roll out; collect more logs or accept status quo. |
+| `do_not_deploy` | Do not roll out; fix support/overlap or the candidate. |
+
+## See also
+
+- [The Daily Driver guide](daily-driver.md) — the workflow that produces the
+  verdict this checklist consumes.
+- [Report interpretation guide](report-interpretation.md)
+- [What skdr-eval claims](https://github.com/dgenio/skdr-eval/blob/main/CLAIMS.md) — especially the non-claims.

--- a/examples/extending/custom_estimator.py
+++ b/examples/extending/custom_estimator.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Worked example: add your own DR estimator via the strategy seam (#188).
+
+This is the runnable companion to ``docs/extending/add-an-estimator.md``. It
+implements a brand-new doubly-robust variant — **SoftClipDR** — without
+forking any library internals, by plugging a custom :class:`WeightTransform`
+into the public estimator strategy seam
+(:mod:`skdr_eval.estimators`).
+
+SoftClipDR replaces the hard clip ``min(1/pi, c)`` of plain DR with a smooth
+saturating transform ``c * tanh(w / c)``. It approaches the raw importance
+weight for small ``w`` and saturates gently at the clip ceiling ``c`` for
+heavy tails, trading a little bias for a smoother variance profile than the
+hard ``ClipTransform``.
+
+The flow mirrors what ``evaluate_sklearn_models`` does internally, but stops
+at the estimator core so the custom strategy is visible end to end:
+
+1. build the design matrices from logs (:func:`skdr_eval.build_design`);
+2. fit the cross-fitted propensity and outcome nuisances;
+3. induce a candidate policy from a scikit-learn model;
+4. evaluate it with the *custom* :class:`EstimatorStrategy` via
+   :func:`skdr_eval.estimators.dr_value_with_strategy`.
+
+Run it directly::
+
+    python examples/extending/custom_estimator.py
+
+``tests/test_extending_example.py`` imports :func:`run` and asserts the
+estimator returns a finite value on synthetic logs, so the tutorial cannot
+silently rot.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+from sklearn.ensemble import HistGradientBoostingRegressor
+
+import skdr_eval
+from skdr_eval.estimators import (
+    EstimatorStrategy,
+    MSEOutcomeLoss,
+    dr_value_with_strategy,
+)
+
+if TYPE_CHECKING:
+    # Imported for the type annotation only; the protocol is structural, so no
+    # runtime import of TransformContext is needed to implement a transform.
+    from skdr_eval.estimators.protocols import TransformContext
+
+
+@dataclass(frozen=True)
+class SoftClipTransform:
+    """A smooth saturating importance-weight transform (the new estimator).
+
+    Implements the :class:`skdr_eval.estimators.WeightTransform` protocol:
+    given a :class:`~skdr_eval.estimators.TransformContext`, return the
+    non-negative working weight vector ``w`` (shape ``(n,)``) with zeros on
+    unmatched rows.
+
+    The raw inverse-propensity weight on a matched row is
+    ``pi_target(a|x) / pi_logging(a|x)``. SoftClipDR maps it through
+    ``clip * tanh(w / clip)``: near-linear for ``w << clip`` and asymptotic to
+    ``clip`` for ``w >> clip``, so a few extreme weights can no longer
+    dominate the estimate the way an unclipped IPS weight would.
+
+    Parameters
+    ----------
+    clip : float
+        Saturation ceiling. Large values approach raw IPS; small values pull
+        the estimator toward the direct method.
+    """
+
+    clip: float = 10.0
+    name: str = "soft_clip"
+
+    def __call__(self, context: TransformContext) -> np.ndarray:
+        """Return the soft-clipped working weights for one evaluation call."""
+        if not np.isfinite(self.clip) or self.clip <= 0:
+            raise ValueError(f"clip must be positive and finite, got {self.clip!r}")
+        n = context.pi_obs.shape[0]
+        pi_target_obs = context.policy_probs[np.arange(n), context.A.astype(int)]
+        w_raw = np.zeros_like(context.pi_obs, dtype=np.float64)
+        safe = context.matched & (context.pi_obs > 0)
+        w_raw[safe] = pi_target_obs[safe] / context.pi_obs[safe]
+        return self.clip * np.tanh(w_raw / self.clip)
+
+
+def soft_clip_strategy(clip: float = 10.0) -> EstimatorStrategy:
+    """Pair :class:`SoftClipTransform` with the standard MSE outcome loss.
+
+    This is the named strategy you would register in
+    ``skdr_eval.estimators.build_strategy`` if you wanted
+    ``estimators=("SoftClipDR",)`` to resolve from the high-level evaluators
+    (see the tutorial for that one-line library diff).
+    """
+    return EstimatorStrategy(
+        name="SoftClipDR",
+        weight_transform=SoftClipTransform(clip=clip),
+        outcome_loss=MSEOutcomeLoss(),
+        self_normalised=False,
+    )
+
+
+def run(n: int = 4000, n_ops: int = 4, seed: int = 0, clip: float = 10.0) -> dict:
+    """Evaluate a candidate policy with SoftClipDR and built-in DR for contrast.
+
+    Returns a dict with both point estimates so callers (and the test) can
+    assert the custom estimator produces a finite value in the same ballpark
+    as the shipped DR estimator.
+    """
+    logs, ops_all, _ = skdr_eval.make_synth_logs(n=n, n_ops=n_ops, seed=seed)
+    design = skdr_eval.build_design(logs)
+
+    # Cross-fitted nuisances — identical to the standard pipeline.
+    propensities, _ = skdr_eval.fit_propensity_timecal(
+        design.X_phi, design.A, design.ts, n_splits=3, random_state=seed
+    )
+    q_hat, _ = skdr_eval.fit_outcome_crossfit(
+        design.X_obs, design.Y, n_splits=3, random_state=seed
+    )
+
+    # A candidate policy induced from a scikit-learn regressor.
+    model = HistGradientBoostingRegressor(random_state=seed).fit(design.X_obs, design.Y)
+    policy_probs = skdr_eval.induce_policy_from_sklearn(
+        model, design.X_base, list(ops_all), design.elig
+    )
+
+    shared = {
+        "propensities": propensities,
+        "policy_probs": policy_probs,
+        "Y": design.Y,
+        "q_hat": q_hat,
+        "A": design.A,
+        "elig": design.elig,
+    }
+    soft = dr_value_with_strategy(strategy=soft_clip_strategy(clip), **shared)
+    builtin_dr = dr_value_with_strategy(
+        strategy=skdr_eval.estimators.build_strategy("DR", clip=clip), **shared
+    )
+    return {
+        "SoftClipDR": soft.V_hat,
+        "DR": builtin_dr.V_hat,
+        "SoftClipDR_ESS": soft.ESS,
+    }
+
+
+def main() -> None:
+    """Print the SoftClipDR vs DR estimates on synthetic logs."""
+    out = run()
+    print("Custom estimator demo — SoftClipDR (smooth-clipped DR)")
+    print(
+        f"  SoftClipDR V_hat : {out['SoftClipDR']:.4f}  (ESS {out['SoftClipDR_ESS']:.0f})"
+    )
+    print(f"  built-in DR V_hat: {out['DR']:.4f}")
+    print("Both finite and close: the custom strategy is wired correctly.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/extending/custom_estimator.py
+++ b/examples/extending/custom_estimator.py
@@ -49,7 +49,7 @@ from skdr_eval.estimators import (
 if TYPE_CHECKING:
     # Imported for the type annotation only; the protocol is structural, so no
     # runtime import of TransformContext is needed to implement a transform.
-    from skdr_eval.estimators.protocols import TransformContext
+    from skdr_eval.estimators import TransformContext
 
 
 @dataclass(frozen=True)

--- a/examples/obp_interop.py
+++ b/examples/obp_interop.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Evaluate an Open Bandit Pipeline (OBP) dataset with skdr-eval (#179).
+
+Runnable companion to ``docs/recipes/obp-interop.md``. It takes logged bandit
+feedback in the shape an OBP user already has it — an
+``obp``-style ``bandit_feedback`` dict of numpy arrays (``context``,
+``action``, ``reward``, ``pscore``, ``position``, ``n_actions``) — maps each
+field onto the skdr-eval log schema via the generic trace adapter
+(:func:`skdr_eval.adapters.from_records`), and runs DR / SNDR with the full
+trust-diagnostics surface.
+
+Two data sources are supported:
+
+* ``--obd`` — load a slice of the real Open Bandit Dataset via
+  :func:`skdr_eval.load_obd` (downloads a small public mirror).
+* default — a self-contained, synthetic ``bandit_feedback`` dict so the recipe
+  runs offline and in CI with **no dependency on OBP itself**. OBP stays a
+  docs/notebook-only library; nothing here imports ``obp``.
+
+Honest note carried into the recipe: skdr-eval calibrates its own
+propensities, so the logged ``pscore`` is *reported* (the adapter records its
+presence) but not *consumed* by the estimators today. First-class logged
+propensities are tracked separately in issue #167.
+
+Run it::
+
+    python examples/obp_interop.py            # offline synthetic OBP-shaped data
+    python examples/obp_interop.py --obd       # real Open Bandit Dataset slice
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+import numpy as np
+from sklearn.ensemble import HistGradientBoostingRegressor
+
+import skdr_eval
+
+# OBP term  ->  skdr-eval log-schema column. The mapping the recipe documents.
+OBP_FIELD_MAP = {
+    "context": "cli_* feature columns (one per context dimension)",
+    "action": "action (integer index, 0..n_actions-1)",
+    "reward": "reward (the y_col / reward_col)",
+    "pscore": "propensity (reported via from_records, not consumed yet — #167)",
+    "position": "no equivalent — skdr-eval is single-slot; see the slate API",
+    "timestamp": "arrival_ts (skdr-eval is time-aware; OBP is not)",
+}
+
+
+def make_obp_bandit_feedback(
+    n: int = 5000, n_actions: int = 4, seed: int = 0
+) -> dict[str, Any]:
+    """Synthesize an ``obp``-style ``bandit_feedback`` dict of numpy arrays.
+
+    Mirrors the structure ``obp.dataset.*.obtain_batch_bandit_feedback()``
+    returns: ``context`` ``(n, dim)``, ``action`` ``(n,)``, ``reward`` ``(n,)``,
+    ``pscore`` ``(n,)`` (logged action propensity), ``position`` ``(n,)`` and
+    ``n_actions``. This is deliberately OBP's vocabulary so the field-mapping
+    step in the recipe is concrete.
+    """
+    rng = np.random.RandomState(seed)
+    context = rng.normal(size=(n, 3))
+    logits = context @ rng.normal(size=(3, n_actions))
+    probs = np.exp(logits - logits.max(axis=1, keepdims=True))
+    probs /= probs.sum(axis=1, keepdims=True)
+    action = np.array([rng.choice(n_actions, p=probs[i]) for i in range(n)])
+    pscore = probs[np.arange(n), action]
+    action_effect = (np.arange(n_actions) - 1.5) * 0.5
+    mean_reward = 1.0 + 0.6 * context[:, 0] - action_effect[action] * context[:, 1]
+    reward = mean_reward + rng.normal(scale=0.3, size=n)
+    return {
+        "context": context,
+        "action": action,
+        "reward": reward,
+        "pscore": pscore,
+        "position": np.zeros(n, dtype=int),
+        "n_actions": n_actions,
+    }
+
+
+def bandit_feedback_to_records(feedback: dict[str, Any]) -> list[dict[str, Any]]:
+    """Map an OBP ``bandit_feedback`` dict to generic trace records.
+
+    Each record carries a ``context`` (sequence of numeric features), the
+    logged ``action`` (int), the observed ``reward`` and the logged
+    ``propensity`` (OBP's ``pscore``). This is the one field-mapping step a
+    practitioner coming from OBP has to perform.
+    """
+    context = feedback["context"]
+    action = feedback["action"]
+    reward = feedback["reward"]
+    pscore = feedback["pscore"]
+    return [
+        {
+            "context": context[i].tolist(),
+            "action": int(action[i]),
+            "reward": float(reward[i]),
+            "propensity": float(pscore[i]),
+        }
+        for i in range(len(action))
+    ]
+
+
+def print_field_map() -> None:
+    """Print the OBP -> skdr-eval field-mapping table from the recipe."""
+    print("OBP field  ->  skdr-eval log schema")
+    for obp_field, skdr_col in OBP_FIELD_MAP.items():
+        print(f"  {obp_field:<10} -> {skdr_col}")
+
+
+def evaluate_records(records: list[dict[str, Any]]) -> skdr_eval.EvaluationArtifact:
+    """Adapt generic records to logs and evaluate a candidate policy."""
+    adapted = skdr_eval.adapters.from_records(records)
+    print(
+        f"\nlogged propensities present: {adapted.had_logged_propensities} "
+        "(reported, not consumed — see #167)"
+    )
+    models = {"hgb": HistGradientBoostingRegressor(random_state=0)}
+    return skdr_eval.evaluate_sklearn_models(
+        logs=adapted.logs,
+        models=models,
+        fit_models=True,
+        n_splits=3,
+        random_state=0,
+        policy_train="pre_split",
+        y_col="reward",
+    )
+
+
+def run_synthetic() -> skdr_eval.EvaluationArtifact:
+    """Evaluate a candidate policy on offline OBP-shaped synthetic feedback."""
+    feedback = make_obp_bandit_feedback()
+    return evaluate_records(bandit_feedback_to_records(feedback))
+
+
+def run_obd_slice(max_rows: int = 4000) -> skdr_eval.EvaluationArtifact:
+    """Load a slice of the real Open Bandit Dataset and evaluate a candidate."""
+    bundle = skdr_eval.load_obd(max_rows=max_rows)
+    models = {"hgb": HistGradientBoostingRegressor(random_state=0)}
+    return skdr_eval.evaluate_sklearn_models(
+        logs=bundle.logs,
+        models=models,
+        fit_models=True,
+        n_splits=3,
+        random_state=0,
+        policy_train="pre_split",
+    )
+
+
+def main() -> None:
+    """Run the interop demo and print the headline report + trust verdict."""
+    parser = argparse.ArgumentParser(description="OBP -> skdr-eval interop demo")
+    parser.add_argument(
+        "--obd",
+        action="store_true",
+        help="Use the real Open Bandit Dataset via load_obd (downloads a slice).",
+    )
+    args = parser.parse_args()
+
+    print_field_map()
+    artifact = run_obd_slice() if args.obd else run_synthetic()
+
+    print("\nHeadline report (skdr-eval adds trust diagnostics on top of DR/SNDR):")
+    cols = [
+        c
+        for c in ("model", "estimator", "V_hat", "SE_if", "ESS")
+        if c in artifact.report.columns
+    ]
+    print(artifact.report[cols].to_string(index=False))
+    print("\nsupport_health per row:")
+    print(
+        artifact.warnings[["model", "estimator", "support_health"]].to_string(
+            index=False
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,7 +60,11 @@ plugins:
 markdown_extensions:
   - admonition
   - pymdownx.details
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.arithmatex:
@@ -79,20 +83,30 @@ nav:
   - Concepts:
       - Estimands & assumptions: concepts/estimands-and-assumptions.md
       - Methods (DR / SNDR): methods.md
+      - Choosing an estimator: choosing-an-estimator.md
       - Metrics glossary: metrics-glossary.md
       - Reading the report: report-interpretation.md
       - Statistical validation matrix: statistical-validation-matrix.md
+  - Guides:
+      - The Daily Driver workflow: daily-driver.md
+      - Production rollout checklist: rollout-checklist.md
   - Recipes:
       - Logs → experiment-review card: recipes/logs-to-experiment-card.md
       - Good vs bad support: recipes/good-vs-bad-support.md
       - LLM-reranker OPE: recipes/llm-reranker-ope.md
+      - Coming from Open Bandit Pipeline: recipes/obp-interop.md
       - Datasets, inputs & adapters: datasets.md
   - Comparisons:
       - vs OBP / SCOPE-RL / d3rlpy: comparisons.md
       - Slate vs pairwise vs standard: slate-vs-pairwise-vs-standard.md
   - Ecosystem:
       - Offline-evaluation companion: weaver-stack.md
+      - Agent routing & tool selection: agent-routing.md
+  - Contributing:
+      - Architecture tour: architecture.md
+      - Write your own estimator: extending/add-an-estimator.md
   - Project:
       - Launch readiness checklist: LAUNCH_CHECKLIST.md
+      - API stability & road to 1.0: api-stability.md
       - Citing & DOI: zenodo.md
   - API reference: api.md

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,9 @@
 """Test API imports and basic functionality."""
 
 import logging
+import re
 import warnings
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -613,3 +615,66 @@ def test_evaluate_sklearn_models_new_public_symbols_importable() -> None:
     assert hasattr(skdr_eval, "gate_diagnostics")
     assert hasattr(skdr_eval, "simulate_coverage")
     assert hasattr(skdr_eval, "CoverageResult")
+
+
+# --------------------------------------------------------------------------- #
+# Public API inventory drift guard (#180)                                     #
+# --------------------------------------------------------------------------- #
+
+_API_DOC = Path(__file__).resolve().parents[1] / "docs" / "api-stability.md"
+_INVENTORY_RE = re.compile(
+    r"<!--\s*api-inventory:start\s*-->(.*?)<!--\s*api-inventory:end\s*-->",
+    re.DOTALL,
+)
+_NAME_RE = re.compile(r"`([A-Za-z_][A-Za-z0-9_]*)`")
+
+
+def _documented_public_names() -> set[str]:
+    """Extract the public-name inventory listed in ``docs/api-stability.md``."""
+    text = _API_DOC.read_text(encoding="utf-8")
+    match = _INVENTORY_RE.search(text)
+    assert match is not None, (
+        "docs/api-stability.md must contain an "
+        "<!-- api-inventory:start --> / <!-- api-inventory:end --> region."
+    )
+    return set(_NAME_RE.findall(match.group(1)))
+
+
+def test_public_api_inventory_documents_every_export() -> None:
+    """#180: every name in ``skdr_eval.__all__`` is listed in the stability doc.
+
+    This is the drift guard: adding a public name to ``skdr_eval.__all__``
+    without recording it in ``docs/api-stability.md`` fails this test, so the
+    documented stability contract cannot silently fall behind the namespace.
+    """
+    documented = _documented_public_names()
+    exported = {n for n in skdr_eval.__all__ if not n.startswith("__")}
+    undocumented = exported - documented
+    assert not undocumented, (
+        "These public names are exported from skdr_eval.__all__ but are not "
+        "listed in docs/api-stability.md (add them to the api-inventory "
+        f"region): {sorted(undocumented)}"
+    )
+
+
+def test_public_api_inventory_has_no_stale_entries() -> None:
+    """#180: every documented core name still exists on the package.
+
+    Visualization helpers are gated behind the optional ``[viz]`` extra, so
+    they may legitimately be documented but absent from ``__all__`` in a
+    minimal install; they are exempt from the staleness check.
+    """
+    documented = _documented_public_names()
+    viz_only = {
+        "create_dashboard",
+        "plot_calibration_curve",
+        "plot_diagnostics_summary",
+        "plot_dr_results",
+        "plot_propensity_distribution",
+        "plot_roc_curve",
+    }
+    stale = {name for name in documented - viz_only if not hasattr(skdr_eval, name)}
+    assert not stale, (
+        "These names are documented in docs/api-stability.md but are not "
+        f"importable from skdr_eval (remove or fix): {sorted(stale)}"
+    )

--- a/tests/test_extending_example.py
+++ b/tests/test_extending_example.py
@@ -1,0 +1,52 @@
+"""Verify the "write your own estimator" tutorial stays runnable (#188).
+
+``docs/extending/add-an-estimator.md`` promises that following the worked
+example produces a working estimator. This test executes that example
+(``examples/extending/custom_estimator.py``) so the guide cannot rot silently:
+if the strategy seam changes shape, this fails alongside the library tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+_EXAMPLE = (
+    Path(__file__).resolve().parents[1]
+    / "examples"
+    / "extending"
+    / "custom_estimator.py"
+)
+
+
+@pytest.fixture(scope="module")
+def custom_estimator_module():
+    """Import the tutorial example script as a module."""
+    spec = importlib.util.spec_from_file_location("custom_estimator", _EXAMPLE)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["custom_estimator"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_custom_estimator_runs_and_is_finite(custom_estimator_module):
+    """The SoftClipDR tutorial estimator returns a finite value."""
+    out = custom_estimator_module.run(n=2000, n_ops=4, seed=0)
+    assert np.isfinite(out["SoftClipDR"])
+    assert np.isfinite(out["DR"])
+    assert out["SoftClipDR_ESS"] > 0
+
+
+def test_custom_estimator_close_to_builtin_dr(custom_estimator_module):
+    """SoftClipDR tracks built-in DR on well-supported synthetic logs.
+
+    The smooth clip only reshapes heavy-tail weights, so on synthetic logs
+    with healthy overlap the two estimates must land in the same ballpark.
+    """
+    out = custom_estimator_module.run(n=4000, n_ops=4, seed=0)
+    assert abs(out["SoftClipDR"] - out["DR"]) < 0.5 * abs(out["DR"])

--- a/tests/test_extending_example.py
+++ b/tests/test_extending_example.py
@@ -26,8 +26,16 @@ _EXAMPLE = (
 @pytest.fixture(scope="module")
 def custom_estimator_module():
     """Import the tutorial example script as a module."""
+    assert _EXAMPLE.exists(), (
+        f"Tutorial example not found at {_EXAMPLE}. The 'write your own "
+        "estimator' guide points here; if the file moved, update _EXAMPLE "
+        "and docs/extending/add-an-estimator.md together."
+    )
     spec = importlib.util.spec_from_file_location("custom_estimator", _EXAMPLE)
-    assert spec is not None and spec.loader is not None
+    assert spec is not None and spec.loader is not None, (
+        f"Could not build an import spec for {_EXAMPLE}; it must be an "
+        "importable Python module."
+    )
     module = importlib.util.module_from_spec(spec)
     sys.modules["custom_estimator"] = module
     spec.loader.exec_module(module)

--- a/tests/test_obp_interop_example.py
+++ b/tests/test_obp_interop_example.py
@@ -1,0 +1,75 @@
+"""Verify the OBP-interop example stays runnable (#179).
+
+``docs/recipes/obp-interop.md`` and ``examples/obp_interop.py`` promise that a
+practitioner coming from Open Bandit Pipeline can map an ``obp``-style
+``bandit_feedback`` dict onto skdr-eval logs and evaluate a candidate policy,
+with **no runtime dependency on OBP**. This test executes that example so the
+recipe cannot rot silently: if the public ingestion/evaluation surface
+(``skdr_eval.adapters.from_records``, ``evaluate_sklearn_models``) changes
+shape, this fails alongside the library tests.
+
+Mirrors ``tests/test_extending_example.py`` (#188), which guards the sibling
+``custom_estimator.py`` example the same way.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+
+_EXAMPLE = Path(__file__).resolve().parents[1] / "examples" / "obp_interop.py"
+
+
+def _load_example():
+    """Import the OBP-interop example script as a module."""
+    assert _EXAMPLE.exists(), (
+        f"OBP-interop example not found at {_EXAMPLE}. docs/recipes/obp-interop.md "
+        "points here; if the file moved, update this test and the recipe together."
+    )
+    spec = importlib.util.spec_from_file_location("obp_interop", _EXAMPLE)
+    assert spec is not None and spec.loader is not None, (
+        f"Could not build an import spec for {_EXAMPLE}; it must be an "
+        "importable Python module."
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["obp_interop"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_obp_interop_imports_without_obp() -> None:
+    """The example must import with no runtime dependency on ``obp`` (#179)."""
+    assert "obp" not in sys.modules
+    module = _load_example()
+    assert "obp" not in sys.modules, (
+        "examples/obp_interop.py imported `obp` at runtime; the recipe promises "
+        "no runtime OBP dependency."
+    )
+    assert hasattr(module, "OBP_FIELD_MAP") and module.OBP_FIELD_MAP
+
+
+def test_field_mapping_produces_generic_records() -> None:
+    """The one field-mapping step yields the generic record schema."""
+    module = _load_example()
+    feedback = module.make_obp_bandit_feedback(n=200, n_actions=4, seed=0)
+    records = module.bandit_feedback_to_records(feedback)
+    assert len(records) == 200
+    assert set(records[0]) == {"context", "action", "reward", "propensity"}
+
+
+def test_obp_interop_evaluates_to_finite_headline() -> None:
+    """Records map onto logs and evaluate to a finite DR headline.
+
+    Exercises the full public ingestion + evaluation path the recipe relies on
+    (``adapters.from_records`` -> ``evaluate_sklearn_models``) at a small scale.
+    """
+    module = _load_example()
+    feedback = module.make_obp_bandit_feedback(n=900, n_actions=4, seed=0)
+    artifact = module.evaluate_records(module.bandit_feedback_to_records(feedback))
+
+    assert "V_hat" in artifact.report.columns
+    assert np.isfinite(artifact.report["V_hat"]).all()
+    assert "support_health" in artifact.warnings.columns


### PR DESCRIPTION
Implements the documentation suite spanning #160, #162, #163, #165, #179,
#180, #181, #188:

- CLAIMS.md: receipts-first claims and explicit non-claims (#162)
- docs/daily-driver.md: logs -> evaluation -> decision workflow (#163)
- docs/rollout-checklist.md: offline-to-online validation gates (#165)
- docs/recipes/obp-interop.md + examples/obp_interop.py: OBP interop with a
  field-mapping table; no runtime dependency on OBP (#179)
- docs/api-stability.md: public API inventory (137 names), deprecation and
  schema-versioning policy, and the road to 1.0; guarded by a drift test in
  tests/test_api.py that fails on undocumented additions to __all__ (#180)
- docs/choosing-an-estimator.md: Mermaid decision flowchart and a
  per-estimator failure-mode table (#181)
- docs/architecture.md, docs/extending/add-an-estimator.md,
  examples/extending/custom_estimator.py (SoftClipDR) and
  tests/test_extending_example.py verifying the worked estimator (#188)
- docs/agent-routing.md: agent routing / tool-selection landing page (#160)

Wire the new pages into the mkdocs nav (with a Mermaid superfence) and
cross-link them from README and CONTRIBUTING. CLAIMS.md lives at the repo
root per the issue title; docs-site pages reference it via its GitHub URL so
`mkdocs build --strict` stays green.

https://claude.ai/code/session_01KTVxgq6jBDNxfz6BAmDiwh