### PR TITLE
feat(cli): explain, quickstart, capabilities + stronger doctor (#164, #201, #207, #215, #246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **CLI-first diagnostics & verdict explainability** ([#164], [#201], [#207],
+  [#215], [#246]). A coherent expansion of the command-line / `doctor` surface:
+  - `skdr-eval explain artifact.json --model M [--estimator SNDR] [--json]`
+    narrates *why* a saved artifact got its verdict — each gating reason with
+    its measured value and threshold — by reading the saved `artifact.json`
+    without re-running the evaluation. Backed by the new
+    `EvaluationArtifact.explain()` method, the
+    `skdr_eval.explain_artifact_schema()` helper, and the `Explanation` object
+    (a pure presentation layer over the existing recommendation/gate logic, so
+    the narrative cannot drift from the card/report) ([#201]).
+  - `skdr-eval quickstart` runs the full value loop — synthetic logs → `doctor`
+    → `evaluate` → card → `explain` — in one command, no Python required. It is
+    an onboarding demo and always exits `0` on success ([#207]).
+  - `skdr-eval capabilities` (and `skdr_eval.get_capability_matrix()`) report
+    which optional extras (`viz`/`speed`/`cli`/`boosting`/`mlflow`/`wandb`/`aim`)
+    are installed and what each unlocks, with a `pip install` hint. The matrix
+    is also rendered by `doctor` ([#215]).
+  - `doctor` gained **time-ordering** and **column-missingness** checks, and now
+    carries a privacy-safe `DataProfile` (column names/dtypes/shape only — never
+    cell values) ([#164]).
+  - `DoctorReport.to_repro()` / `skdr-eval doctor --repro` emit a copy-paste,
+    **data-free** minimal-reproduction snippet (same schema/shape, placeholder
+    values) to attach to bug reports ([#246]).
 - **`insufficient_evidence` is now a first-class, gated verdict** ([#197]). The
   CLI exposes a new exit code `4` for runs where at least one estimator's
   verdict is `insufficient_evidence` (and none is `do_not_deploy`) — an honest
@@ -851,10 +874,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#27]: https://github.com/dgenio/skdr-eval/issues/27
 [#28]: https://github.com/dgenio/skdr-eval/issues/28
 [#30]: https://github.com/dgenio/skdr-eval/issues/30
+[#164]: https://github.com/dgenio/skdr-eval/issues/164
 [#193]: https://github.com/dgenio/skdr-eval/issues/193
 [#196]: https://github.com/dgenio/skdr-eval/issues/196
 [#197]: https://github.com/dgenio/skdr-eval/issues/197
+[#201]: https://github.com/dgenio/skdr-eval/issues/201
+[#207]: https://github.com/dgenio/skdr-eval/issues/207
+[#215]: https://github.com/dgenio/skdr-eval/issues/215
 [#235]: https://github.com/dgenio/skdr-eval/issues/235
+[#246]: https://github.com/dgenio/skdr-eval/issues/246
 
 ## [0.5.0] - 2026-04-08
 

--- a/README.md
+++ b/README.md
@@ -536,9 +536,19 @@ evaluation surface to teams that don't want to write Python.
 ```bash
 pip install 'skdr-eval[cli]'
 
+# Zero-to-card in one command (synth logs → doctor → evaluate → explain).
+# Great first run; always exits 0 (it's a demo, not a CI gate).
+skdr-eval quickstart --out ./quickstart
+
+# See which optional extras are installed and what each one unlocks.
+skdr-eval capabilities
+skdr-eval capabilities --json | jq .
+
 # Quick environment + schema probe before evaluation.
 skdr-eval doctor logs.parquet
 skdr-eval doctor logs.parquet --json | jq .
+# Emit a copy-paste, data-free reproduction snippet for a bug report.
+skdr-eval doctor logs.parquet --repro
 
 # Validate logs against the schema (exit code 1 on failure — useful in CI).
 skdr-eval validate-schema logs.parquet --strict
@@ -556,6 +566,10 @@ skdr-eval evaluate logs.parquet \
 # Re-render a card directly from a saved artifact.json.
 skdr-eval card ./run/artifact.json --model HGB --estimator DR \
     --out ./run/card.yaml --format yaml
+
+# Narrate *why* a saved artifact got its verdict (no re-evaluation).
+skdr-eval explain ./run/artifact.json --model HGB --estimator SNDR
+skdr-eval explain ./run/artifact.json --model HGB --json | jq .
 
 # Stable exit codes (good for CI gates):
 #   0 — success: no 'do_not_deploy' or 'insufficient_evidence' verdict was
@@ -586,10 +600,28 @@ import skdr_eval
 
 logs, _, _ = skdr_eval.make_synth_logs(n=5000, n_ops=3, seed=0)
 report = skdr_eval.doctor(logs)
-report.print()            # text table with status glyphs
+report.print()            # text table with status glyphs + capability matrix
 report.to_markdown()      # copy-pasteable Markdown
-report.to_dict()          # JSON-serializable
+report.to_dict()          # JSON-serializable (checks + capabilities + profile)
+report.to_repro()         # data-free minimal reproduction snippet for bug reports
 assert report.ok          # True iff no Check has status='fail'
+```
+
+Checks cover environment, schema, duplicates, **time ordering** (time-aware CV
+assumes chronological logs), **column missingness**, finite outcomes,
+positivity, and sample size. The report also carries a full **optional-extra
+capability matrix** — the same data behind `skdr_eval.get_capability_matrix()`
+and `skdr-eval capabilities` — and a privacy-safe `DataProfile` (column
+names/dtypes/shape only) used by `to_repro()`.
+
+You can also narrate a verdict programmatically:
+
+```python
+artifact = skdr_eval.evaluate_sklearn_models(logs=logs, models=models)
+print(artifact.explain("HGB", estimator="SNDR").to_text())
+# Or, from a saved artifact.json, without re-running the evaluation:
+schema = skdr_eval.load_artifact_json("run/artifact.json")
+skdr_eval.explain_artifact_schema(schema, "HGB", estimator="SNDR").to_dict()
 ```
 
 ## Machine-readable cards: `EvaluationCard`

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -94,9 +94,10 @@ extra is installed.
 `dr_value_with_strategy` `embedding_sufficiency_diagnostic`
 `evaluate_external_policies` `evaluate_pairwise_models`
 `evaluate_propensity_diagnostics` `evaluate_sklearn_models`
-`evaluate_slate_models` `export_results` `fit_outcome_crossfit`
-`fit_propensity_timecal` `gate_diagnostics` `get_capabilities`
-`get_default_config` `get_model_recommendations` `induce_policy_from_sklearn`
+`evaluate_slate_models` `explain_artifact_schema` `export_results`
+`fit_outcome_crossfit` `fit_propensity_timecal` `gate_diagnostics`
+`get_capabilities` `get_capability_matrix` `get_default_config`
+`get_model_recommendations` `induce_policy_from_sklearn`
 `kolmogorov_smirnov_test` `load_artifact_json` `load_config_from_file`
 `load_criteo_counterfactual` `load_movielens_ope` `load_obd`
 `make_pairwise_synth` `make_slate_synth` `make_synth_logs`
@@ -112,11 +113,12 @@ extra is installed.
 
 ### Classes and dataclasses
 
-`ArtifactSchema` `BaselineBlock` `Check` `ClipTransform` `ConfigManager`
-`CoverageResult` `CoverageSimBlock` `DRResult` `DRosShrinkTransform`
-`DatasetBundle` `Design` `DiagnosticGate` `DiagnosticsBlock` `DoctorReport`
-`EmbeddingSufficiencyReport` `EstimandBlock` `EstimatorStrategy`
-`EvaluationArtifact` `EvaluationCard` `EvaluationConfig` `FileTracker`
+`ArtifactSchema` `BaselineBlock` `Capability` `Check` `ClipTransform`
+`ConfigManager` `CoverageResult` `CoverageSimBlock` `DRResult`
+`DRosShrinkTransform` `DataProfile` `DatasetBundle` `Design` `DiagnosticGate`
+`DiagnosticsBlock` `DoctorReport` `EmbeddingSufficiencyReport` `EstimandBlock`
+`EstimatorStrategy` `EvaluationArtifact` `EvaluationCard` `EvaluationConfig`
+`Explanation` `FileTracker`
 `GateResult` `HeadlineBlock` `IdentityTransform` `MIPSTransform`
 `MRDRWeightedLoss` `MSEOutcomeLoss` `ModelConfig` `ModelEvaluator`
 `ModelFactory` `ModelSelector` `NullTracker` `OutcomeLoss` `PairwiseDesign`

--- a/src/skdr_eval/__init__.py
+++ b/src/skdr_eval/__init__.py
@@ -7,7 +7,7 @@ from . import datasets as datasets
 from . import estimators as estimators
 from . import slate as slate
 from ._simulation import CoverageResult, simulate_coverage
-from .capabilities import get_capabilities
+from .capabilities import Capability, get_capabilities, get_capability_matrix
 from .config import (
     ConfigManager,
     EvaluationConfig,
@@ -44,7 +44,7 @@ from .diagnostics import (
     PropensityDiagnostics,
     per_action_propensity_diagnostics,
 )
-from .doctor import Check, DoctorReport, doctor
+from .doctor import Check, DataProfile, DoctorReport, doctor
 from .estimators import (
     ClipTransform,
     DRosShrinkTransform,
@@ -104,6 +104,7 @@ from .reporting import (
     EstimandBlock,
     EvaluationArtifact,
     EvaluationCard,
+    Explanation,
     GateResult,
     HeadlineBlock,
     ProvenanceBlock,
@@ -115,6 +116,7 @@ from .reporting import (
     TrustBlock,
     attach_warnings,
     build_evaluation_artifact,
+    explain_artifact_schema,
     export_results,
     gate_diagnostics,
     load_artifact_json,
@@ -181,6 +183,7 @@ __all__ = [
     "ArtifactSchema",
     "BaselineBlock",
     "BootstrapError",
+    "Capability",
     "Check",
     "ClipTransform",
     "ConfigManager",
@@ -190,6 +193,7 @@ __all__ = [
     "CoverageSimBlock",
     "DRResult",
     "DRosShrinkTransform",
+    "DataProfile",
     "DataValidationError",
     "DatasetBundle",
     "DatasetError",
@@ -204,6 +208,7 @@ __all__ = [
     "EvaluationArtifact",
     "EvaluationCard",
     "EvaluationConfig",
+    "Explanation",
     "FileTracker",
     "GateResult",
     "HeadlineBlock",
@@ -264,11 +269,13 @@ __all__ = [
     "evaluate_propensity_diagnostics",
     "evaluate_sklearn_models",
     "evaluate_slate_models",
+    "explain_artifact_schema",
     "export_results",
     "fit_outcome_crossfit",
     "fit_propensity_timecal",
     "gate_diagnostics",
     "get_capabilities",
+    "get_capability_matrix",
     "get_default_config",
     "get_model_recommendations",
     "induce_policy_from_sklearn",

--- a/src/skdr_eval/capabilities.py
+++ b/src/skdr_eval/capabilities.py
@@ -14,6 +14,8 @@ propensity estimation is always available and is not listed here.
 from __future__ import annotations
 
 import importlib.util
+from dataclasses import asdict, dataclass
+from typing import Any
 
 # Map of capability name -> list of module names whose presence enables it.
 # Capability is True iff *all* listed modules can be located.
@@ -28,12 +30,98 @@ _EXTRA_BY_CAPABILITY = {
     "speed": "speed",
 }
 
+# Full capability matrix (#215): every optional ``[extra]`` declared in
+# ``pyproject.toml``, the modules that enable it, and the user-facing feature it
+# unlocks. ``scipy`` is a mandatory dependency (conditional-logit propensities
+# are always available), so it is intentionally absent here.
+_EXTRA_MODULES: dict[str, tuple[str, ...]] = {
+    "viz": ("matplotlib",),
+    "speed": ("pyarrow", "polars"),
+    "cli": ("typer", "joblib", "pyarrow"),
+    "boosting": ("xgboost", "lightgbm", "catboost"),
+    "mlflow": ("mlflow",),
+    "wandb": ("wandb",),
+    "aim": ("aim",),
+}
+
+_EXTRA_FEATURES: dict[str, str] = {
+    "viz": "Plotting helpers (skdr_eval.visualization).",
+    "speed": "Accelerated parquet/feather I/O via pyarrow + polars.",
+    "cli": "The 'skdr-eval' command-line interface.",
+    "boosting": "XGBoost / LightGBM / CatBoost model adapters.",
+    "mlflow": "MLflow experiment-tracker integration.",
+    "wandb": "Weights & Biases experiment-tracker integration.",
+    "aim": "Aim experiment-tracker integration.",
+}
+
+
+@dataclass(frozen=True)
+class Capability:
+    """One row of the optional-dependency capability matrix (#215).
+
+    Attributes
+    ----------
+    extra : str
+        The pip extra name (e.g. ``"viz"``), installable via
+        ``pip install 'skdr-eval[<extra>]'``.
+    installed : bool
+        ``True`` iff *all* modules backing the extra can be located.
+    feature : str
+        Human-readable description of what the extra unlocks.
+    install_hint : str
+        Copy-pasteable ``pip install`` command that enables the extra.
+    modules : tuple[str, ...]
+        The import names probed to decide ``installed``.
+    """
+
+    extra: str
+    installed: bool
+    feature: str
+    install_hint: str
+    modules: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
 
 def _module_available(name: str) -> bool:
     try:
         return importlib.util.find_spec(name) is not None
     except (ImportError, ValueError):
         return False
+
+
+def get_capability_matrix() -> list[Capability]:
+    """Return the full optional-dependency capability matrix (#215).
+
+    Unlike :func:`get_capabilities` (which reports only the *truly optional*
+    feature toggles ``viz`` / ``speed``), this covers every pip extra declared
+    in ``pyproject.toml`` — including ``cli``, ``boosting`` and the experiment
+    trackers — so ``doctor`` and the ``skdr-eval capabilities`` command can show
+    users which features are available and how to unlock the rest.
+
+    Detection is import-light: it only probes :func:`importlib.util.find_spec`
+    and never imports the heavy extras themselves.
+
+    Returns
+    -------
+    list[Capability]
+        One :class:`Capability` per extra, ordered as declared in
+        :data:`_EXTRA_MODULES`.
+    """
+    matrix: list[Capability] = []
+    for extra, modules in _EXTRA_MODULES.items():
+        installed = all(_module_available(m) for m in modules)
+        matrix.append(
+            Capability(
+                extra=extra,
+                installed=installed,
+                feature=_EXTRA_FEATURES[extra],
+                install_hint=f"pip install 'skdr-eval[{extra}]'",
+                modules=modules,
+            )
+        )
+    return matrix
 
 
 def get_capabilities() -> dict[str, bool | list[str]]:

--- a/src/skdr_eval/cli.py
+++ b/src/skdr_eval/cli.py
@@ -54,7 +54,9 @@ except ImportError as exc:  # pragma: no cover - exercised via tests for the mes
 import pandas as pd
 
 import skdr_eval
+from skdr_eval.capabilities import get_capability_matrix
 from skdr_eval.doctor import doctor as doctor_fn
+from skdr_eval.reporting import explain_artifact_schema
 from skdr_eval.trackers import FileTracker
 
 logger = logging.getLogger("skdr_eval.cli")
@@ -287,6 +289,11 @@ def doctor_cmd(
     json_out: bool = typer.Option(
         False, "--json", help="Emit JSON instead of a text table."
     ),
+    repro: bool = typer.Option(
+        False,
+        "--repro",
+        help="Also emit a copy-paste, data-free minimal reproduction snippet.",
+    ),
 ) -> None:
     """Run preflight diagnostics on input data + environment."""
     if kind not in {"standard", "pairwise"}:
@@ -307,9 +314,15 @@ def doctor_cmd(
         strict=strict,
     )
     if json_out:
-        typer.echo(json.dumps(report.to_dict(), indent=2))
+        payload = report.to_dict()
+        if repro:
+            payload["repro"] = report.to_repro()
+        typer.echo(json.dumps(payload, indent=2))
     else:
         report.print(color=sys.stdout.isatty())
+        if repro:
+            typer.echo("")
+            typer.echo(report.to_repro())
     if not report.ok:
         raise typer.Exit(code=EXIT_DATA)
 
@@ -637,6 +650,127 @@ def _card_from_artifact_schema(
         diagnostics=diagnostics_block,
         sensitivity=sensitivity_block,
         provenance=provenance,
+    )
+
+
+@app.command("explain")
+def explain_cmd(
+    artifact_json: Path = typer.Argument(
+        ..., exists=True, readable=True, help="Path to artifact.json."
+    ),
+    model_name: str = typer.Option(..., "--model", help="Model name."),
+    estimator: str = typer.Option(
+        "SNDR", "--estimator", help="Estimator row to explain (e.g. DR, SNDR)."
+    ),
+    baseline: float | None = typer.Option(
+        None, "--baseline", help="Baseline the CI is compared against (default 0)."
+    ),
+    json_out: bool = typer.Option(
+        False, "--json", help="Emit JSON instead of a text narrative."
+    ),
+) -> None:
+    """Narrate *why* a saved artifact row got its verdict, without re-running (#201).
+
+    Reads a saved ``artifact.json`` and explains which diagnostics gated the
+    chosen ``(model, estimator)`` — each reason with its measured value and the
+    threshold it was compared against.
+    """
+    schema = skdr_eval.load_artifact_json(artifact_json)
+    try:
+        explanation = explain_artifact_schema(
+            schema, model_name, estimator=estimator, baseline=baseline
+        )
+    except skdr_eval.DataValidationError as exc:
+        typer.secho(f"explain: {exc}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=EXIT_DATA) from exc
+    if json_out:
+        typer.echo(json.dumps(explanation.to_dict(), indent=2))
+    else:
+        typer.echo(explanation.to_text())
+
+
+@app.command("capabilities")
+def capabilities_cmd(
+    json_out: bool = typer.Option(
+        False, "--json", help="Emit JSON instead of a text table."
+    ),
+) -> None:
+    """Show which optional extras are installed and what each one unlocks (#215)."""
+    matrix = get_capability_matrix()
+    if json_out:
+        typer.echo(json.dumps([c.to_dict() for c in matrix], indent=2))
+        return
+    use_color = sys.stdout.isatty()
+    typer.echo("skdr-eval capabilities")
+    typer.echo("─" * 48)
+    for cap in matrix:
+        if cap.installed:
+            mark = typer.style("✓", fg=typer.colors.GREEN) if use_color else "yes"
+        else:
+            mark = typer.style("✗", fg=typer.colors.YELLOW) if use_color else "no "
+        typer.echo(f"[{mark}] {cap.extra}: {cap.feature}")
+        if not cap.installed:
+            typer.echo(f"      {cap.install_hint}")
+
+
+@app.command("quickstart")
+def quickstart_cmd(
+    out: Path = typer.Option(
+        Path("./skdr_eval_quickstart"),
+        "--out",
+        help="Output directory for the report + cards.",
+    ),
+    n: int = typer.Option(
+        2000, "--n", min=1, help="Number of synthetic log rows to generate."
+    ),
+    seed: int = typer.Option(
+        0, "--seed", help="Random seed for the synthetic logs + model."
+    ),
+    ci_bootstrap: bool = typer.Option(
+        False,
+        "--ci-bootstrap/--no-ci-bootstrap",
+        help="Compute bootstrap CIs (slower; enables a deploy/don't-deploy verdict).",
+    ),
+) -> None:
+    """Guided first run: synth logs → doctor → evaluate → card → explain (#207).
+
+    Generates synthetic logs, runs the doctor, evaluates a default model, writes
+    the HTML report + cards, and narrates the verdict — the full value loop in a
+    single command, no Python required. Always exits ``0`` on success; it is an
+    onboarding demo, not a CI gate (use ``evaluate`` for gating).
+    """
+    from sklearn.ensemble import HistGradientBoostingRegressor  # noqa: PLC0415
+
+    typer.secho("[1/4] Generating synthetic logs…", fg=typer.colors.CYAN)
+    logs_df, _, _ = skdr_eval.make_synth_logs(n=n, n_ops=3, seed=seed)
+
+    typer.secho("[2/4] Running doctor…", fg=typer.colors.CYAN)
+    report = doctor_fn(logs_df, kind="standard")
+    report.print(color=sys.stdout.isatty())
+
+    typer.secho("[3/4] Evaluating a default model…", fg=typer.colors.CYAN)
+    models = {"hgb": HistGradientBoostingRegressor(max_iter=30, random_state=seed)}
+    try:
+        artifact = skdr_eval.evaluate_sklearn_models(
+            logs=logs_df,
+            models=models,
+            fit_models=True,
+            n_splits=3,
+            random_state=seed,
+            ci_bootstrap=ci_bootstrap,
+            policy_train="pre_split",
+        )
+    except skdr_eval.SkdrEvalError as exc:
+        typer.secho(f"Evaluation error: {exc}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=EXIT_DATA) from exc
+    paths = _write_artifact_outputs(artifact, out)
+
+    typer.secho("[4/4] Explaining the verdict…", fg=typer.colors.CYAN)
+    typer.echo(artifact.explain("hgb", estimator="SNDR").to_text())
+    typer.echo("")
+    typer.echo(
+        f"Wrote {len(paths)} files to {out} "
+        f"(open {out / 'report.html'} for the full card)."
     )
 
 

--- a/src/skdr_eval/doctor.py
+++ b/src/skdr_eval/doctor.py
@@ -108,13 +108,23 @@ def _profile_dataframe(df: pd.DataFrame, *, kind: str, metric_col: str) -> DataP
 
 
 def _repro_column_expr(dtype: str) -> str:
-    """Map a dtype string to a data-free column generator expression."""
-    if dtype.startswith("datetime"):
+    """Map a dtype string to a runnable, data-free column generator expression.
+
+    Best-effort: pandas extension/annotated dtypes (e.g. ``Int64``, ``Float64``,
+    ``int64[pyarrow]``, ``boolean``, ``string``, ``category``) are normalized to
+    a NumPy-constructible placeholder so the generated snippet always runs. The
+    column's broad dtype family is preserved, not necessarily the exact
+    extension dtype.
+    """
+    # Drop any storage annotation (e.g. ``int64[pyarrow]`` → ``int64``) and
+    # case-fold so nullable dtypes (``Int64`` → ``int64``) map to a NumPy name.
+    base = dtype.split("[", 1)[0].strip().lower()
+    if base.startswith("datetime"):
         return 'pd.date_range("2024-01-01", periods=n, freq="s")'
-    if dtype.startswith("bool"):
+    if base in {"bool", "boolean"}:
         return "np.zeros(n, dtype=bool)"
-    if dtype.startswith(("int", "uint", "float")):
-        return f'np.zeros(n, dtype="{dtype}")'
+    if base.startswith(("int", "uint", "float")):
+        return f'np.zeros(n, dtype="{base}")'
     # object / string / category / everything else: data-free placeholder.
     return '[""] * n'
 
@@ -191,10 +201,13 @@ class DoctorReport:
         """Generate a copy-paste, **data-free** minimal reproduction (#246).
 
         Emits a runnable Python snippet that rebuilds a synthetic frame with the
-        *same column names, dtypes and row count* as the inspected logs (filled
-        with placeholder zeros/empties — never any real values) and re-runs
-        :func:`doctor`. Paste it into a bug report so maintainers can reproduce a
-        schema/setup issue without access to your data.
+        *same column names and row count* as the inspected logs, and best-effort
+        dtypes (pandas extension/categorical dtypes are normalized to a
+        NumPy-constructible placeholder, so the snippet always runs even if it
+        does not reproduce the exact extension dtype). Columns are filled with
+        placeholder zeros/empties — never any real values — and the snippet
+        re-runs :func:`doctor`. Paste it into a bug report so maintainers can
+        reproduce a schema/setup issue without access to your data.
 
         Returns
         -------

--- a/src/skdr_eval/doctor.py
+++ b/src/skdr_eval/doctor.py
@@ -14,13 +14,14 @@ from __future__ import annotations
 
 import platform
 import sys
+import warnings
 from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 import pandas as pd
 
-from .capabilities import get_capabilities
+from .capabilities import Capability, get_capabilities, get_capability_matrix
 from .exceptions import DataValidationError, InsufficientDataError
 from .validation import validate_logs, validate_pairwise_inputs
 
@@ -62,6 +63,62 @@ class Check:
         return asdict(self)
 
 
+@dataclass(frozen=True)
+class DataProfile:
+    """Privacy-safe shape/schema fingerprint of the inspected ``logs`` (#246).
+
+    Captures only column names, dtypes, row count, and mode — **never any cell
+    values** — so it can seed a copy-paste minimal reproduction
+    (:meth:`DoctorReport.to_repro`) without leaking user data.
+
+    Attributes
+    ----------
+    kind : str
+        ``"standard"`` or ``"pairwise"``.
+    metric_col : str
+        The reward/outcome column name passed to ``doctor``.
+    n_rows : int
+        Row count of the inspected frame.
+    columns : list[tuple[str, str]]
+        ``(column_name, dtype_str)`` pairs, in column order.
+    """
+
+    kind: str
+    metric_col: str
+    n_rows: int
+    columns: list[tuple[str, str]]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": self.kind,
+            "metric_col": self.metric_col,
+            "n_rows": self.n_rows,
+            "columns": [{"name": n, "dtype": d} for n, d in self.columns],
+        }
+
+
+def _profile_dataframe(df: pd.DataFrame, *, kind: str, metric_col: str) -> DataProfile:
+    """Build a :class:`DataProfile` from ``df`` (names/dtypes/shape only)."""
+    return DataProfile(
+        kind=kind,
+        metric_col=metric_col,
+        n_rows=len(df),
+        columns=[(str(c), str(df[c].dtype)) for c in df.columns],
+    )
+
+
+def _repro_column_expr(dtype: str) -> str:
+    """Map a dtype string to a data-free column generator expression."""
+    if dtype.startswith("datetime"):
+        return 'pd.date_range("2024-01-01", periods=n, freq="s")'
+    if dtype.startswith("bool"):
+        return "np.zeros(n, dtype=bool)"
+    if dtype.startswith(("int", "uint", "float")):
+        return f'np.zeros(n, dtype="{dtype}")'
+    # object / string / category / everything else: data-free placeholder.
+    return '[""] * n'
+
+
 @dataclass
 class DoctorReport:
     """Result of running :func:`doctor`.
@@ -79,12 +136,16 @@ class DoctorReport:
     ok: bool
     checks: list[Check] = field(default_factory=list)
     summary: CheckStatus = "pass"
+    capabilities: list[Capability] = field(default_factory=list)
+    profile: DataProfile | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return {
             "ok": self.ok,
             "summary": self.summary,
             "checks": [c.to_dict() for c in self.checks],
+            "capabilities": [c.to_dict() for c in self.capabilities],
+            "profile": self.profile.to_dict() if self.profile is not None else None,
         }
 
     def to_markdown(self) -> str:
@@ -112,10 +173,66 @@ class DoctorReport:
             lines.append(line)
             if c.fix_hint:
                 lines.append(f"    Fix: {c.fix_hint}")
+        if self.capabilities:
+            lines.append("─" * 40)
+            lines.append("Optional extras (capability matrix):")
+            on = "✓" if color else "yes"
+            off = "✗" if color else "no "
+            for cap in self.capabilities:
+                mark = on if cap.installed else off
+                hint = "" if cap.installed else f"  → {cap.install_hint}"
+                lines.append(f"  [{mark}] {cap.extra}: {cap.feature}{hint}")
         lines.append("─" * 40)
         overall_icon = glyph_map.get(self.summary, self.summary)
         lines.append(f"Overall: {overall_icon} ({self.summary})")
         return "\n".join(lines)
+
+    def to_repro(self) -> str:
+        """Generate a copy-paste, **data-free** minimal reproduction (#246).
+
+        Emits a runnable Python snippet that rebuilds a synthetic frame with the
+        *same column names, dtypes and row count* as the inspected logs (filled
+        with placeholder zeros/empties — never any real values) and re-runs
+        :func:`doctor`. Paste it into a bug report so maintainers can reproduce a
+        schema/setup issue without access to your data.
+
+        Returns
+        -------
+        str
+            A self-contained Python snippet. If no :class:`DataProfile` was
+            captured (e.g. the input was not a DataFrame), returns a short
+            comment explaining why no reproduction could be generated.
+        """
+        if self.profile is None:
+            return (
+                "# No reproduction available: the doctor could not profile the "
+                "input\n# (it was not a pandas DataFrame)."
+            )
+        p = self.profile
+        col_lines = [
+            f"        {name!r}: {_repro_column_expr(dtype)},  # dtype: {dtype}"
+            for name, dtype in p.columns
+        ]
+        cols_block = "\n".join(col_lines)
+        return (
+            "# Minimal, data-free reproduction generated by skdr-eval doctor "
+            "(#246).\n"
+            "# Column names/dtypes/shape only — no real values are included.\n"
+            "import numpy as np\n"
+            "import pandas as pd\n"
+            "import skdr_eval\n"
+            "\n"
+            f"n = {p.n_rows}\n"
+            "df = pd.DataFrame(\n"
+            "    {\n"
+            f"{cols_block}\n"
+            "    }\n"
+            ")\n"
+            "report = skdr_eval.doctor(\n"
+            f"    df, kind={p.kind!r}, metric_col={p.metric_col!r}\n"
+            ")\n"
+            "print(report.to_text())\n"
+        )
 
     def print(self, *, color: bool = True) -> None:
         """Print the report to stdout. Color glyphs auto-disabled off-TTY."""
@@ -377,6 +494,100 @@ def _check_positivity(
     )
 
 
+def _check_time_ordering(df: pd.DataFrame, *, time_col: str) -> Check:
+    """Verify rows are chronologically ordered (time-aware CV assumes this)."""
+    if time_col not in df.columns:
+        return Check(
+            name="time_ordering",
+            status="warn",
+            message=(
+                f"No '{time_col}' column found; cannot verify chronological order."
+            ),
+            category="schema",
+        )
+    series = df[time_col]
+    if pd.api.types.is_datetime64_any_dtype(series) or pd.api.types.is_numeric_dtype(
+        series
+    ):
+        # Already a sortable dtype — no parsing (and no inference warning) needed.
+        parsed: pd.Series = series
+    else:
+        # Object/string column: try datetime, then numeric. Suppress pandas'
+        # "could not infer format" UserWarning — falling back to per-element
+        # parsing is exactly what we want for a best-effort ordering check.
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", UserWarning)
+                parsed = pd.to_datetime(series, errors="raise")
+        except (ValueError, TypeError, OverflowError):
+            try:
+                parsed = pd.to_numeric(series, errors="raise")
+            except (ValueError, TypeError):
+                return Check(
+                    name="time_ordering",
+                    status="warn",
+                    message=f"Could not parse '{time_col}' as datetime or numeric.",
+                    fix_hint="Store arrival times as datetimes or sortable numerics.",
+                    category="schema",
+                )
+    if bool(parsed.is_monotonic_increasing):
+        return Check(
+            name="time_ordering",
+            status="pass",
+            message=f"'{time_col}' is non-decreasing (rows are time-ordered).",
+            category="schema",
+        )
+    arr = parsed.to_numpy()
+    n_inversions = int(np.sum(arr[1:] < arr[:-1]))
+    return Check(
+        name="time_ordering",
+        status="warn",
+        message=(
+            f"'{time_col}' is not sorted ({n_inversions} out-of-order rows); "
+            f"time-aware splits assume chronological order."
+        ),
+        fix_hint=(
+            f"Sort logs by '{time_col}' before evaluate_* "
+            f"(df.sort_values('{time_col}'))."
+        ),
+        category="schema",
+    )
+
+
+def _check_missingness(df: pd.DataFrame, *, threshold: float = 0.2) -> Check:
+    """Flag columns whose missing-value fraction exceeds ``threshold``."""
+    if df.empty or df.shape[1] == 0:
+        return Check(
+            name="missingness",
+            status="warn",
+            message="No columns to check for missingness.",
+            category="schema",
+        )
+    null_frac = df.isna().mean()
+    offenders = {str(c): float(v) for c, v in null_frac.items() if float(v) > threshold}
+    if not offenders:
+        worst = float(null_frac.max()) if len(null_frac) else 0.0
+        return Check(
+            name="missingness",
+            status="pass",
+            message=(f"No column exceeds {threshold:.0%} missing (worst {worst:.1%})."),
+            category="schema",
+        )
+    top = ", ".join(
+        f"{c}={v:.1%}" for c, v in sorted(offenders.items(), key=lambda kv: -kv[1])[:5]
+    )
+    return Check(
+        name="missingness",
+        status="warn",
+        message=f"{len(offenders)} column(s) above {threshold:.0%} missing: {top}.",
+        fix_hint=(
+            "Impute or drop high-missingness columns before evaluate_*; NaNs "
+            "propagate through the DR estimators."
+        ),
+        category="schema",
+    )
+
+
 def _check_sample_size(
     df: pd.DataFrame, *, min_rows: int = 500, n_splits: int = 3
 ) -> Check:
@@ -459,11 +670,12 @@ def doctor(
         ``logs`` argument the report surfaces the failure as a
         ``status="fail"`` :class:`Check`.
     """
+    capabilities = get_capability_matrix()
     checks: list[Check] = [_check_environment(), _check_optional_extras()]
     input_err = _check_input_is_dataframe("logs", logs)
     if input_err is not None:
         checks.append(input_err)
-        return _finalize_report(checks)
+        return _finalize_report(checks, capabilities=capabilities)
 
     if kind not in ("standard", "pairwise"):
         checks.append(
@@ -475,7 +687,9 @@ def doctor(
                 category="input",
             )
         )
-        return _finalize_report(checks)
+        return _finalize_report(checks, capabilities=capabilities)
+
+    profile = _profile_dataframe(logs, kind=kind, metric_col=metric_col)
 
     if kind == "pairwise":
         checks.append(
@@ -486,20 +700,29 @@ def doctor(
                 logs, key_cols=["arrival_day", "client_id", "operator_id"]
             )
         )
+        time_col = "arrival_day"
         outcome_cols: tuple[str, ...] = (metric_col,)
     else:
         checks.append(_check_logs_schema(logs, metric_col=metric_col, strict=strict))
         checks.append(_check_no_duplicates(logs, key_cols=["client_id", "arrival_ts"]))
+        time_col = "arrival_ts"
         outcome_cols = tuple(dict.fromkeys((metric_col, "service_time", "reward", "y")))
 
+    checks.append(_check_time_ordering(logs, time_col=time_col))
+    checks.append(_check_missingness(logs))
     checks.append(_check_finite_outcomes(logs, outcome_cols=outcome_cols))
     checks.append(_check_positivity(logs))
     checks.append(_check_sample_size(logs, n_splits=n_splits))
 
-    return _finalize_report(checks)
+    return _finalize_report(checks, capabilities=capabilities, profile=profile)
 
 
-def _finalize_report(checks: list[Check]) -> DoctorReport:
+def _finalize_report(
+    checks: list[Check],
+    *,
+    capabilities: list[Capability] | None = None,
+    profile: DataProfile | None = None,
+) -> DoctorReport:
     summary: CheckStatus = "pass"
     for c in checks:
         if c.status == "fail":
@@ -508,7 +731,13 @@ def _finalize_report(checks: list[Check]) -> DoctorReport:
         if c.status == "warn":
             summary = "warn"
     ok = summary != "fail"
-    return DoctorReport(ok=ok, checks=checks, summary=summary)
+    return DoctorReport(
+        ok=ok,
+        checks=checks,
+        summary=summary,
+        capabilities=list(capabilities) if capabilities else [],
+        profile=profile,
+    )
 
 
-__all__ = ["Check", "DoctorReport", "doctor"]
+__all__ = ["Check", "DataProfile", "DoctorReport", "doctor"]

--- a/src/skdr_eval/recommendation.py
+++ b/src/skdr_eval/recommendation.py
@@ -138,6 +138,96 @@ class Recommendation:
         )
 
 
+@dataclass
+class Explanation:
+    """Plain-language narrative of *why* a (model, estimator) row got its verdict.
+
+    Built by :meth:`skdr_eval.EvaluationArtifact.explain` and surfaced by the
+    ``skdr-eval explain`` CLI command (#201). It is a thin presentation layer
+    over the already-computed :class:`Recommendation` and
+    :class:`DiagnosticGate` — it never recomputes the evaluation, so the
+    narrative cannot drift from the card/report verdict.
+
+    Attributes
+    ----------
+    model_name, estimator : str
+        Which row this explanation describes.
+    verdict : str
+        ``"deploy"`` | ``"ab_test"`` | ``"do_not_deploy"`` |
+        ``"insufficient_evidence"`` (mirrors :attr:`Recommendation.verdict`).
+    confidence : str
+        ``"high"`` | ``"medium"`` | ``"low"``.
+    primary_blocker : str or None
+        Warning code that single-handedly blocks deployment, if any.
+    V_hat, ci_lower, ci_upper, baseline : float or None
+        Headline estimate, CI bounds, and the baseline the CI was compared
+        against.
+    reasons : list[Reason]
+        Ordered reasons (most severe first), from the recommendation.
+    gate : DiagnosticGate or None
+        The pass/warn/fail diagnostic gate, when it could be computed.
+    """
+
+    model_name: str
+    estimator: str
+    verdict: str
+    confidence: str
+    primary_blocker: str | None
+    V_hat: float | None
+    ci_lower: float | None
+    ci_upper: float | None
+    baseline: float | None
+    reasons: list[Reason]
+    gate: DiagnosticGate | None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain, JSON-ready dict."""
+        return {
+            "model_name": self.model_name,
+            "estimator": self.estimator,
+            "verdict": self.verdict,
+            "confidence": self.confidence,
+            "primary_blocker": self.primary_blocker,
+            "V_hat": self.V_hat,
+            "ci_lower": self.ci_lower,
+            "ci_upper": self.ci_upper,
+            "baseline": self.baseline,
+            "reasons": [
+                {"code": r.code, "message": r.message, "severity": r.severity}
+                for r in self.reasons
+            ],
+            "gate": self.gate.to_dict() if self.gate is not None else None,
+        }
+
+    def to_text(self) -> str:
+        """Render a concise, terminal-friendly narrative."""
+        ci = (
+            f"[{self.ci_lower:.4g}, {self.ci_upper:.4g}]"
+            if self.ci_lower is not None and self.ci_upper is not None
+            else "not available (run with ci_bootstrap=True)"
+        )
+        v_hat = f"{self.V_hat:.4g}" if self.V_hat is not None else "—"
+        baseline = f"{self.baseline:.4g}" if self.baseline is not None else "0"
+        lines = [
+            f"skdr-eval explain — {self.model_name} / {self.estimator}",
+            "─" * 48,
+            f"Verdict: {self.verdict.upper()} (confidence: {self.confidence})",
+            f"Estimate V_hat={v_hat}; CI {ci}; baseline {baseline}.",
+        ]
+        if self.primary_blocker:
+            lines.append(f"Primary blocker: {self.primary_blocker}")
+        lines.append("")
+        lines.append("Why:")
+        _sev_glyph = {"high_risk": "✗", "caution": "⚠", "info": "•"}
+        for r in self.reasons:
+            glyph = _sev_glyph.get(r.severity, "•")
+            lines.append(f"  {glyph} [{r.code}] {r.message}")
+        if self.gate is not None:
+            lines.append("")
+            lines.append(self.gate.to_text())
+        return "\n".join(lines)
+
+
 def _build_recommendation(
     artifact: EvaluationArtifact,
     model_name: str,

--- a/src/skdr_eval/reporting.py
+++ b/src/skdr_eval/reporting.py
@@ -1329,9 +1329,25 @@ class EvaluationArtifact:
             If ``model_name`` or ``estimator`` is not found in the artifact.
         """
         rec = self.recommendation(model_name, estimator=estimator, baseline=baseline)
+        # The gate is best-effort context: model/estimator membership was already
+        # validated by ``recommendation`` above, so the only expected failures here
+        # are missing diagnostic columns / metadata in a thinly reconstructed
+        # artifact. Catch those narrowly (not bare ``Exception``) so a genuine bug
+        # in ``gate_diagnostics`` still surfaces, and record why the gate was dropped.
         try:
             gate: DiagnosticGate | None = gate_diagnostics(self, model_name, estimator)
-        except Exception:  # pragma: no cover - gate is best-effort context
+        except (
+            DataValidationError,
+            KeyError,
+            ValueError,
+            TypeError,
+        ) as exc:  # pragma: no cover - gate is best-effort context
+            logger.debug(
+                "explain: gate omitted for %s/%s (best-effort): %s",
+                model_name,
+                estimator,
+                exc,
+            )
             gate = None
 
         row_mask = (self.report["model"] == model_name) & (

--- a/src/skdr_eval/reporting.py
+++ b/src/skdr_eval/reporting.py
@@ -1294,6 +1294,69 @@ class EvaluationArtifact:
             _policy = RecommendationPolicy(baseline=0.0)
         return _build_recommendation(self, model_name, estimator, _policy)
 
+    def explain(
+        self,
+        model_name: str,
+        *,
+        estimator: str = "SNDR",
+        baseline: float | None = None,
+    ) -> Explanation:
+        """Narrate *why* one (model, estimator) row received its verdict (#201).
+
+        Combines the structured :class:`Recommendation` (verdict, confidence,
+        reasons) with the :func:`gate_diagnostics` pass/warn/fail gate and the
+        headline estimate/CI into a single :class:`Explanation`. This is a pure
+        presentation layer over already-computed fields — it never recomputes
+        the evaluation, so the narrative cannot drift from the card/report.
+
+        Parameters
+        ----------
+        model_name : str
+            Model present in :attr:`detailed`.
+        estimator : str, default ``"SNDR"``
+            Estimator row to explain (any first-class estimator in the artifact).
+        baseline : float or None, default None
+            Baseline the CI is compared against; defaults to ``0.0``.
+
+        Returns
+        -------
+        Explanation
+            Structured, renderable narrative.
+
+        Raises
+        ------
+        DataValidationError
+            If ``model_name`` or ``estimator`` is not found in the artifact.
+        """
+        rec = self.recommendation(model_name, estimator=estimator, baseline=baseline)
+        try:
+            gate: DiagnosticGate | None = gate_diagnostics(self, model_name, estimator)
+        except Exception:  # pragma: no cover - gate is best-effort context
+            gate = None
+
+        row_mask = (self.report["model"] == model_name) & (
+            self.report["estimator"] == estimator
+        )
+        rows = self.report[row_mask]
+        row = rows.iloc[0] if not rows.empty else None
+        return Explanation(
+            model_name=model_name,
+            estimator=estimator,
+            verdict=rec.verdict,
+            confidence=rec.confidence,
+            primary_blocker=rec.primary_blocker,
+            V_hat=_coerce_optional_float(row.get("V_hat")) if row is not None else None,
+            ci_lower=(
+                _coerce_optional_float(row.get("ci_lower")) if row is not None else None
+            ),
+            ci_upper=(
+                _coerce_optional_float(row.get("ci_upper")) if row is not None else None
+            ),
+            baseline=baseline if baseline is not None else 0.0,
+            reasons=rec.reasons,
+            gate=gate,
+        )
+
     # ------------------------------------------------------------------ #
     # Card schema (#88)                                                   #
     # ------------------------------------------------------------------ #
@@ -1583,7 +1646,8 @@ def _build_interpretation(
 # and ``EvaluationArtifact`` methods can reference these names as module
 # globals. The verdict/gate logic is unchanged by the move.
 from .recommendation import (  # noqa: E402 - re-export after artifact definitions
-    DiagnosticGate,  # noqa: F401 - re-exported for skdr_eval.reporting compatibility
+    DiagnosticGate,
+    Explanation,
     GateResult,  # noqa: F401 - re-exported for skdr_eval.reporting compatibility
     Reason,  # noqa: F401 - re-exported for skdr_eval.reporting compatibility
     Recommendation,
@@ -2221,6 +2285,55 @@ def load_artifact_json(path: str | Path) -> ArtifactSchema:
     data = json.loads(p.read_text(encoding="utf-8"))
     schema: ArtifactSchema = ArtifactSchema.model_validate(data)
     return schema
+
+
+def _thin_artifact_from_schema(schema: ArtifactSchema) -> EvaluationArtifact:
+    """Reconstruct a minimal :class:`EvaluationArtifact` from a saved schema.
+
+    The verdict (:meth:`EvaluationArtifact.recommendation`) and gate
+    (:func:`gate_diagnostics`) read **only** the report DataFrame, the
+    ``(model, estimator)`` membership of ``detailed``, and ``metadata`` —
+    none of which require the original ``DRResult`` objects. So an explanation
+    can be rebuilt faithfully from a saved ``artifact.json`` without
+    re-running the evaluation (#201). The ``detailed`` map therefore carries
+    ``None`` sentinels: it is sufficient for membership checks but must not be
+    used for anything that dereferences a ``DRResult``.
+    """
+    report_df = pd.DataFrame([row.model_dump() for row in schema.report])
+    detailed: dict[str, dict[str, Any]] = {}
+    for row in schema.report:
+        detailed.setdefault(row.model, {})[row.estimator] = None
+    return EvaluationArtifact(
+        report=report_df,
+        detailed=detailed,  # sentinels only; see docstring
+        warnings=pd.DataFrame(),
+        sensitivity=pd.DataFrame(),
+        diagnostics={},
+        metadata=dict(schema.metadata),
+    )
+
+
+def explain_artifact_schema(
+    schema: ArtifactSchema,
+    model_name: str,
+    *,
+    estimator: str = "SNDR",
+    baseline: float | None = None,
+) -> Explanation:
+    """Explain a verdict from a saved :class:`ArtifactSchema` (#201).
+
+    Companion to :meth:`EvaluationArtifact.explain` for the common case where
+    only a saved ``artifact.json`` (loaded via :func:`load_artifact_json`) is
+    available — e.g. the ``skdr-eval explain`` CLI command. Reuses the existing
+    recommendation/gate logic, so the narrative matches the live artifact.
+
+    Raises
+    ------
+    DataValidationError
+        If ``model_name`` or ``estimator`` is not present in the schema.
+    """
+    artifact = _thin_artifact_from_schema(schema)
+    return artifact.explain(model_name, estimator=estimator, baseline=baseline)
 
 
 def export_results(

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -93,3 +93,53 @@ def test_find_spec_value_error_treated_as_missing(monkeypatch):
     caps = cap_module.get_capabilities()
     assert caps["viz"] is False
     assert caps["missing_extras"] == sorted(["speed", "viz"])
+
+
+class TestCapabilityMatrix:
+    """#215: the full optional-dependency capability matrix."""
+
+    def test_matrix_covers_every_declared_extra(self):
+        pyproject = tomllib.loads(
+            (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        )
+        declared = set(pyproject["project"]["optional-dependencies"])
+        # The matrix intentionally omits dev-only / docs / notebooks extras,
+        # but must cover every *runtime feature* extra.
+        feature_extras = {
+            "viz",
+            "speed",
+            "cli",
+            "boosting",
+            "mlflow",
+            "wandb",
+            "aim",
+        }
+        assert feature_extras <= declared, (
+            "matrix references extras not declared in pyproject.toml"
+        )
+        matrix = skdr_eval.get_capability_matrix()
+        assert {c.extra for c in matrix} == feature_extras
+
+    def test_matrix_entries_are_well_formed(self):
+        for cap in skdr_eval.get_capability_matrix():
+            assert isinstance(cap.installed, bool)
+            assert cap.feature
+            assert cap.install_hint == f"pip install 'skdr-eval[{cap.extra}]'"
+            assert cap.modules
+            assert cap.to_dict()["extra"] == cap.extra
+
+    def test_installed_reflects_module_presence(self, monkeypatch):
+        # Simulate an environment where only matplotlib (viz) is importable.
+        def only_matplotlib(name):
+            class _Spec:
+                pass
+
+            return _Spec() if name == "matplotlib" else None
+
+        monkeypatch.setattr(cap_module.importlib.util, "find_spec", only_matplotlib)
+        by_extra = {c.extra: c for c in cap_module.get_capability_matrix()}
+        assert by_extra["viz"].installed is True
+        # boosting needs all three of xgboost/lightgbm/catboost → absent.
+        assert by_extra["boosting"].installed is False
+        # speed needs pyarrow AND polars → absent.
+        assert by_extra["speed"].installed is False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -579,6 +579,107 @@ class TestPairwiseSubcommand:
         assert result.exit_code == EXIT_DATA
 
 
+def _artifact_json(tmp_path: Path) -> Path:
+    """Evaluate a small model and checkpoint the artifact JSON."""
+    logs, _, _ = skdr_eval.make_synth_logs(n=600, n_ops=3, seed=0)
+    models = {"HGB": HistGradientBoostingRegressor(max_iter=20, random_state=0)}
+    artifact = skdr_eval.evaluate_sklearn_models(
+        logs=logs,
+        models=models,
+        fit_models=True,
+        n_splits=3,
+        random_state=0,
+        policy_train="pre_split",
+    )
+    path = tmp_path / "artifact.json"
+    path.write_text(artifact.to_schema().model_dump_json(indent=2))
+    return path
+
+
+class TestExplainSubcommand:
+    """#201: ``skdr-eval explain``."""
+
+    def test_explain_text_output(self, tmp_path: Path):
+        artifact_json = _artifact_json(tmp_path)
+        result = runner.invoke(
+            app, ["explain", str(artifact_json), "--model", "HGB", "--estimator", "DR"]
+        )
+        assert result.exit_code == EXIT_OK, result.stdout
+        assert "HGB / DR" in result.stdout
+        assert "Verdict:" in result.stdout
+
+    def test_explain_json_output(self, tmp_path: Path):
+        artifact_json = _artifact_json(tmp_path)
+        result = runner.invoke(
+            app,
+            ["explain", str(artifact_json), "--model", "HGB", "--json"],
+        )
+        assert result.exit_code == EXIT_OK, result.stdout
+        payload = json.loads(result.stdout)
+        assert payload["model_name"] == "HGB"
+        assert "verdict" in payload
+        assert isinstance(payload["reasons"], list)
+
+    def test_explain_unknown_model_exits_data(self, tmp_path: Path):
+        artifact_json = _artifact_json(tmp_path)
+        result = runner.invoke(app, ["explain", str(artifact_json), "--model", "Nope"])
+        assert result.exit_code == EXIT_DATA
+
+
+class TestCapabilitiesSubcommand:
+    """#215: ``skdr-eval capabilities``."""
+
+    def test_capabilities_text(self):
+        result = runner.invoke(app, ["capabilities"])
+        assert result.exit_code == EXIT_OK, result.stdout
+        assert "capabilities" in result.stdout.lower()
+        for extra in ("viz", "cli", "boosting", "mlflow"):
+            assert extra in result.stdout
+
+    def test_capabilities_json(self):
+        result = runner.invoke(app, ["capabilities", "--json"])
+        assert result.exit_code == EXIT_OK
+        payload = json.loads(result.stdout)
+        extras = {row["extra"] for row in payload}
+        assert {"viz", "speed", "cli", "boosting", "mlflow", "wandb", "aim"} == extras
+        assert all(isinstance(row["installed"], bool) for row in payload)
+
+
+class TestDoctorRepro:
+    """#246: ``skdr-eval doctor --repro``."""
+
+    def test_repro_text_appended(self, synth_logs_parquet: Path):
+        result = runner.invoke(app, ["doctor", str(synth_logs_parquet), "--repro"])
+        assert "skdr_eval.doctor" in result.stdout
+        assert "import pandas as pd" in result.stdout
+
+    def test_repro_in_json(self, synth_logs_parquet: Path):
+        result = runner.invoke(
+            app, ["doctor", str(synth_logs_parquet), "--json", "--repro"]
+        )
+        payload = json.loads(result.stdout)
+        assert "repro" in payload
+        assert "skdr_eval.doctor" in payload["repro"]
+
+
+class TestQuickstartSubcommand:
+    """#207: ``skdr-eval quickstart`` golden path."""
+
+    def test_quickstart_writes_card_and_explains(self, tmp_path: Path):
+        out = tmp_path / "qs"
+        result = runner.invoke(app, ["quickstart", "--out", str(out), "--n", "800"])
+        # Onboarding demo always exits 0 on success (not a CI gate).
+        assert result.exit_code == EXIT_OK, result.stdout + result.stderr
+        assert (out / "report.html").is_file()
+        assert (out / "artifact.json").is_file()
+        assert "Verdict:" in result.stdout
+
+    def test_help_lists_new_subcommands(self):
+        result = runner.invoke(app, ["--help"])
+        for sub in ("explain", "capabilities", "quickstart"):
+            assert sub in result.stdout
+
+
 class TestLoadModelDirect:
     """Direct unit tests for _load_model to ensure coverage of guard paths."""
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -674,6 +674,19 @@ class TestQuickstartSubcommand:
         assert (out / "artifact.json").is_file()
         assert "Verdict:" in result.stdout
 
+    def test_quickstart_evaluation_error_exits_data(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A SkdrEvalError during evaluation surfaces as EXIT_DATA, not a crash."""
+
+        def _boom(*_args: object, **_kwargs: object) -> None:
+            raise skdr_eval.SkdrEvalError("synthetic evaluation failure")
+
+        monkeypatch.setattr(skdr_eval, "evaluate_sklearn_models", _boom)
+        out = tmp_path / "qs_err"
+        result = runner.invoke(app, ["quickstart", "--out", str(out), "--n", "800"])
+        assert result.exit_code == EXIT_DATA, result.stdout + result.stderr
+
     def test_help_lists_new_subcommands(self):
         result = runner.invoke(app, ["--help"])
         for sub in ("explain", "capabilities", "quickstart"):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -8,7 +8,14 @@ import numpy as np
 import pandas as pd
 
 import skdr_eval
-from skdr_eval.doctor import Check, DoctorReport, _check_environment, doctor
+from skdr_eval.doctor import (
+    Check,
+    DoctorReport,
+    _check_environment,
+    _check_missingness,
+    _check_time_ordering,
+    doctor,
+)
 
 
 def _good_logs(n: int = 800):
@@ -184,6 +191,98 @@ class TestDoctorBadKwargs:
         assert any(
             "kind" in c.name.lower() or "bogus" in c.message for c in report.checks
         )
+
+
+class TestTimeOrdering:
+    """#164: chronological-order check for time-aware CV."""
+
+    def test_sorted_arrival_ts_passes(self):
+        check = _check_time_ordering(_good_logs(), time_col="arrival_ts")
+        assert check.status == "pass"
+
+    def test_unsorted_arrival_ts_warns(self):
+        logs = _good_logs().sort_values("arrival_ts").reset_index(drop=True)
+        shuffled = logs.iloc[::-1].reset_index(drop=True)
+        check = _check_time_ordering(shuffled, time_col="arrival_ts")
+        assert check.status == "warn"
+        assert "out-of-order" in check.message
+        assert "sort_values" in check.fix_hint
+
+    def test_missing_time_column_warns(self):
+        check = _check_time_ordering(
+            pd.DataFrame({"x": [1, 2, 3]}), time_col="arrival_ts"
+        )
+        assert check.status == "warn"
+
+    def test_numeric_time_column_supported(self):
+        df = pd.DataFrame({"arrival_day": [0, 1, 1, 2, 5]})
+        assert _check_time_ordering(df, time_col="arrival_day").status == "pass"
+        df_bad = pd.DataFrame({"arrival_day": [5, 1, 0]})
+        assert _check_time_ordering(df_bad, time_col="arrival_day").status == "warn"
+
+
+class TestMissingness:
+    """#164: high-missingness column detection."""
+
+    def test_clean_frame_passes(self):
+        check = _check_missingness(_good_logs())
+        assert check.status == "pass"
+
+    def test_high_missingness_warns(self):
+        df = pd.DataFrame({"a": [1.0, None, None, None, None], "b": [1, 2, 3, 4, 5]})
+        check = _check_missingness(df, threshold=0.2)
+        assert check.status == "warn"
+        assert "a=80.0%" in check.message
+        assert "b" not in check.message.split(":")[-1]
+
+    def test_empty_frame_warns(self):
+        check = _check_missingness(pd.DataFrame())
+        assert check.status == "warn"
+
+
+class TestCapabilityMatrixAndProfile:
+    """#215 + #246: doctor surfaces the capability matrix, profile, repro."""
+
+    def test_report_carries_capabilities_and_profile(self):
+        report = doctor(_good_logs(n=600))
+        assert report.capabilities  # non-empty matrix
+        assert {c.extra for c in report.capabilities} >= {"viz", "cli", "boosting"}
+        assert report.profile is not None
+        assert report.profile.kind == "standard"
+        assert report.profile.n_rows == 600
+        assert report.profile.metric_col == "service_time"
+
+    def test_to_dict_includes_capabilities_and_profile(self):
+        d = doctor(_good_logs(n=600)).to_dict()
+        assert "capabilities" in d
+        assert "profile" in d
+        assert d["profile"]["n_rows"] == 600
+        assert all("installed" in c for c in d["capabilities"])
+
+    def test_to_text_renders_capability_matrix(self):
+        text = doctor(_good_logs(n=600)).to_text()
+        assert "capability matrix" in text.lower()
+
+    def test_to_repro_is_runnable_and_data_free(self):
+        logs = _good_logs(n=600)
+        report = doctor(logs)
+        repro = report.to_repro()
+        # No real values: every observed service_time / cli_* value must be absent.
+        sample_values = [repr(v) for v in logs["service_time"].head(5).tolist()]
+        for val in sample_values:
+            assert val not in repro
+        # Carries the schema (column names + dtypes + shape only).
+        assert "service_time" in repro
+        assert "n = 600" in repro
+        # Runs and yields a DoctorReport without touching the original data.
+        namespace: dict = {}
+        exec(repro.replace("print(report.to_text())", ""), namespace)
+        assert isinstance(namespace["report"], DoctorReport)
+
+    def test_to_repro_without_profile_is_safe(self):
+        report = doctor("not a dataframe")  # type: ignore[arg-type]
+        assert report.profile is None
+        assert "No reproduction available" in report.to_repro()
 
 
 def test_environment_check_fails_below_minimum(monkeypatch) -> None:

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -284,6 +284,30 @@ class TestCapabilityMatrixAndProfile:
         assert report.profile is None
         assert "No reproduction available" in report.to_repro()
 
+    def test_to_repro_runs_with_extension_dtypes(self):
+        # Pandas extension / annotated dtypes must normalize to a
+        # NumPy-constructible placeholder so the snippet still runs.
+        df = pd.DataFrame(
+            {
+                "nullable_int": pd.array([1, 2, 3], dtype="Int64"),
+                "nullable_float": pd.array([1.0, 2.0, 3.0], dtype="Float64"),
+                "nullable_bool": pd.array([True, False, True], dtype="boolean"),
+                "string_col": pd.array(["a", "b", "c"], dtype="string"),
+                "cat_col": pd.Series(["x", "y", "x"], dtype="category"),
+                "service_time": [1.0, 2.0, 3.0],
+            }
+        )
+        repro = doctor(df).to_repro()
+        # The generated snippet must execute without raising.
+        namespace: dict = {}
+        exec(repro.replace("print(report.to_text())", ""), namespace)
+        assert isinstance(namespace["report"], DoctorReport)
+        # The executable generator expressions use normalized NumPy dtype names
+        # (the original extension dtype is preserved only in a trailing comment).
+        assert 'np.zeros(n, dtype="int64")' in repro
+        assert 'np.zeros(n, dtype="float64")' in repro
+        assert 'dtype="Int64"' not in repro
+
 
 def test_environment_check_fails_below_minimum(monkeypatch) -> None:
     """The environment check fails when the running Python is below the

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -1,0 +1,96 @@
+"""Tests for the verdict-explanation surface (#201).
+
+Covers :meth:`EvaluationArtifact.explain`, the schema-based
+:func:`explain_artifact_schema`, and the :class:`Explanation` rendering — all of
+which are a pure presentation layer over the existing recommendation/gate logic
+(no statistical recomputation).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from sklearn.ensemble import HistGradientBoostingRegressor
+
+import skdr_eval
+from skdr_eval import Explanation, explain_artifact_schema, load_artifact_json
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _artifact(*, ci_bootstrap: bool = False):
+    logs, _, _ = skdr_eval.make_synth_logs(n=600, n_ops=3, seed=0)
+    models = {"hgb": HistGradientBoostingRegressor(max_iter=20, random_state=0)}
+    return skdr_eval.evaluate_sklearn_models(
+        logs=logs,
+        models=models,
+        fit_models=True,
+        n_splits=3,
+        random_state=0,
+        ci_bootstrap=ci_bootstrap,
+        policy_train="pre_split",
+    )
+
+
+class TestEvaluationArtifactExplain:
+    def test_explain_matches_recommendation_verdict(self):
+        artifact = _artifact()
+        rec = artifact.recommendation("hgb", estimator="SNDR")
+        expl = artifact.explain("hgb", estimator="SNDR")
+        assert isinstance(expl, Explanation)
+        # The narrative must not drift from the structured recommendation.
+        assert expl.verdict == rec.verdict
+        assert expl.confidence == rec.confidence
+        assert expl.primary_blocker == rec.primary_blocker
+        assert [r.code for r in expl.reasons] == [r.code for r in rec.reasons]
+
+    def test_explain_renders_reasons_with_thresholds(self):
+        expl = _artifact().explain("hgb", estimator="DR")
+        text = expl.to_text()
+        assert "hgb / DR" in text
+        assert expl.verdict.upper() in text
+        # The embedded gate names a measured value against its threshold.
+        if expl.gate is not None:
+            assert "overlap" in expl.gate.to_text()
+
+    def test_explain_unknown_model_raises(self):
+        with pytest.raises(skdr_eval.DataValidationError):
+            _artifact().explain("does-not-exist", estimator="SNDR")
+
+    def test_explain_to_dict_is_jsonable(self):
+        d = _artifact().explain("hgb", estimator="SNDR").to_dict()
+        assert set(d) >= {"verdict", "confidence", "reasons", "gate", "V_hat"}
+        assert isinstance(d["reasons"], list)
+
+
+class TestExplainArtifactSchema:
+    def test_schema_explanation_matches_live(self, tmp_path: Path):
+        artifact = _artifact()
+        live = artifact.explain("hgb", estimator="SNDR")
+        path = tmp_path / "artifact.json"
+        artifact.to_json(path)
+        schema = load_artifact_json(path)
+        from_schema = explain_artifact_schema(schema, "hgb", estimator="SNDR")
+        # Reconstructed-from-disk explanation must equal the live one.
+        assert from_schema.verdict == live.verdict
+        assert from_schema.primary_blocker == live.primary_blocker
+        assert [r.code for r in from_schema.reasons] == [r.code for r in live.reasons]
+        assert from_schema.to_dict()["gate"] == live.to_dict()["gate"]
+
+    def test_schema_explanation_unknown_estimator_raises(self, tmp_path: Path):
+        artifact = _artifact()
+        path = tmp_path / "artifact.json"
+        artifact.to_json(path)
+        schema = load_artifact_json(path)
+        with pytest.raises(skdr_eval.DataValidationError):
+            explain_artifact_schema(schema, "hgb", estimator="NOPE")
+
+    def test_no_ci_yields_insufficient_evidence_narrative(self, tmp_path: Path):
+        artifact = _artifact(ci_bootstrap=False)
+        expl = artifact.explain("hgb", estimator="SNDR")
+        # Without a high-risk blocker, no CI ⇒ insufficient_evidence; with one,
+        # do_not_deploy. Either way the CI line must say it is unavailable.
+        assert expl.verdict in {"insufficient_evidence", "do_not_deploy"}
+        assert "not available" in expl.to_text()


### PR DESCRIPTION
# Pull Request

## 📋 Description

Implements the **CLI-first diagnostics & verdict-explainability** group as one
coherent change over the `cli.py` / `doctor.py` / `capabilities.py` surface. All
five issues share that implementation path; `quickstart` (#207) is the
connective tissue that chains `doctor → evaluate → explain`.

### Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 📚 Documentation update
- [x] 🧪 Test improvements

## 🔗 Related Issues

- Closes #201 — `skdr-eval explain` / `EvaluationArtifact.explain()`
- Closes #207 — `skdr-eval quickstart` golden path
- Closes #215 — capability matrix in `doctor` + `skdr-eval capabilities`
- Closes #164 — stronger `doctor` (time-ordering, missingness, JSON output)
- Closes #246 — data-free minimal-reproduction snippet

## 🧪 Testing

### Test Coverage
- [x] Added tests that prove the features work (`tests/test_explain.py` + additions to `test_cli.py`, `test_doctor.py`, `test_capabilities.py`)
- [x] New and existing unit tests pass locally
- [x] Integration (CLI) tests added via Typer's `CliRunner`

### Manual Testing
- [x] Exercised every new command end-to-end via the installed `skdr-eval` entry point
- [x] Tested edge cases (unknown model/estimator → exit 1; no-CI → `insufficient_evidence`; non-DataFrame input → safe `to_repro`)

**Test commands run:**
```bash
ruff check src/ tests/            # All checks passed!
ruff format --check src/ tests/   # 105 files already formatted
mypy src/skdr_eval/               # Success: no issues found in 44 source files
python -m pytest tests/test_cli.py tests/test_doctor.py \
  tests/test_capabilities.py tests/test_explain.py \
  tests/test_reporting_artifact.py tests/test_recommendation_invariants.py \
  tests/test_cli_exit_codes.py        # 209 passed (+ 31 new)
```

> Note: `make validate` runs the bare `pytest` binary, which in this sandbox
> resolves to a uv-tool install with an isolated interpreter lacking the project
> deps; the project interpreter (`python -m pytest`) is green. CI uses the
> project environment, so this is a local-sandbox PATH quirk only.

## 📝 Changes Made

### Code Changes
- **`explain` (#201)** — `EvaluationArtifact.explain()`, module-level `explain_artifact_schema()`, and the `Explanation` dataclass. The CLI reads a saved `artifact.json` and narrates the verdict (each reason + measured value + threshold) **without re-running** the evaluation. Pure presentation over the existing `Recommendation`/`DiagnosticGate` — **no statistical-logic change**, so the narrative can't drift from the card/report.
- **`quickstart` (#207)** — one command: synth logs → `doctor` → `evaluate` → card → `explain`. Always exits `0` (onboarding demo, not a CI gate).
- **`capabilities` (#215)** — `get_capability_matrix()` + `Capability` cover every runtime extra (`viz`/`speed`/`cli`/`boosting`/`mlflow`/`wandb`/`aim`) with feature + install hint; rendered by `doctor` and the new `skdr-eval capabilities` command. `get_capabilities()` is unchanged (companion, not a breaking change).
- **`doctor` (#164)** — new time-ordering and column-missingness checks; captures a privacy-safe `DataProfile` (column names/dtypes/shape only).
- **repro (#246)** — `DoctorReport.to_repro()` / `skdr-eval doctor --repro` emit a copy-paste, **data-free** minimal reproduction (same schema/shape, placeholder values, no real cell values).

### API Changes
- [x] Backward compatible API additions

**API changes:** new public symbols `Explanation`, `explain_artifact_schema`, `EvaluationArtifact.explain`, `Capability`, `get_capability_matrix`, `DataProfile`, and new `DoctorReport.{capabilities,profile,to_repro}` fields/methods. No existing signatures changed.

## 📚 Documentation
- [x] README CLI section + preflight section updated
- [x] Docstrings on all new public functions/classes
- [x] CHANGELOG.md `### Added` entry with issue links

## ✅ Checklist
- [x] Follows project style; `ruff check`/`ruff format`/`mypy` clean
- [x] Self-reviewed; no new warnings (suppressed only the benign pandas
  date-inference `UserWarning` in the best-effort ordering check)
- [x] Conventional-commit message
- [x] CHANGELOG updated

## 🔍 Review Notes

### Focus Areas
- `reporting._thin_artifact_from_schema` — reconstructs a minimal artifact from a saved schema so `explain` can reuse the **existing** recommendation/gate logic (verified to match the live artifact in `test_explain.py`). The `detailed` map holds `None` sentinels — sufficient for membership checks, never dereferenced.
- `quickstart` intentionally exits `0` even on a `do_not_deploy`/`insufficient_evidence` verdict (it's a demo); use `evaluate` for CI gating.

### Questions for Reviewers
- `to_repro()` fills synthetic columns with dtype-appropriate placeholders (zeros/empties), so for *clean* inputs the regenerated frame may itself fail schema validation — acceptable since the snippet's purpose is reproducing schema/setup failures while leaking no data. Happy to adjust the fidelity if you'd prefer.

## 📸 Examples

```bash
skdr-eval quickstart --out ./quickstart        # zero-to-card in one command
skdr-eval capabilities                          # what's installed + install hints
skdr-eval explain ./run/artifact.json --model HGB --estimator SNDR
skdr-eval doctor logs.parquet --repro           # data-free bug-report snippet
```

## 🚀 Deployment Notes
- [x] No special deployment considerations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4s4NZWJsZ2kYkfk21ScqK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4s4NZWJsZ2kYkfk21ScqK)_