### PR TITLE
chore(deps): harden dependency automation and Action pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      python-nonmajor:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: [minor, patch]
+      python-security-nonmajor:
+        applies-to: security-updates
+        patterns: ["*"]
+        update-types: [minor, patch]
+    labels: [dependencies]
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      actions-nonmajor:
+        applies-to: version-updates
+        patterns: ["*"]
+        update-types: [minor, patch]
+      actions-security:
+        applies-to: security-updates
+        patterns: ["*"]
+    labels: [dependencies]
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,12 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0  # Needed for setuptools_scm
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -34,186 +34,133 @@ jobs:
         ruff format --check src/ tests/ examples/
 
     - name: Type check with mypy
-      # mypy results are config-driven (python_version = 3.10), not interpreter
-      # dependent, so we type-check once on the oldest supported Python. This is
-      # also the only matrix entry where numpy stays < 2.5: numpy >= 2.5 dropped
-      # 3.10 and ships PEP 695 `type` stubs that mypy cannot parse under a 3.10
-      # target, so running mypy on 3.11+ would fail on numpy's own stub file.
       if: matrix.python-version == '3.10'
-      run: |
-        mypy src/skdr_eval/
+      run: mypy src/skdr_eval/
 
     - name: Test with pytest
-      run: |
-        pytest -v --cov=skdr_eval --cov-report=xml --cov-report=html --cov-report=term-missing
+      run: pytest -v --cov=skdr_eval --cov-report=xml --cov-report=html --cov-report=term-missing
 
     - name: Upload coverage reports
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
       with:
         file: ./coverage.xml
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false
 
-  # Floor-deps job (#152): install the *minimum* declared dependency versions
-  # on the lowest supported Python (3.10) and run the full suite. This proves
-  # every ``>=X`` lower bound in pyproject.toml is truthful — a normal CI run
-  # resolves the latest deps and would silently mask a broken floor.
   floor-deps:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
-        fetch-depth: 0  # Needed for setuptools_scm
-
+        fetch-depth: 0
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.10"
-
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
-
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
     - name: Install with scientific-core deps pinned to their declared floors
-      # constraints-min.txt pins numpy/pandas/scipy/scikit-learn to the floors
-      # declared in pyproject.toml, while dev/test tooling (pytest, matplotlib,
-      # …) still resolves at current versions. Flooring the test tooling itself
-      # is not the point — only the runtime scientific core.
-      run: |
-        uv pip install --system -e .[dev] --constraint constraints-min.txt
-
+      run: uv pip install --system -e .[dev] --constraint constraints-min.txt
     - name: Test with pytest (minimum dependency floors)
-      run: |
-        pytest -q --no-header
+      run: pytest -q --no-header
 
   examples-smoke:
     runs-on: ubuntu-latest
     needs: test
-
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
-
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.11"
-
     - name: Install (default extras only)
       run: |
         python -m pip install --upgrade pip
         pip install -e .
-
     - name: Run preflight example
-      run: |
-        python examples/preflight.py
-
+      run: python examples/preflight.py
     - name: Run quickstart example
-      run: |
-        python examples/quickstart.py
+      run: python examples/quickstart.py
 
   viz-extra-smoke:
     runs-on: ubuntu-latest
     needs: test
-
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
-
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.11"
-
     - name: Install with [viz] extra
       run: |
         python -m pip install --upgrade pip
         pip install -e .[viz]
-
     - name: Assert [viz] capability is enabled
-      run: |
-        python -c "import skdr_eval; caps = skdr_eval.get_capabilities(); assert caps['viz'], caps; print('viz capability:', caps['viz'])"
-
+      run: python -c "import skdr_eval; caps = skdr_eval.get_capabilities(); assert caps['viz'], caps; print('viz capability:', caps['viz'])"
     - name: Run preflight under [viz] extra
-      run: |
-        python examples/preflight.py
+      run: python examples/preflight.py
 
   cli-smoke:
     runs-on: ubuntu-latest
     needs: test
-
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
-
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.11"
-
     - name: Install with [cli] extra
       run: |
         python -m pip install --upgrade pip
         pip install -e .[cli]
-
     - name: skdr-eval CLI smoke (version + doctor on synth parquet)
       run: |
         skdr-eval version
-        python -c "import skdr_eval, pathlib; \
-            logs, _, _ = skdr_eval.make_synth_logs(n=800, n_ops=3, seed=0); \
-            logs.to_parquet('logs.parquet')"
+        python -c "import skdr_eval, pathlib; logs, _, _ = skdr_eval.make_synth_logs(n=800, n_ops=3, seed=0); logs.to_parquet('logs.parquet')"
         skdr-eval doctor logs.parquet --json
         skdr-eval validate-schema logs.parquet
 
   notebooks-smoke:
     runs-on: ubuntu-latest
     needs: test
-
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
-
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.11"
-
     - name: Install (dev extras include nbmake)
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev]
-
     - name: Execute Colab quickstart notebooks via nbmake
       run: |
