### PR TITLE
docs(packaging): make public OPE maturity and purpose honest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "skdr-eval"
 dynamic = ["version"]
-description = "Offline policy evaluation (OPE) for scikit-learn policies — time-aware doubly-robust (DR/SNDR) estimates with honest trust diagnostics and a deploy / don't-deploy verdict"
+description = "Offline policy evaluation (OPE) for scikit-learn-compatible decision policies — DR/SNDR estimates with overlap, support, sensitivity, and uncertainty diagnostics for pre-experiment review"
 readme = "README.md"
 license = {text = "MIT"}
 authors = [
@@ -22,6 +22,10 @@ keywords = [
     "contextual bandits",
     "causal inference",
     "treatment effects",
+    "decision policy",
+    "routing policy",
+    "agent evaluation",
+    "llm evaluation",
     "ranking",
     "recommender systems",
     "ad targeting",
@@ -33,7 +37,7 @@ keywords = [
     "python",
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 3 - Alpha",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Public package metadata currently out-runs the scientific maturity documented in the active backlog: it advertises a `deploy / don't-deploy verdict` and a Beta classifier while #282/#58/#280/#62 still gate the trusted estimator path and #245 is explicitly moving the product toward experiment-eligibility semantics.

This PR changes metadata only:

- description: DR/SNDR + overlap/support/sensitivity/uncertainty diagnostics for **pre-experiment review**, not a deployment verdict
- maturity: `Development Status :: 4 - Beta` → `3 - Alpha` while the trusted-path gate is unresolved
- adds accurate PyPI discovery keywords for decision/routing policy and agent/LLM evaluation

No estimator, threshold, report, CLI, dependency, or runtime behavior changes. This intentionally does **not** close #245 or #282; it stops current packaging metadata from overclaiming while those issues are being resolved.

Validation target is the exact final head.