### PR TITLE
fix: isolate conditional-logit RNG from global NumPy state (#193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -277,6 +277,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of pure-Python nested loops. Outputs are unchanged (parity asserted
   against the reference implementation in `tests/test_slate_vectorization.py`);
   large-catalogue runs are dramatically faster.
+- **Conditional-logit RNG is now isolated from the global NumPy state**
+  ([#193]). `fit_conditional_logit`, `sample_negative_pairs`, and
+  `fit_conditional_logit_with_sampling` use a local `np.random.default_rng(...)`
+  instead of the process-global `np.random.seed(...)`, so fitting no longer
+  silently reseeds a caller's RNG or interferes with concurrent evaluations.
+  `random_state` now also accepts an `np.random.Generator` or `None` in
+  addition to an integer seed. Results remain deterministic for a given integer
+  `random_state`; only the exact initialization draw sequence shifts (a
+  numerical, not behavioural, change), so a previously pinned numeric snapshot
+  may move at the last digits.
 
 ## [0.10.0] - 2026-05-29
 
@@ -841,6 +851,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#27]: https://github.com/dgenio/skdr-eval/issues/27
 [#28]: https://github.com/dgenio/skdr-eval/issues/28
 [#30]: https://github.com/dgenio/skdr-eval/issues/30
+[#193]: https://github.com/dgenio/skdr-eval/issues/193
 [#196]: https://github.com/dgenio/skdr-eval/issues/196
 [#197]: https://github.com/dgenio/skdr-eval/issues/197
 [#235]: https://github.com/dgenio/skdr-eval/issues/235

--- a/src/skdr_eval/choice.py
+++ b/src/skdr_eval/choice.py
@@ -7,9 +7,12 @@ import numpy as np
 
 logger = logging.getLogger("skdr_eval")
 
-# Accepted seed types for the local ``numpy`` Generator. Mirrors what
-# ``np.random.default_rng`` accepts: an integer seed, an existing Generator
-# (passed through unchanged), or ``None`` for non-deterministic seeding.
+# Accepted seed types for the local ``numpy`` Generator. This is the subset of
+# what ``np.random.default_rng`` accepts that this API documents and tests: an
+# integer seed, an existing Generator (passed through unchanged), or ``None``
+# for non-deterministic seeding. ``default_rng`` also accepts other forms
+# (e.g. ``SeedSequence``, ``BitGenerator``, array-like seeds), which still work
+# at runtime but are outside this annotation.
 RandomStateLike: TypeAlias = int | np.random.Generator | None
 
 # Try to import scipy, but make it optional

--- a/src/skdr_eval/choice.py
+++ b/src/skdr_eval/choice.py
@@ -1,10 +1,16 @@
 """Conditional logit model for propensity estimation."""
 
 import logging
+from typing import TypeAlias
 
 import numpy as np
 
 logger = logging.getLogger("skdr_eval")
+
+# Accepted seed types for the local ``numpy`` Generator. Mirrors what
+# ``np.random.default_rng`` accepts: an integer seed, an existing Generator
+# (passed through unchanged), or ``None`` for non-deterministic seeding.
+RandomStateLike: TypeAlias = int | np.random.Generator | None
 
 # Try to import scipy, but make it optional
 try:
@@ -24,7 +30,7 @@ def fit_conditional_logit(
     y: np.ndarray,
     l2: float = 1.0,
     maxiter: int = 200,
-    random_state: int = 0,
+    random_state: RandomStateLike = 0,
 ) -> tuple[np.ndarray, float, float]:
     """Fit conditional logit model using scipy optimization.
 
@@ -40,8 +46,10 @@ def fit_conditional_logit(
         L2 regularization strength
     maxiter : int
         Maximum optimization iterations
-    random_state : int
-        Random seed for initialization
+    random_state : int, np.random.Generator, or None
+        Seed for the local Generator used to initialize the optimizer. Using a
+        local Generator (instead of the global ``np.random`` state) keeps the
+        fit reproducible and isolated from any other RNG use in the process.
 
     Returns
     -------
@@ -57,11 +65,11 @@ def fit_conditional_logit(
             "SciPy is required for conditional logit. Install with: pip install skdr-eval[choice]"
         )
 
-    np.random.seed(random_state)
+    rng = np.random.default_rng(random_state)
     n_features = X.shape[1]
 
     # Initialize parameters
-    initial_params = np.random.normal(0, 0.01, n_features + 1)  # +1 for intercept
+    initial_params = rng.normal(0, 0.01, n_features + 1)  # +1 for intercept
 
     def objective(params: np.ndarray) -> float:
         coef = params[:-1]
@@ -234,7 +242,7 @@ def sample_negative_pairs(
     choice_ids: np.ndarray,
     y: np.ndarray,
     neg_per_pos: int = 5,
-    random_state: int = 0,
+    random_state: RandomStateLike = 0,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Sample negative pairs to reduce computational cost.
 
@@ -248,8 +256,10 @@ def sample_negative_pairs(
         Binary outcomes
     neg_per_pos : int
         Number of negative samples per positive
-    random_state : int
-        Random seed
+    random_state : int, np.random.Generator, or None
+        Seed for the local Generator used to draw negative samples. Using a
+        local Generator keeps sampling reproducible and isolated from the
+        global ``np.random`` state.
 
     Returns
     -------
@@ -260,7 +270,7 @@ def sample_negative_pairs(
     y_sampled : np.ndarray
         Sampled outcomes
     """
-    np.random.seed(random_state)
+    rng = np.random.default_rng(random_state)
 
     sampled_indices = []
     unique_choice_ids = np.unique(choice_ids)
@@ -280,7 +290,7 @@ def sample_negative_pairs(
         # Sample negatives
         if len(neg_indices) > 0:
             n_neg_to_sample = min(len(neg_indices), len(pos_indices) * neg_per_pos)
-            sampled_neg = np.random.choice(neg_indices, n_neg_to_sample, replace=False)
+            sampled_neg = rng.choice(neg_indices, n_neg_to_sample, replace=False)
             sampled_indices.extend(sampled_neg)
 
     sampled_indices_array = np.array(sampled_indices)
@@ -299,7 +309,7 @@ def fit_conditional_logit_with_sampling(
     neg_per_pos: int = 5,
     l2: float = 1.0,
     maxiter: int = 200,
-    random_state: int = 0,
+    random_state: RandomStateLike = 0,
 ) -> tuple[np.ndarray, float, float]:
     """Fit conditional logit with negative sampling for efficiency.
 
@@ -317,8 +327,10 @@ def fit_conditional_logit_with_sampling(
         L2 regularization strength
     maxiter : int
         Maximum optimization iterations
-    random_state : int
-        Random seed
+    random_state : int, np.random.Generator, or None
+        Seed for the local Generators used for negative sampling and optimizer
+        initialization. Passing a Generator threads a single stream through both
+        steps; passing an integer seeds each step reproducibly.
 
     Returns
     -------

--- a/tests/test_propensity_choice.py
+++ b/tests/test_propensity_choice.py
@@ -458,5 +458,44 @@ def test_fit_conditional_logit_recovers_ground_truth():
     np.testing.assert_allclose(coef, beta, atol=0.2)
 
 
+def test_fit_conditional_logit_with_sampling_threads_generator():
+    """A ``Generator`` is threaded as one stream through sampling + init.
+
+    ``fit_conditional_logit_with_sampling`` passes ``random_state`` to both
+    ``sample_negative_pairs`` and ``fit_conditional_logit``. The docstring
+    promises that passing a ``Generator`` threads a single stream through both
+    steps (it is advanced, not reset/reused). This verifies that contract:
+    two fresh ``default_rng(k)`` instances reproduce the same fit, and the
+    Generator's state advances across the call.
+    """
+    if fit_conditional_logit_with_sampling is None or not SCIPY_AVAILABLE:
+        pytest.skip("SciPy/choice module not available")
+
+    x, choice_ids, y = _make_condlogit_data(
+        n_sets=300, k_alts=4, beta=[1.0, -0.5], rng=np.random.default_rng(11)
+    )
+
+    # Two independent Generators seeded identically thread the same single
+    # stream through negative sampling and optimizer init -> identical fit.
+    coef_a, int_a, _ = fit_conditional_logit_with_sampling(
+        x, choice_ids, y, neg_per_pos=3, random_state=np.random.default_rng(7)
+    )
+    coef_b, int_b, _ = fit_conditional_logit_with_sampling(
+        x, choice_ids, y, neg_per_pos=3, random_state=np.random.default_rng(7)
+    )
+    np.testing.assert_allclose(coef_a, coef_b, rtol=0, atol=1e-12)
+    np.testing.assert_allclose(int_a, int_b, rtol=0, atol=1e-12)
+
+    # The Generator is consumed (threaded), not reset: a draw taken afterwards
+    # does not match a fresh stream's first draw.
+    gen = np.random.default_rng(7)
+    fit_conditional_logit_with_sampling(
+        x, choice_ids, y, neg_per_pos=3, random_state=gen
+    )
+    assert not np.array_equal(
+        gen.normal(size=3), np.random.default_rng(7).normal(size=3)
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_propensity_choice.py
+++ b/tests/test_propensity_choice.py
@@ -345,8 +345,12 @@ def test_fit_conditional_logit_deterministic():
     coef_a, int_a, _ = fit_conditional_logit(x, choice_ids, y, random_state=42)
     coef_b, int_b, _ = fit_conditional_logit(x, choice_ids, y, random_state=42)
 
-    np.testing.assert_array_equal(coef_a, coef_b)
-    assert int_a == int_b
+    # Both fits run the identical computation in-process, so a tight tolerance
+    # still flags any determinism/RNG regression: such a regression shifts the
+    # optimizer's initialization (and trajectory) by orders of magnitude more
+    # than this. Avoids brittle exact-equality on floating-point outputs.
+    np.testing.assert_allclose(coef_a, coef_b, rtol=0, atol=1e-12)
+    np.testing.assert_allclose(int_a, int_b, rtol=0, atol=1e-12)
 
 
 def test_fit_conditional_logit_isolated_from_global_seed():
@@ -363,8 +367,10 @@ def test_fit_conditional_logit_isolated_from_global_seed():
     np.random.seed(123456)  # would change a global-RNG initialization
     coef_b, int_b, _ = fit_conditional_logit(x, choice_ids, y, random_state=42)
 
-    np.testing.assert_array_equal(coef_a, coef_b)
-    assert int_a == int_b
+    # Tight tolerance rather than exact ==: any leak of global state into the
+    # fit would move the coefficients far more than this.
+    np.testing.assert_allclose(coef_a, coef_b, rtol=0, atol=1e-12)
+    np.testing.assert_allclose(int_a, int_b, rtol=0, atol=1e-12)
 
 
 def test_fit_conditional_logit_does_not_mutate_global_rng():

--- a/tests/test_propensity_choice.py
+++ b/tests/test_propensity_choice.py
@@ -12,13 +12,37 @@ from skdr_eval.pairwise import PairwiseDesign
 try:
     from skdr_eval.choice import (
         SCIPY_AVAILABLE,
+        fit_conditional_logit,
         fit_conditional_logit_with_sampling,
         sample_negative_pairs,
     )
 except ImportError:
     SCIPY_AVAILABLE = False
+    fit_conditional_logit = None
     fit_conditional_logit_with_sampling = None
     sample_negative_pairs = None
+
+
+def _make_condlogit_data(n_sets, k_alts, beta, rng):
+    """Build a conditional-logit dataset with a known ground-truth ``beta``.
+
+    For each of ``n_sets`` choice sets the chosen alternative is drawn from the
+    softmax over ``X @ beta``, so a correctly fitted model should recover
+    ``beta`` (up to regularization and sampling noise).
+    """
+    n_features = len(beta)
+    n_pairs = n_sets * k_alts
+    x = rng.normal(0, 1, (n_pairs, n_features)).astype(np.float32)
+    choice_ids = np.repeat(np.arange(n_sets), k_alts)
+    y = np.zeros(n_pairs)
+    utilities = x @ np.asarray(beta, dtype=np.float64)
+    for s in range(n_sets):
+        idx = np.where(choice_ids == s)[0]
+        u = utilities[idx]
+        probs = np.exp(u - u.max())
+        probs /= probs.sum()
+        y[rng.choice(idx, p=probs)] = 1
+    return x, choice_ids, y
 
 
 def test_propensity_multinomial_fallback():
@@ -282,6 +306,150 @@ def test_large_dataset_fallback():
         # Should still work (fallback to multinomial)
         assert propensities.shape[0] == len(logs_df)
         assert (propensities >= 0).all()
+
+
+def test_sample_negative_pairs_isolated_from_global_seed():
+    """Negative sampling must not depend on the global ``np.random`` state."""
+    if sample_negative_pairs is None:
+        pytest.skip("Choice module not available")
+
+    rng = np.random.default_rng(0)
+    n_pairs = 200
+    x = rng.normal(0, 1, (n_pairs, 4)).astype(np.float32)
+    choice_ids = np.repeat(np.arange(20), 10)
+    y = np.zeros(n_pairs)
+    for i in range(20):
+        y[i * 10 + int(rng.integers(0, 10))] = 1
+
+    np.random.seed(123)
+    _, ids_a, y_a = sample_negative_pairs(
+        x, choice_ids, y, neg_per_pos=3, random_state=7
+    )
+    np.random.seed(999)  # unrelated global reseed between calls
+    _, ids_b, y_b = sample_negative_pairs(
+        x, choice_ids, y, neg_per_pos=3, random_state=7
+    )
+
+    np.testing.assert_array_equal(ids_a, ids_b)
+    np.testing.assert_array_equal(y_a, y_b)
+
+
+def test_fit_conditional_logit_deterministic():
+    """The same ``random_state`` yields identical coefficients."""
+    if not SCIPY_AVAILABLE:
+        pytest.skip("SciPy not installed in this environment")
+
+    x, choice_ids, y = _make_condlogit_data(
+        n_sets=400, k_alts=4, beta=[1.0, -0.5], rng=np.random.default_rng(0)
+    )
+    coef_a, int_a, _ = fit_conditional_logit(x, choice_ids, y, random_state=42)
+    coef_b, int_b, _ = fit_conditional_logit(x, choice_ids, y, random_state=42)
+
+    np.testing.assert_array_equal(coef_a, coef_b)
+    assert int_a == int_b
+
+
+def test_fit_conditional_logit_isolated_from_global_seed():
+    """An unrelated ``np.random.seed`` must not change the fitted coefficients."""
+    if not SCIPY_AVAILABLE:
+        pytest.skip("SciPy not installed in this environment")
+
+    x, choice_ids, y = _make_condlogit_data(
+        n_sets=400, k_alts=4, beta=[1.0, -0.5], rng=np.random.default_rng(1)
+    )
+
+    np.random.seed(0)
+    coef_a, int_a, _ = fit_conditional_logit(x, choice_ids, y, random_state=42)
+    np.random.seed(123456)  # would change a global-RNG initialization
+    coef_b, int_b, _ = fit_conditional_logit(x, choice_ids, y, random_state=42)
+
+    np.testing.assert_array_equal(coef_a, coef_b)
+    assert int_a == int_b
+
+
+def test_fit_conditional_logit_does_not_mutate_global_rng():
+    """Fitting must not reseed or consume the global ``np.random`` stream.
+
+    This is the regression the issue targets: the old code called
+    ``np.random.seed(random_state)``, silently reseeding the process-wide RNG
+    and altering a caller's subsequent draws.
+    """
+    if not SCIPY_AVAILABLE:
+        pytest.skip("SciPy not installed in this environment")
+
+    x, choice_ids, y = _make_condlogit_data(
+        n_sets=300, k_alts=3, beta=[1.0, -0.5], rng=np.random.default_rng(3)
+    )
+
+    np.random.seed(0)
+    expected = np.random.random(5)
+
+    np.random.seed(0)
+    fit_conditional_logit(x, choice_ids, y, random_state=42)
+    after = np.random.random(5)
+
+    np.testing.assert_array_equal(expected, after)
+
+
+def test_sample_negative_pairs_does_not_mutate_global_rng():
+    """Negative sampling must not reseed or consume the global ``np.random`` stream."""
+    if sample_negative_pairs is None:
+        pytest.skip("Choice module not available")
+
+    rng = np.random.default_rng(4)
+    x = rng.normal(0, 1, (200, 4)).astype(np.float32)
+    choice_ids = np.repeat(np.arange(20), 10)
+    y = np.zeros(200)
+    for i in range(20):
+        y[i * 10 + int(rng.integers(0, 10))] = 1
+
+    np.random.seed(0)
+    expected = np.random.random(5)
+
+    np.random.seed(0)
+    sample_negative_pairs(x, choice_ids, y, neg_per_pos=3, random_state=7)
+    after = np.random.random(5)
+
+    np.testing.assert_array_equal(expected, after)
+
+
+def test_fit_conditional_logit_accepts_generator_and_none():
+    """``random_state`` accepts int, Generator, and None without error."""
+    if not SCIPY_AVAILABLE:
+        pytest.skip("SciPy not installed in this environment")
+
+    x, choice_ids, y = _make_condlogit_data(
+        n_sets=200, k_alts=3, beta=[0.8, -0.3], rng=np.random.default_rng(2)
+    )
+    for seed in (0, np.random.default_rng(5), None):
+        coef, _intercept, temp = fit_conditional_logit(
+            x, choice_ids, y, random_state=seed
+        )
+        assert coef.shape == (2,)
+        assert np.isfinite(coef).all()
+        assert temp == 1.0
+
+
+def test_fit_conditional_logit_recovers_ground_truth():
+    """Simulation proof: the fit recovers a known conditional-logit ``beta``.
+
+    Required for statistical-logic changes (docs/agent-context/review-checklist.md):
+    initialization from a local Generator must not break parameter recovery.
+    """
+    if not SCIPY_AVAILABLE:
+        pytest.skip("SciPy not installed in this environment")
+
+    beta = np.array([1.5, -1.0])
+    x, choice_ids, y = _make_condlogit_data(
+        n_sets=4000, k_alts=4, beta=beta, rng=np.random.default_rng(2024)
+    )
+
+    coef, _, _ = fit_conditional_logit(
+        x, choice_ids, y, l2=1e-3, maxiter=500, random_state=0
+    )
+
+    # Coefficients recover the ground truth within sampling/regularization noise.
+    np.testing.assert_allclose(coef, beta, atol=0.2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request

## 📋 Description

Replaces the two process-global `np.random.seed(random_state)` calls in `src/skdr_eval/choice.py` with a local `np.random.default_rng(...)` Generator, matching the `default_rng` pattern already used in `_simulation.py` and `scenarios.py`. Fitting the conditional-logit model no longer silently reseeds the caller's global NumPy RNG or interferes with concurrent evaluations — a first-order reproducibility concern for a statistical-evaluation library.

`random_state` now also accepts an `np.random.Generator` or `None` in addition to an integer seed.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [x] 🧹 Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test improvements
- [ ] 🔧 Build/CI improvements

## 🔗 Related Issues
- Fixes #193

## 🧪 Testing

### Test Coverage
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] I have added integration tests if applicable — N/A (unit-level RNG isolation)

### Manual Testing
- [x] Tested locally (`python -m pytest`, `ruff`, `mypy`)
- [x] Tested with example scripts (preflight + quickstart smoke)
- [x] Tested edge cases (`random_state` as int, `Generator`, and `None`)

**Test commands run:**
```bash
ruff check src/ tests/ examples/            # All checks passed
ruff format --check src/ tests/ examples/   # All formatting OK
mypy src/skdr_eval/                          # Success: no issues in 44 files
python -m pytest -q --cov=skdr_eval          # 948 passed, 9 skipped — 93.27% coverage
```

> Note: `make validate` runs the bare `pytest` console script, which in this sandbox resolves to a separate uv-tool install lacking the project's deps (`matplotlib`); the faithful run is `python -m pytest`, which is green. This is a pre-existing environment quirk, not introduced by this PR.

## 📝 Changes Made

### Code Changes
- `src/skdr_eval/choice.py`: `fit_conditional_logit`, `sample_negative_pairs`, and `fit_conditional_logit_with_sampling` now build a local `np.random.default_rng(random_state)` and draw via `rng.normal` / `rng.choice` instead of `np.random.seed(...)` + `np.random.*`. Added a `RandomStateLike` type alias (`int | np.random.Generator | None`) and updated docstrings.
- `tests/test_propensity_choice.py`: added determinism, global-reseed isolation, no-global-mutation (the regression target), edge-case seed types, and a ground-truth recovery simulation; plus a `_make_condlogit_data` helper.
- `CHANGELOG.md`: `### Changed` entry under Unreleased ([#193]).

### API Changes
- [ ] No API changes
- [x] Backward compatible API additions — `random_state` widened from `int` to `int | np.random.Generator | None`; existing integer callers are unaffected.
- [ ] Breaking API changes (requires major version bump)

## 📚 Documentation
- [x] I have updated the documentation accordingly — docstrings updated; no public quickstart/example references these internal functions, so no `examples/`/README change needed.
- [x] I have updated docstrings for new/modified functions
- [ ] I have added examples if applicable — N/A
- [x] I have updated the CHANGELOG.md

## ✅ Checklist

### Code Quality
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have run `ruff check` and `ruff format`
- [x] I have run `mypy` type checking

### Testing & CI
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] All CI checks pass — pending CI
- [x] Code coverage is maintained or improved (93.27%)

### Documentation & Communication
- [x] I have made corresponding changes to the documentation
- [x] My commit messages follow the conventional commit format
- [x] I have updated the CHANGELOG.md

## 🔍 Review Notes

### Focus Areas
- The key regression test is `test_fit_conditional_logit_does_not_mutate_global_rng` — it fails against the old `np.random.seed` behaviour and passes now (verified).
- Simulation proof (`test_fit_conditional_logit_recovers_ground_truth`) recovers `beta=[1.5, -1.0]` to within max abs error ≈0.044 (`atol=0.2`), satisfying the repo's Definition of Done for statistical-logic changes.

### Note on threading
In `fit_conditional_logit_with_sampling`, passing an integer seeds each step reproducibly; passing a `Generator` threads a single stream through both negative sampling and optimizer init (no draw reuse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AEGSrSJ3abcoGCnmyQNva7)_