-        python -m pytest --nbmake examples/notebooks/ \
-          --nbmake-timeout=300 \
-          --override-ini="addopts=" \
-          -p no:cacheprovider
+        python -m pytest --nbmake examples/notebooks/ --nbmake-timeout=300 --override-ini="addopts=" -p no:cacheprovider
 
   use-cases-smoke:
     runs-on: ubuntu-latest
     needs: test
-
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
-
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.11"
-
     - name: Install (default extras only)
       run: |
         python -m pip install --upgrade pip
         pip install -e .
-
     - name: Run domain use-case scripts
       run: |
         python examples/use_cases/01_ecommerce_ranking.py
@@ -224,87 +171,63 @@ jobs:
         python examples/use_cases/06_agent_routing_policy.py
         python examples/use_cases/07_simulator_and_scenarios.py
 
-  # Boosting-adapter job (#71): the GBDT adapter tests are skipif-gated on the
-  # backend being importable, and the default `test` job installs only `[dev]`
-  # (no xgboost/lightgbm/catboost), so they would otherwise always skip. This
-  # job installs `[boosting]` on one stable Python and runs them, so the
-  # XGBoost / LightGBM / CatBoost adapter paths are actually exercised in CI —
-  # without adding the heavy GBDT wheels to the 3.10–3.14 test matrix.
   boosting-smoke:
     runs-on: ubuntu-latest
     needs: test
-
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
-
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.12"
-
     - name: Install with [dev,boosting] extras
       run: |
         python -m pip install --upgrade pip
         pip install -e .[dev,boosting]
-
     - name: Run boosting adapter tests (XGBoost / LightGBM / CatBoost exercised)
-      run: |
-        pytest tests/test_adapters_boosting.py -v
+      run: pytest tests/test_adapters_boosting.py -v
 
   docs:
     runs-on: ubuntu-latest
     needs: test
-
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
-
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.12"
-
     - name: Install with [docs] extra
       run: |
         python -m pip install --upgrade pip
         pip install -e .[docs]
-
     - name: Build docs site (fail on warnings)
-      run: |
-        mkdocs build --strict
+      run: mkdocs build --strict
 
   build:
     runs-on: ubuntu-latest
     needs: test
-
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
-        fetch-depth: 0  # Needed for setuptools_scm
-
+        fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.11"
-
     - name: Install build dependencies
       run: |
         python -m pip install --upgrade pip
         pip install build twine
-
     - name: Build package
-      run: |
-        python -m build
-
+      run: python -m build
     - name: Check package
