### PR TITLE
fix(packaging): make Python compatibility forward-open

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,21 +7,14 @@ updates:
       day: monday
       time: "06:00"
       timezone: Etc/UTC
-    open-pull-requests-limit: 5
-    cooldown:
-      default-days: 7
+    open-pull-requests-limit: 0
     groups:
-      python-nonmajor:
-        applies-to: version-updates
-        patterns: ["*"]
-        update-types: [minor, patch]
-      python-security-nonmajor:
+      python-security:
         applies-to: security-updates
         patterns: ["*"]
-        update-types: [minor, patch]
     labels: [dependencies]
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "fix(deps)"
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/.github/workflows/python-next.yml
+++ b/.github/workflows/python-next.yml
@@ -1,0 +1,33 @@
+name: Python Next Canary
+
+on:
+  schedule:
+    - cron: "5 7 * * 3"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "pyproject.toml"
+      - ".github/workflows/python-next.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  python-next:
+    name: Python 3.15 pre-release
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.15"
+          allow-prereleases: true
+      - name: Install runtime and test harness
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e . pytest pytest-cov
+      - name: Import smoke
+        run: python -c "import skdr_eval; print(skdr_eval.__name__)"
+      - name: Test core package
+        run: pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.10,<3.15"
+requires-python = ">=3.10"
 # Library-grade dependency constraints (#152): lower bounds only — no exact
 # pins (``==``) and no speculative upper-bound caps. Floors are the lowest
 # versions the test suite is known to pass on (proven by the ``floor-deps``
@@ -156,8 +156,6 @@ skdr_eval = ["templates/*.html"]
 write_to = "src/skdr_eval/_version.py"
 tag_regex = "^v(?P<version>[^\\+]+)(?:\\+.*)?$"
 fallback_version = "0.0.0"
-# Use "dirty-tag" to append '.dirty' to the version when the working directory has uncommitted changes,
-# making it clear when a build is not from a clean state.
 local_scheme = "dirty-tag"
 
 [tool.pytest.ini_options]
@@ -235,19 +233,10 @@ module = [
 ]
 ignore_missing_imports = true
 
-# The Typer CLI module uses ``@app.command(...)`` decorators that mypy
-# (correctly) flags as untyped because Typer's command decorator is
-# overloaded; suppress only that one error code so the rest of the strict
-# config still applies.
-# NOTE: These overrides mirror mypy.ini (which takes precedence at runtime).
 [[tool.mypy.overrides]]
 module = ["skdr_eval.cli"]
 disable_error_code = ["untyped-decorator"]
 
-# Conflict-resistant changelog (#255). Each PR drops a small fragment under
-# changelog.d/ (e.g. ``123.fixed.md``) instead of editing a shared "Unreleased"
-# section, so concurrent branches stop colliding on CHANGELOG.md. The fragments
-# are compiled into a dated section at release time with ``make changelog``.
 [tool.towncrier]
 package = "skdr_eval"
 directory = "changelog.d"
@@ -256,7 +245,6 @@ start_string = "<!-- towncrier release notes start -->\n"
 title_format = "## [{version}] - {project_date}"
 issue_format = "[#{issue}](https://github.com/dgenio/skdr-eval/issues/{issue})"
 underlines = ["", "", ""]
-# Non-fragment files kept in changelog.d/ for humans, not for compilation.
 ignore = ["README.md", ".gitkeep"]
 
 [[tool.towncrier.type]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,8 @@ skdr_eval = ["templates/*.html"]
 write_to = "src/skdr_eval/_version.py"
 tag_regex = "^v(?P<version>[^\\+]+)(?:\\+.*)?$"
 fallback_version = "0.0.0"
+# Use "dirty-tag" to append '.dirty' to the version when the working directory has uncommitted changes,
+# making it clear when a build is not from a clean state.
 local_scheme = "dirty-tag"
 
 [tool.pytest.ini_options]
@@ -233,10 +235,19 @@ module = [
 ]
 ignore_missing_imports = true
 
+# The Typer CLI module uses ``@app.command(...)`` decorators that mypy
+# (correctly) flags as untyped because Typer's command decorator is
+# overloaded; suppress only that one error code so the rest of the strict
+# config still applies.
+# NOTE: These overrides mirror mypy.ini (which takes precedence at runtime).
 [[tool.mypy.overrides]]
 module = ["skdr_eval.cli"]
 disable_error_code = ["untyped-decorator"]
 
+# Conflict-resistant changelog (#255). Each PR drops a small fragment under
+# changelog.d/ (e.g. ``123.fixed.md``) instead of editing a shared "Unreleased"
+# section, so concurrent branches stop colliding on CHANGELOG.md. The fragments
+# are compiled into a dated section at release time with ``make changelog``.
 [tool.towncrier]
 package = "skdr_eval"
 directory = "changelog.d"
@@ -245,6 +256,7 @@ start_string = "<!-- towncrier release notes start -->\n"
 title_format = "## [{version}] - {project_date}"
 issue_format = "[#{issue}](https://github.com/dgenio/skdr-eval/issues/{issue})"
 underlines = ["", "", ""]
+# Non-fragment files kept in changelog.d/ for humans, not for compilation.
 ignore = ["README.md", ".gitkeep"]
 
 [[tool.towncrier.type]]


### PR DESCRIPTION
Closes #291.

- remove the speculative `<3.15` `Requires-Python` cap
- make Python Dependabot security-only so routine releases do not rewrite public compatibility ranges
- retain existing floor/latest dependency testing
- add a non-gating Python 3.15 pre-release canary

The current stable 3.10–3.14 compatibility claim remains unchanged; the new canary surfaces future interpreter breakage without pre-emptively rejecting it.