### PR TITLE
[Superseded by #303] docs: define validated-v1 evidence envelope

### DIFF
--- a/docs/design-partner-study.md
+++ b/docs/design-partner-study.md
@@ -1,0 +1,207 @@
+# Design-partner validation study
+
+This document operationalizes issue #299. The purpose is to falsify or validate the product thesis with practitioners who have the data required for defensible one-step OPE.
+
+This is **not** a marketing interview script and should not be used to solicit stars, endorsements, or feature wishlists.
+
+## Questions the study must answer
+
+1. Do enough target teams actually log the data required by validated-v1?
+2. Can a competent practitioner map those logs to the contract without maintainer intervention?
+3. Does the evidence artifact change or improve a real experiment-review decision?
+4. Is the evidence-quality layer meaningfully more useful than direct use of established OPE tooling?
+5. Which recurring obstacles justify product work after validation?
+
+## Recruitment
+
+Target approximately 15–20 practitioner conversations across several settings:
+
+- recommender / personalization teams;
+- advertising / targeting / contextual-bandit experimentation;
+- operational routing or assignment systems with explicit exploration;
+- model/LLM routing only when the team genuinely logs action eligibility and behavior probabilities.
+
+Prefer practitioners who have participated in real randomized online experiments and can discuss their logging/review process concretely.
+
+Do not count generic ML practitioners with no policy-logging workflow as successful design partners; their lack of readiness is itself useful market evidence.
+
+## Screening
+
+Before a hands-on attempt, establish whether the team can answer **yes** to the key data questions:
+
+- Is the action selected at each decision explicitly recorded?
+- Is the eligible action set known or reconstructable for that decision?
+- Is the probability of the logged action recorded at decision time?
+- Is the logging-policy provenance auditable?
+- Is there a scalar outcome/reward tied to the decision?
+- Can the target policy produce an explicit action distribution over the same vocabulary?
+- Is the problem one-step/contextual rather than long-horizon sequential RL?
+
+Record `yes`, `no`, or `unknown`; do not reinterpret missing information as available.
+
+## Interview guide
+
+### Existing decision process
+
+- What happens between an offline model improvement and permission to run an online experiment?
+- Who reviews the evidence?
+- Which offline metrics are currently considered persuasive?
+- Which failure modes make reviewers reject an offline result?
+- How much does a failed online experiment cost in time, traffic, revenue, operational risk, or opportunity cost?
+
+### Logging contract
+
+- Why does the behavior policy randomize, if it does?
+- Where is the action probability generated and logged?
+- Can probabilities be lost, rounded, recomputed, or joined incorrectly?
+- Does action eligibility change per request/user/time?
+- Can deployed policy versions be tied to each log row?
+- Are outcomes delayed, censored, or missing?
+
+### Current OPE behavior
+
+- Do you already run IPS/DR/OPE?
+- Which implementation do you trust and why?
+- How do you assess overlap/support today?
+- Do you ever refuse to report an offline estimate because support is inadequate?
+- How are confidence intervals interpreted in experiment review?
+
+### Artifact usefulness
+
+Show the narrow evidence concept, not a polished sales demo.
+
+Ask:
+
+- Which fields would you use in an actual review?
+- Which fields would you distrust or ignore?
+- What could be misinterpreted?
+- Would you attach this artifact to a PR, experiment ticket, model card, or review document?
+- What evidence is missing before you would rely on it?
+
+## Hands-on study
+
+Aim for at least five data-ready attempts.
+
+Use the same validated-v1 workflow for all participants unless a compatibility bug prevents it. Avoid bespoke integrations during the study.
+
+Record timestamps for:
+
+1. start;
+2. data-contract understanding;
+3. first `doctor`/validation result;
+4. first successful evaluation, if reached;
+5. first evidence artifact;
+6. participant's interpretation of the result.
+
+Record every maintainer intervention and classify it:
+
+- unclear documentation;
+- schema mismatch;
+- missing instrumentation;
+- software bug;
+- unsupported problem setting;
+- statistical concept confusion;
+- missing integration;
+- performance/resource problem;
+- other.
+
+## Outcome record per participant
+
+Use an anonymized record such as:
+
+```yaml
+participant_id: P01
+domain: recommender
+qualified_for_validated_v1: true
+logged_propensity_available: true
+eligibility_available: true
+target_policy_distribution_available: true
+minutes_to_valid_schema: 18
+minutes_to_first_artifact: 42
+maintainer_interventions: 1
+artifact_used_in_real_decision: true
+repeat_evaluation_within_study: false
+outcome:
+  - narrowed experiment population
+  - identified weak support
+blocking_friction:
+  - eligibility column mapping unclear
+requested_features:
+  - parquet CLI example
+```
+
+Never store confidential business data, raw logs, participant PII, or proprietary model information in the public study record.
+
+## Aggregate metrics
+
+At minimum report:
+
+- number screened;
+- percentage with logged propensities;
+- percentage with explicit/reconstructable eligibility;
+- percentage satisfying full validated-v1 data contract;
+- median time to valid schema;
+- median time to first artifact among qualified attempts;
+- percentage completing without maintainer intervention;
+- number of artifacts used in a real review decision;
+- number of repeat evaluations;
+- recurring friction themes;
+- recurring feature requests, counting only independently repeated requests;
+- reasons for non-adoption.
+
+## Predeclared product decisions
+
+### Continue native-product strategy
+
+Evidence:
+
+- multiple independent teams satisfy the data contract;
+- users can complete the workflow with low maintainer intervention;
+- evidence artifacts enter real review decisions;
+- users value native estimation plus evidence quality.
+
+### Pivot toward an evidence/reporting layer over established backends
+
+Evidence:
+
+- users prefer established estimator backends such as OBP/VW for computation;
+- they still value skdr-eval's evidence validation, abstention, provenance, and artifact semantics.
+
+### Pivot toward OPE-readiness / decision-logging tooling
+
+Evidence:
+
+- otherwise relevant teams repeatedly fail screening because behavior probabilities, action eligibility, or policy provenance are not logged;
+- instrumentation/readiness is a more common pain than estimator execution.
+
+### Narrow or stop
+
+Evidence:
+
+- qualified teams already solve the problem adequately with existing tooling;
+- the evidence artifact does not change review decisions;
+- the workflow requires persistent maintainer involvement;
+- the addressable set of data-ready teams is too small for the maintenance burden.
+
+## Kill criteria
+
+Trigger an explicit product-strategy review when any of the following holds:
+
+- fewer than roughly 3 of the first 15 qualified-target conversations have the validated-v1 data contract;
+- fewer than 2 of 5 data-ready attempts produce an artifact used in a real review decision;
+- most successful users prefer a direct established backend and see no material value in the evidence layer;
+- more than half of data-ready attempts require nontrivial maintainer intervention after obvious docs bugs are fixed.
+
+Do not move the goalposts after observing the results without documenting why.
+
+## Feature-request rule
+
+A design-partner request is not automatically roadmap evidence.
+
+Promote a feature only when it:
+
+- fixes a correctness or misuse problem; or
+- is independently requested/observed across multiple design partners; or
+- directly unblocks the validated-v1 workflow.
+
+Record one-off requests, but keep them deferred.

--- a/docs/methodological-review-protocol.md
+++ b/docs/methodological-review-protocol.md
@@ -1,0 +1,142 @@
+# Independent methodological review protocol
+
+This document operationalizes issue #298. It is a review protocol, not a testimonial template.
+
+The purpose of independent review is to challenge the **specific validation envelope** claimed by `skdr-eval`, identify unsupported assumptions or misleading semantics, and create a public record of what was reviewed and what remains unresolved.
+
+## When to run the review
+
+Do not ask reviewers to certify a moving target.
+
+Prepare the review packet only after the validated-v1 contracts and corresponding evidence are coherent enough to inspect:
+
+- `docs/validated-v1.md` / #297;
+- explicit target-policy contract (#279);
+- effective OOF evaluation population (#280);
+- logged-propensity path (#167);
+- corrected multi-action estimand (#58);
+- estimator-specific reference agreement (#281);
+- end-to-end validation report (#62/#223);
+- evidence-state semantics (#245/#282);
+- historical correctness advisory (#300).
+
+The reviewed commit and validation-report version must be immutable and recorded.
+
+## Reviewer independence
+
+Aim for three distinct reviewer perspectives. One person may cover more than one perspective only when their expertise genuinely spans them, but at least two independent humans should review the package before an `independently_validated` claim is made.
+
+### OPE / contextual-bandit methods reviewer
+
+Challenge:
+
+- exact estimand and formulas;
+- behavior-policy and target-policy semantics;
+- deterministic vs stochastic policy representation;
+- action ordering and eligibility;
+- logged propensity interpretation;
+- DR/SNDR implementation details;
+- reference-equivalence assumptions;
+- overlap/positivity boundaries.
+
+### Causal / statistical-ML reviewer
+
+Challenge:
+
+- nuisance fitting and OOF guarantees;
+- evaluated population and exclusions;
+- uncertainty target and CI semantics;
+- temporal/dependence claims;
+- diagnostic thresholds and false reassurance;
+- distinction between empirical validation and untestable causal assumptions;
+- unsupported observational/clinical claims.
+
+### Production experimentation / recommender reviewer
+
+Challenge:
+
+- whether real logging systems can satisfy the data contract;
+- propensity provenance and instrumentation failure modes;
+- action-catalogue / eligibility drift;
+- artifact usefulness in a real review process;
+- ways a practitioner could misread `estimate_supported`;
+- whether the core accidentally authorizes experiments or deployment.
+
+## Review packet
+
+Provide the reviewer with a single versioned packet containing:
+
+1. exact package commit/tag;
+2. validated-v1 scope;
+3. public API examples that exercise only the claimed validated path;
+4. estimand/formula documentation;
+5. target-policy/action-distribution contract;
+6. behavior-propensity contract;
+7. effective evaluation-population semantics;
+8. reference-agreement reports and reference versions;
+9. known-ground-truth simulation configuration;
+10. validation report with bias, RMSE, coverage, interval width, abstention/failure, and false reassurance;
+11. evidence-state definitions and thresholds;
+12. explicit non-claims and unsupported regimes;
+13. historical correctness advisory;
+14. instructions to reproduce the validation evidence.
+
+Do not send only the README or a curated success notebook.
+
+## Required reviewer questions
+
+Each reviewer should answer, in their own words:
+
+1. **What exact statistical question does the validated path answer?**
+2. **Which assumptions are required but cannot be verified from the artifact?**
+3. **Can the implementation accidentally evaluate a policy different from the one the user intended?**
+4. **Can rows without valid nuisance information silently enter the estimate?**
+5. **Are reference comparisons semantically equivalent, not merely numerically close?**
+6. **What does the reported confidence interval cover, and what uncertainty is excluded?**
+7. **Are any temporal/dependence claims broader than the validation evidence?**
+8. **Can a validated implementation still produce unsupported evidence? Is that obvious to users?**
+9. **How often can evidence diagnostics falsely reassure according to the validation study? Is that acceptable for the stated claim?**
+10. **Which examples/docs are most likely to encourage misuse?**
+11. **Which claim would you remove or narrow before 1.0?**
+12. **What test or evidence would most increase your confidence?**
+
+## Required public review record
+
+With reviewer permission, publish:
+
+- reviewer identity or role/background;
+- date;
+- exact commit/tag reviewed;
+- validation-report identifier;
+- material findings, including negative findings;
+- severity / blocking status;
+- maintainer response;
+- code/docs changes triggered by the finding;
+- unresolved limitations;
+- reviewer conclusion on whether the **stated envelope** is defensible.
+
+A reviewer conclusion is not a claim that every future evaluation is correct.
+
+## Blocking findings
+
+The following are release blockers until resolved or the validated envelope is narrowed to exclude them:
+
+- wrong or ambiguous estimand;
+- target-policy semantics that can differ from the evaluated policy without detection;
+- evaluated observations lacking required non-leaky nuisance information;
+- a claimed reference comparison that is not semantically equivalent;
+- material undercoverage or false reassurance outside the predeclared validation tolerance;
+- evidence states that can imply support when required diagnostics are unknown;
+- unsupported temporal/dependence claims;
+- documentation that presents a validation-pending/experimental path as validated.
+
+## Review closure
+
+A review is complete only when every material finding has one of:
+
+- fixed and verified;
+- explicitly accepted as a limitation **inside** the validated envelope;
+- removed from the validated envelope;
+- left unresolved and therefore blocking validation/1.0.
+
+Do not close a finding because the implementation is inconvenient to change.

--- a/docs/validated-v1.md
+++ b/docs/validated-v1.md
@@ -1,0 +1,194 @@
+# Validated v1 evidence envelope
+
+> **Status:** proposed validation contract. Until the gates below pass, DR/SNDR remain validation-pending and experimental surfaces must not inherit validated claims.
+
+`skdr-eval` is an offline policy-evaluation toolkit for discrete, one-step contextual decisions. Its strongest intended promise is not that every estimate is trustworthy; it is that the library makes the implementation, assumptions, evidence quality, and reasons to abstain explicit enough for a practitioner to review.
+
+The first validated path is deliberately narrow. Breadth can be added later only through separate validation.
+
+## The claim
+
+For the validated-v1 path, `skdr-eval` aims to:
+
+> estimate the value of an explicit, finite-discrete, one-step target policy from logged contextual decisions with recorded behavior propensities, and report whether the available evidence supports that estimate under a documented validation envelope.
+
+This is an **evidence claim**, not an authorization to deploy or run an online experiment.
+
+## Validated-v1 setting
+
+### Decision setting
+
+- one-shot / contextual decisions;
+- finite discrete action set;
+- explicit action vocabulary and ordering;
+- explicit per-row eligibility where action availability varies;
+- no state transitions or long-horizon/sequential-RL interpretation.
+
+### Target policy
+
+The target policy must be explicit. It returns a probability distribution over the eligible actions for every evaluated context.
+
+Deterministic policies are represented as one-hot distributions. The validated path must not infer a deployment policy implicitly from arbitrary outcome-model scores.
+
+Tracked in #279.
+
+### Behavior policy
+
+The first validated path requires the probability of the logged action to have been recorded at decision time.
+
+- finite values in `(0, 1]`;
+- explicit provenance;
+- aligned with the same action vocabulary and eligibility represented by the row;
+- no estimated propensity may silently replace a missing logged propensity in the validated path.
+
+Estimated-propensity workflows may remain available, but they are validation-pending/experimental until separately validated.
+
+Tracked in #167.
+
+### Effective evaluation population
+
+Every observation contributing to a validated estimate must have nuisance predictions that are valid under the declared cross-fitting contract.
+
+Warm-up/training-only rows, excluded rows, and exclusion reasons must be explicit. Statistical defaults must never be invented merely to keep an evaluation running.
+
+Tracked in #280.
+
+### Estimand and outcome prediction
+
+For multi-action DR-style evaluation:
+
+- `q_obs[i] = q_hat(x_i, a_i)` for the logged action;
+- `q_pi[i] = sum_a pi(a | x_i) q_hat(x_i, a)` for the target policy;
+- action-specific outcome predictions and action mapping are explicit;
+- silent `(n,) -> (n, n_actions)` broadcasting is not a supported validated shortcut.
+
+Tracked in #58.
+
+### Inference
+
+Only inferential regimes that have passed end-to-end validation may be described as validated.
+
+Temporal leakage controls, dependence-aware resampling, and support diagnostics solve different problems. The project must not use broad language such as “time-aware OPE” to imply that arbitrary adaptive logging or temporal dependence has been solved.
+
+Tracked in #62.
+
+## Two independent status axes
+
+A validated implementation does **not** imply supported evidence for a particular dataset.
+
+### Implementation maturity
+
+Examples:
+
+- `experimental`
+- `validation_pending`
+- `reference_validated`
+- `independently_validated`
+- `deprecated`
+
+### Evidence state
+
+A concrete evaluation independently reports whether its evidence is usable. Candidate vocabulary:
+
+- `estimate_supported`
+- `inconclusive`
+- `insufficient_evidence`
+- `unsupported`
+- `invalid_evaluation`
+
+A validated estimator on weak-overlap or otherwise unsupported data must still return a non-positive evidence state.
+
+Tracked in #282 and #245.
+
+## No deployment authorization in the core evidence state
+
+The statistical core does not know enough to declare deployment or an online experiment safe. Those decisions can depend on harm, reversibility, regulatory constraints, monitoring, rollout size, business risk, and other organization-specific considerations.
+
+Core evidence output therefore should not mean `deploy`, `do_not_deploy`, or `eligible_for_guarded_online_test`.
+
+Organizations may layer a separate explicit decision policy over an `EvaluationArtifact`, but that policy is not the statistical evidence state.
+
+Tracked in #245.
+
+## Validation requirements
+
+Validation is cumulative. No single line of evidence is sufficient.
+
+1. formula and invariant tests;
+2. analytic known-ground-truth DGPs;
+3. randomized parameter-sweep simulation;
+4. estimator-specific independent/reference agreement where semantic equivalence exists;
+5. end-to-end bias/RMSE/coverage/interval-width/failure validation;
+6. evidence-health calibration, including false-reassurance rate;
+7. appropriate public logged-bandit data;
+8. retrospective offline-vs-online comparisons when available;
+9. independent human methodological review before `independently_validated` status.
+
+Reference implementations are evidence, not mathematical oracles. An estimator must never be forced into comparison with a superficially similar but semantically different reference method.
+
+Tracked in #281, #62, #223, and #298.
+
+## Evidence-health validation
+
+Diagnostics such as overlap, ESS, Pareto-k, propensity calibration, and sensitivity should not be trusted merely because they are intuitive.
+
+Across the validation matrix the project must test whether these signals actually predict large estimation error and calibrate thresholds accordingly.
+
+A key metric is **false reassurance rate**: among cases where the estimate is materially wrong, how often does the evidence layer nevertheless classify it as supported/healthy?
+
+Tracked in #62 and #223.
+
+## Explicitly outside the initial validated claim
+
+Until separately validated, the following are experimental or unsupported for validated-v1 claims:
+
+- sequential/offline RL;
+- slate / top-k policy evaluation;
+- continuous actions;
+- estimated behavior propensities;
+- arbitrary adaptive contextual-bandit dependence;
+- multi-objective decision semantics;
+- broad post-deploy monitoring semantics;
+- agent/LLM routing with changing action catalogues unless the data exactly satisfy this validated contract;
+- healthcare/clinical treatment recommendations as a production claim;
+- automatic deployment or experiment authorization.
+
+Examples may demonstrate experimental surfaces, but their status must be visible and they must not borrow validated-v1 language.
+
+## Historical correctness
+
+Material correctness problems found before the validated release must be documented explicitly, including which versions/configurations may need to be rerun.
+
+Known tracked items include #58 and #280. The migration/advisory work is tracked in #300.
+
+## Product/adoption gate
+
+Statistical validation alone does not prove product-market fit. Before broad feature expansion, the project should validate with data-ready practitioners that:
+
+- teams actually have the required behavior propensities/action provenance;
+- first-use can be completed without maintainer intervention;
+- the evidence artifact enters a real experiment-review decision;
+- the workflow is sufficiently differentiated from direct use of established OPE tooling.
+
+Tracked in #299.
+
+## Freeze rule
+
+Until the validated-v1 path and external review pass:
+
+- do not add new estimator families to the validated roadmap;
+- do not add new validated decision domains;
+- defer speculative presentation/integration/product breadth unless directly required by validation or repeated design-partner evidence;
+- prioritize correctness, reproducibility, explicit failure, external review, and real-user validation.
+
+Tracked in #297 and #301.
+
+## Project promise
+
+A useful mental model for the project is:
+
+> **Know when your offline policy estimate deserves to be believed.**
+
+A high-quality result can therefore be an explicit abstention:
+
+> **The logs cannot answer this question under the validated evidence contract.**

--- a/docs/validation-report-template.md
+++ b/docs/validation-report-template.md
@@ -1,0 +1,260 @@
+# Validation report template
+
+Use this template for versioned validation evidence produced under #62 and #223. It is intentionally designed to make unsupported regimes and negative results visible.
+
+A completed report should be reproducible from a committed/versioned configuration and should identify the exact package and reference-backend versions used.
+
+## 1. Identity
+
+```yaml
+report_id: skdr-validation-YYYY-MM-DD-001
+skdr_eval_version: "..."
+skdr_eval_commit: "..."
+python_version: "..."
+platform: "..."
+validation_config_version: "..."
+seed_policy: "..."
+reference_backends:
+  - estimator: DR
+    backend: OBP
+    version: "..."
+    semantic_equivalence: "..."
+review_status:
+  external_methodological_review: pending
+```
+
+## 2. Claimed validation envelope
+
+State the exact scope tested by this report.
+
+- decision setting:
+- action-space contract:
+- target-policy contract:
+- behavior-propensity contract:
+- outcome/estimand:
+- effective evaluation-population rule:
+- nuisance-fitting/cross-fitting regime:
+- dependence regime:
+- CI/inference procedure:
+- estimator(s):
+- explicitly unsupported configurations:
+
+Do not write “contextual OPE generally” when the matrix validates a narrower regime.
+
+## 3. Promotion target
+
+For each estimator/configuration:
+
+```yaml
+estimator: DR
+current_maturity: validation_pending
+requested_maturity: reference_validated
+reference_agreement_required: true
+independent_human_review_required_for_next_level: true
+```
+
+Implementation maturity and evidence status for individual runs are separate concepts.
+
+## 4. Predeclared validation thresholds
+
+Declare thresholds **before** inspecting the final validation results.
+
+Examples of fields, not mandated values:
+
+```yaml
+criteria:
+  max_absolute_bias: "..."
+  max_relative_rmse: "..."
+  ci_nominal_level: 0.95
+  ci_coverage_tolerance: "..."
+  max_failure_rate: "..."
+  max_false_reassurance_rate: "..."
+  max_false_abstention_rate: "..."
+  reference_agreement_tolerance: "..."
+```
+
+Justify each threshold. Do not loosen a threshold after observing failure without recording the change as a new validation-config version.
+
+## 5. Scenario matrix
+
+Every scenario family must identify what is varied and what truth is known.
+
+Suggested dimensions for validated-v1:
+
+- sample size;
+- action count;
+- deterministic vs stochastic target policy;
+- strong / moderate / weak overlap;
+- outcome-model specification quality;
+- logging-policy shape with exact logged propensities;
+- heterogeneous outcomes;
+- policy distance from behavior;
+- supported temporal/dependence regimes;
+- clipping configuration if clipping is inside the claimed validated path.
+
+Also include deliberately unsupported cases that should fail closed.
+
+## 6. Known-ground-truth results
+
+For every scenario family publish at least:
+
+| Scenario | N runs | True value | Mean estimate | Bias | RMSE | Failure/abstention |
+|---|---:|---:|---:|---:|---:|---:|
+| ... | ... | ... | ... | ... | ... | ... |
+
+Include full machine-readable results alongside any summarized table.
+
+## 7. Inferential validation
+
+For every supported CI regime publish:
+
+| Scenario | Nominal coverage | Empirical coverage | Mean width | Median width | Failure rate |
+|---|---:|---:|---:|---:|---:|
+| ... | ... | ... | ... | ... | ... |
+
+Explicitly distinguish:
+
+- conditional intervals;
+- end-to-end intervals;
+- any uncertainty component that is held fixed or omitted.
+
+If a scenario does not support the claimed interval semantics, mark it unsupported rather than silently showing an interval.
+
+## 8. Evidence-health validation
+
+The project claim depends on knowing when an estimate should *not* be believed. Diagnostics therefore need their own empirical validation.
+
+For each run record:
+
+- absolute/relative estimation error;
+- overlap metrics;
+- ESS / ESS fraction;
+- weight-tail / Pareto-k diagnostics where applicable;
+- propensity diagnostics where applicable;
+- sensitivity/clip instability;
+- normalized diagnostic states;
+- final evidence state.
+
+### False reassurance
+
+Predefine what constitutes a materially wrong estimate for each DGP family.
+
+Report:
+
+> Among runs whose estimation error exceeded the material-error threshold, what fraction were nevertheless classified `estimate_supported` (or equivalent positive evidence state)?
+
+| Scenario | Material-error runs | Falsely supported | False-reassurance rate |
+|---|---:|---:|---:|
+| ... | ... | ... | ... |
+
+This metric must not be omitted because the result is unfavorable.
+
+### False abstention / over-conservatism
+
+Where a reliable ground truth permits it, also report cases where the evidence layer abstains/fails despite an accurate estimate and healthy supported conditions.
+
+### Diagnostic discrimination
+
+Report whether individual and combined diagnostics actually enrich for large estimation error. Suitable summaries may include:
+
+- error distributions by diagnostic state;
+- risk ratios / enrichment;
+- threshold curves;
+- calibration plots;
+- classification metrics only when their interpretation is appropriate.
+
+Do not turn this into a single vanity score.
+
+## 9. Reference agreement
+
+Follow #281 estimator by estimator.
+
+For each claimed comparison record:
+
+- estimator definition on both sides;
+- estimand;
+- target-policy probabilities;
+- logged propensities;
+- effective row mask;
+- action ordering;
+- clipping/normalization;
+- reference version/commit;
+- declared tolerance;
+- result.
+
+If semantic equivalence is unavailable, state `reference_agreement: unavailable` rather than comparing a superficially similar estimator.
+
+| Estimator | Reference | Equivalent scope | Scenarios | Pass/fail | Notes |
+|---|---|---|---:|---|---|
+| ... | ... | ... | ... | ... | ... |
+
+## 10. Public-data evidence
+
+Public logged-bandit data can demonstrate realism but cannot replace known-ground-truth validation.
+
+Record:
+
+- dataset/version/license;
+- exact slice/filtering;
+- logged-propensity semantics;
+- action/eligibility mapping;
+- what can and cannot be concluded because ground truth is unknown;
+- any online-policy comparison available from the dataset design.
+
+## 11. Failure cases
+
+Publish important failures prominently.
+
+For every failed validation criterion:
+
+```yaml
+scenario: "..."
+criterion: "..."
+observed: "..."
+threshold: "..."
+impact:
+  - estimator remains validation_pending
+  - scope narrowed
+root_cause_status: known | suspected | unknown
+follow_up: "#..."
+```
+
+A validation report with no visible failures should trigger scrutiny, not celebration.
+
+## 12. Historical behavior comparison
+
+When this report follows a correctness change such as #58 or #280, include a controlled comparison between the historical and corrected behavior and link the user-facing advisory (#300).
+
+## 13. Conclusion by estimator/configuration
+
+For each candidate promotion, use one of:
+
+- `promotion_passed`
+- `promotion_blocked`
+- `scope_narrowed_and_passed`
+- `validation_incomplete`
+
+Explain the exact validation envelope earned by the evidence.
+
+Do not conclude that a validated implementation makes every future evaluation trustworthy.
+
+## 14. Reproduction
+
+Provide exact commands/configuration needed to regenerate:
+
+- simulations;
+- reference agreement;
+- summary tables;
+- published machine-readable result bundle.
+
+Record expected runtime/resource requirements and any external dataset download requirements.
+
+## 15. External review
+
+After independent methodological review (#298), append or link:
+
+- reviewed report ID;
+- reviewer findings;
+- changes made;
+- remaining limitations;
+- final promotion decision.


### PR DESCRIPTION
## Superseded by merged PR #303

PR #303 landed the evidence-first v1 claim boundary, public roadmap, design-partner guide, external methodological-review packet, `CLAIMS.md`, and docs navigation on current `main`.

This branch independently developed substantially overlapping material. Keeping two competing strategy/research documents would create drift, so this PR is intentionally closed rather than rebased.

### Preserve / re-extract

The unique `docs/validation-report-template.md` from this branch is still valuable because #303 does not include a concrete machine/human validation-report template with predeclared thresholds, bias/RMSE/coverage, false-reassurance and diagnostic-discrimination sections. That file will be re-extracted in a focused PR from current `main`.

No strategy information is intentionally lost; #303 is now the canonical merged claim/research documentation.