### PR TITLE
docs: link the Weaver Stack overview article (Towards AI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CI](https://github.com/dgenio/skdr-eval/workflows/CI/badge.svg)](https://github.com/dgenio/skdr-eval/actions)
 [![Coverage](https://codecov.io/gh/dgenio/skdr-eval/branch/main/graph/badge.svg)](https://codecov.io/gh/dgenio/skdr-eval)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Read the Weaver Stack overview on Towards AI](https://img.shields.io/badge/Read_the_overview-Towards_AI-black?logo=medium&logoColor=white)](https://pub.towardsai.net/the-weaver-stack-one-contract-layer-for-safe-llm-agents-7f733cad5eac)
 
 **You trained a better recommender, routing model, treatment rule, or targeting
 policy. Offline metrics look good — but deploying it directly is risky.**


### PR DESCRIPTION
Adds a **Read the overview on Towards AI** badge to the README's badge row, linking the Weaver Stack pillar article so repo visitors can find the narrative context — why the stack exists and how the layers compose.

README only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