-      run: |
-        twine check dist/*
-
+      run: twine check dist/*
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: dist
         path: dist/

--- a/.github/workflows/deps-weekly.yml
+++ b/.github/workflows/deps-weekly.yml
@@ -1,39 +1,26 @@
 name: Weekly latest/pre-release deps
 
-# Safety net for the "no upper-bound caps" dependency policy (#152). A normal
-# CI run resolves whatever is current at the time; this scheduled job goes one
-# step further and installs the *newest* releases including pre-releases, so a
-# breaking numpy / scipy / scikit-learn / pandas release is caught early rather
-# than at a user's install time. It is allowed to fail (continue-on-error) —
-# a red run here is an early-warning signal, not a merge blocker.
-
+# Safety net for the "no upper-bound caps" dependency policy (#152).
 on:
   schedule:
-    - cron: "0 6 * * 1"  # Mondays 06:00 UTC
+    - cron: "0 6 * * 1"
   workflow_dispatch: {}
 
 jobs:
   latest-deps:
     runs-on: ubuntu-latest
     continue-on-error: true
-
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
-        fetch-depth: 0  # Needed for setuptools_scm
-
+        fetch-depth: 0
     - name: Set up Python 3.14
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.14"
-
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
-
+      uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
     - name: Install with newest deps (pre-releases allowed)
-      run: |
-        uv pip install --system --upgrade --prerelease allow -e .[dev]
-
+      run: uv pip install --system --upgrade --prerelease allow -e .[dev]
     - name: Test with pytest (latest/pre-release deps)
-      run: |
-        pytest -q --no-header
+      run: pytest -q --no-header

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,16 +1,11 @@
 name: Release
 
 on:
-  # Publish on the version tag only (#191). The job's final step creates the
-  # GitHub Release from that tag, so a `release: published` trigger here would
-  # fire a SECOND run that re-attempts the PyPI upload and fails with
-  # "File already exists". Tag-push is the single source of truth for a release.
   push:
     tags:
-      - 'v*'  # Trigger on any version tag (v1.0.0, v2.1.3, etc.)
-  workflow_dispatch:  # Allow manual triggering
+      - 'v*'
+  workflow_dispatch:
 
-# Never run two publishes for the same ref concurrently.
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
@@ -20,16 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     environment: release
     permissions:
-      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
-      contents: write  # Required to create GitHub Releases
+      id-token: write
+      contents: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
-        fetch-depth: 0  # Needed for setuptools_scm
+        fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.11"
 
@@ -40,46 +35,32 @@ jobs:
 
     - name: Verify git state for clean versioning
       run: |
-        echo "Current git status:"
         git status --porcelain
-        echo "Current git describe:"
         git describe --tags --long --dirty
-        echo "Expected setuptools-scm version:"
         python -c "import setuptools_scm; print(setuptools_scm.get_version())"
 
     - name: Clean working directory for setuptools-scm
       run: |
-        # Remove any untracked files that might interfere with versioning
         git clean -fd
-        # Check for uncommitted changes (but don't reset them if they're intentional)
         if [ -n "$(git status --porcelain)" ]; then
           echo "Warning: Working directory has uncommitted changes"
           git status --porcelain
         fi
-        echo "Current git describe:"
         git describe --tags --long --dirty
 
     - name: Build package
-      run: |
-        python -m build
+      run: python -m build
 
     - name: Verify built version matches tag
       run: |
-        # Extract version from the built wheel file
         BUILT_VERSION=$(python -c "
-        import zipfile
-        import os
-        import re
-        
-        # Find the wheel file
+        import zipfile, os
         for file in os.listdir('dist'):
             if file.endswith('.whl'):
                 with zipfile.ZipFile(f'dist/{file}', 'r') as wheel:
-                    # Look for the package metadata
                     for name in wheel.namelist():
                         if name.endswith('.dist-info/METADATA'):
                             content = wheel.read(name).decode('utf-8')
-                            # Extract version from metadata
                             for line in content.split('\n'):
                                 if line.startswith('Version:'):
                                     print(line.split(':', 1)[1].strip())
@@ -87,69 +68,41 @@ jobs:
                             break
                 break
         ")
-        
-        # Extract tag version (remove 'v' prefix if present)
         TAG_VERSION=${GITHUB_REF#refs/tags/}
         TAG_VERSION=${TAG_VERSION#v}
-
         echo "Built version: $BUILT_VERSION"
         echo "Tag version: $TAG_VERSION"
-        echo "Git describe: $(git describe --tags --long --dirty)"
-
-        # Check if versions match
-        if [[ "$BUILT_VERSION" == "$TAG_VERSION" ]]; then
-          echo "✅ Version verification passed: $BUILT_VERSION (matches tag: $TAG_VERSION)"
-        else
-          echo "❌ ERROR: Built version ($BUILT_VERSION) does not match tag version ($TAG_VERSION)"
-          echo "This indicates a setuptools-scm configuration issue."
-          echo "Git status:"
-          git status --porcelain
-          echo "Git log (last 3 commits):"
-          git log --oneline -3
-          ls -la dist/
+        if [[ "$BUILT_VERSION" != "$TAG_VERSION" ]]; then
+          echo "ERROR: Built version does not match tag"
           exit 1
         fi
 
     - name: Check package
-      run: |
-        twine check dist/*
+      run: twine check dist/*
 
     - name: Publish to PyPI (Trusted Publishing)
       id: pypi-publish
       continue-on-error: true
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
       with:
         print-hash: true
 
     - name: Fallback - Manual PyPI publish instructions
       if: steps.pypi-publish.outcome == 'failure'
       run: |
-        echo "❌ Trusted Publishing failed. Manual upload required."
-        echo ""
-        echo "To publish manually:"
-        echo "1. Download the build artifacts from this workflow"
-        echo "2. Set up your PyPI API token: https://pypi.org/manage/account/token/"
-        echo "3. Run: pip install twine"
-        echo "4. Run: twine upload dist/*"
-        echo ""
-        echo "For Trusted Publishing setup:"
-        echo "1. Go to https://pypi.org/manage/project/skdr-eval/settings/publishing/"
-        echo "2. Add this GitHub repository as a trusted publisher"
-        echo "3. Set environment name to 'release'"
-        echo "4. Set workflow filename to 'release.yml'"
-        echo ""
+        echo "Trusted Publishing failed. Manual upload required."
         exit 1
 
     - name: Upload build artifacts (for manual fallback)
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: dist-${{ github.run_number }}
         path: dist/
 
     - name: Create GitHub Release
       if: startsWith(github.ref, 'refs/tags/v')
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@7c4723f7a335432393329f8f1c564994ce50185d # v3
       with:
         files: dist/*
         generate_release_notes: false


### PR DESCRIPTION
## What changed

- add lightweight Dependabot for grouped routine non-major Python and GitHub Actions updates
- add explicit security groups, seven-day cooldowns, PR limits, labels, and commit prefixes
- leave breaking majors separate
- SHA-pin CI, floor-dependency, latest/pre-release, coverage, build-artifact, and release Actions
- keep the existing lower-bound and latest/pre-release compatibility model intact

## Why

`skdr-eval` already has the right library compatibility strategy. This adds reviewable stable-update automation and immutable Action references without introducing lockfile churn or weakening the floor/latest test model.