### PR TITLE
docs: freeze evidence-first v1 claims after red-team review

### DIFF
--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -1,87 +1,150 @@
 # What skdr-eval claims (and what it does not)
 
-A receipts-first page. Every claim below links to something you can run — a
-command, an example script, a test, or a notebook — so you can check it
-yourself rather than take our word for it. The companion non-claims section is
-just as important: it states, explicitly, what offline evaluation cannot do.
+This page is the public claim boundary for `skdr-eval`. It is deliberately
+conservative: implementation validity, evidence quality, and an organization's
+decision to run an online experiment are separate concerns.
 
-## Estimator scope
+> **Current status:** the first DR/SNDR implementation path is
+> `validation_pending`. The July/August 2026 audit identified correctness and
+> inference work that must land before a strong validated-path claim is made.
+> Existing experimental APIs remain available, but breadth is not evidence of
+> validation.
 
-`skdr-eval` evaluates **one-shot contextual-bandit policies** from logged
-decisions. It ships a doubly-robust estimator family and a slate family.
+## The claim we are working toward
 
-| Claim | Estimators | Receipt |
-|---|---|---|
-| DR and Stabilized DR (SNDR) on sklearn-compatible policies | `DR`, `SNDR` | `examples/quickstart.py`; `tests/test_dr_sndr_smoke.py` |
-| MRDR / SWITCH-DR / DRos / MIPS via a composable strategy seam | `MRDR`, `SWITCH-DR`, `DRos`, `MIPS` | `build_strategy(...)`; `tests/test_estimators_extended.py`, `tests/test_mips_api.py` |
-| Slate / top-K off-policy evaluation | `slate_standard_ips`, `pseudo_inverse_ips`, `reward_interaction_ips`, `slate_cascade_dr` | `tests/test_slate_coverage.py` |
-| Pairwise / autoscaling evaluation | `evaluate_pairwise_models` | `examples/use_cases/04_call_routing.py` |
-| Estimators recover a known ground-truth value on synthetic DGPs | all | `tests/test_estimator_recovery_simulation.py`, `tests/sim_studies/` |
+The initial validated-v1 envelope is intentionally narrow:
 
-See [Choosing an estimator](docs/choosing-an-estimator.md) for which one to
-run and [methods](docs/methods.md) for the math.
+> `skdr-eval` estimates the value of an explicit, finite-discrete, one-step
+> target policy from logged contextual decisions with recorded behavior
+> propensities, and reports whether the available evidence supports that
+> estimate under a documented validation envelope.
 
-## Supported logged-data assumptions
+The validated-v1 work is tracked by #297 and its blockers.
 
-The estimates are valid under the standard OPE assumptions; they are stated,
-not hidden:
+## What validated-v1 is intended to require
 
-- **Unconfoundedness** — the logged action's propensity is explainable from
-  the recorded context.
-- **Overlap** — the candidate policy only takes actions the logging policy
-  also took with positive probability. When this fails, `support_health`
-  reports `high_risk`.
-- **Stable data-generating process** across the log window (time-aware splits
-  and moving-block bootstrap respect the temporal correlation).
-- **Useful nuisance models** — the propensity and outcome models are not
-  arbitrarily misspecified.
+- **One-shot contextual decisions.** Sequential / long-horizon RL is out of
+  scope.
+- **Finite, explicit actions.** The action vocabulary and per-row eligibility
+  must be represented explicitly when they vary.
+- **An explicit target policy.** The evaluated policy must provide an action
+  probability distribution; it is not inferred implicitly from arbitrary
+  outcome-model scores in the validated path (#279).
+- **Recorded behavior propensities.** The chosen-action probability logged at
+  decision time is required for the first validated path (#167). Estimated
+  propensities remain experimental until separately validated.
+- **A genuine evaluation population.** Every row contributing to a validated
+  estimate must have valid, non-leaky OOF nuisance predictions; statistical
+  defaults must not be invented to keep an evaluation running (#280).
+- **Correct multi-action DR semantics.** `q_hat(x,a)`, `q_obs`, and `q_pi` must
+  have explicit, action-specific meaning (#58).
+- **Only validated inference regimes.** Temporal leakage controls do not imply
+  that arbitrary adaptive logging or dependence has been solved. Confidence
+  intervals and dependence claims are limited to regimes validated by #62.
 
-Receipt: the assumption tags travel with every artifact
-(`DEFAULT_ASSUMPTION_TAGS`) and are printed on the card; see
-[estimands & assumptions](docs/concepts/estimands-and-assumptions.md).
+## Implementation maturity is not evidence quality
 
-## Trust diagnostics
+An estimator implementation can be validated while a particular evaluation is
+unsupported.
 
-The differentiator is that `skdr-eval` tells you when **not** to trust the
-estimate. Each diagnostic has a receipt.
+For example, a correct DR implementation can still receive weak or invalid
+inputs: poor overlap, invalid propensities, a target policy outside the logging
+support, unsupported dependence, missing diagnostics, or an ambiguous action
+mapping.
 
-| Diagnostic | What it catches | Receipt |
-|---|---|---|
-| `support_health` (`ok` / `caution` / `high_risk`) | poor overlap, low ESS, low match-rate | `docs/recipes/good-vs-bad-support.md`; `tests/test_diagnostics_trust.py` |
-| PSIS Pareto-k | heavy-tailed importance weights (variance may not exist) | `tests/test_diagnostics_trust.py` |
-| Effective sample size (ESS) and tail mass | a few rows dominating the estimate | `report` columns `ESS`, `tail_mass` |
-| Propensity calibration (ECE / Brier) | miscalibrated logging-policy model | `evaluate_propensity_diagnostics`; `tests/test_propensity_diagnostics.py` |
-| Clip-grid sensitivity | estimate that moves with the clip threshold | `summarize_sensitivity`; `tests/test_reporting_artifact.py` |
-| Deploy / don't-deploy verdict | turning all of the above into a decision | `EvaluationArtifact.recommendation(...)`; `tests/test_card_schema.py` |
+`skdr-eval` therefore separates:
 
-The CLI turns the verdict into a CI gate: `skdr-eval evaluate` exits with code
-`3` when any model's verdict is `do_not_deploy`.
+1. **implementation maturity** — whether an estimator/configuration has passed
+   the project's validation requirements; and
+2. **evidence status** — whether the concrete evaluation has enough support to
+   sustain the reported estimate under the declared validation envelope.
 
-## Reproducible examples
+This separation is tracked by #282 and #245.
 
-| Want to see... | Run |
-|---|---|
-| The 10-minute quickstart | `python examples/quickstart.py` |
-| Preflight on your own logs | `skdr-eval doctor your_logs.parquet --json` |
-| A good vs. bad support contrast | `python examples/use_cases/06_agent_routing_policy.py` |
-| Coming from Open Bandit Pipeline | `python examples/obp_interop.py` |
-| What a bad evaluation looks like | `make known-failures` |
-| Coverage of the bootstrap CI | `make coverage-sim` |
+## Evidence status, not deployment authorization
 
-## Non-claims (read these)
+The core library should describe evidence, not authorize deployment or an online
+experiment.
 
-- **Offline evaluation does not replace an online experiment.** A green
-  `skdr-eval` verdict is evidence that a candidate is *worth* an A/B test, not
-  proof it will win one. See the [rollout checklist](docs/rollout-checklist.md).
-- **No method can fix no-overlap logs.** If the candidate only takes actions
-  the logging policy never explored, there is no counterfactual signal in the
-  data; `skdr-eval` returns `support_health = high_risk` rather than a
-  confident number.
-- **Not for sequential / reinforcement-learning problems.** State transitions
-  and long horizons are out of scope — use SCOPE-RL or d3rlpy
-  (see [comparisons](docs/comparisons.md)).
-- **Logged propensities are reported, not consumed (yet).** `skdr-eval`
-  estimates calibrated propensities internally; first-class use of a logged
-  `pscore` is tracked in issue #167.
-- **Diagnostics are signals, not proofs.** They help you decide whether an
-  estimate is worth acting on; they do not certify it is correct.
+The target semantics are evidence-oriented states such as:
+
+- `estimate_supported`
+- `inconclusive`
+- `insufficient_evidence`
+- `unsupported`
+- `invalid_evaluation`
+
+Exact names are being finalized under #245.
+
+A positive evidence state means that the statistical/evidence contract passed
+under the declared validation envelope. It does **not** mean that deployment or
+an online experiment is safe, ethical, approved, reversible, sufficiently
+monitored, or commercially justified. Those decisions require information the
+core library does not possess.
+
+## Validation evidence required before strong claims
+
+No estimator/configuration becomes strongly validated from internal unit tests
+alone. The validation program requires multiple independent forms of evidence:
+
+1. formula and invariant tests;
+2. analytic known-ground-truth data-generating processes;
+3. randomized simulation stress tests;
+4. estimator-specific external/reference agreement where semantics genuinely
+   match (#281);
+5. empirical bias, RMSE, interval coverage, failure/abstention and
+   **false-reassurance** validation (#62);
+6. appropriate public logged-policy data where useful;
+7. retrospective offline-vs-online comparisons when available;
+8. independent human methodological review before an
+   `independently_validated` claim (#298).
+
+The public validation-lab work is tracked by #223.
+
+## Current non-claims
+
+- **No deployment recommendation.** Core statistical output is not a deployment
+  or experiment-approval decision.
+- **No guarantee from diagnostics.** ESS, overlap, Pareto-k, calibration and
+  sensitivity are evidence signals. Their thresholds must be empirically
+  validated; they are not proofs of correctness.
+- **No rescue for no-overlap logs.** If the target policy takes actions outside
+  logging support, counterfactual evidence is absent.
+- **No general sequential / RL claim.** State transitions and long horizons are
+  out of scope.
+- **No general adaptive-logging claim.** Time-aware splits and block bootstrap
+  do not by themselves validate inference under arbitrary adaptive behavior
+  policies.
+- **No validated estimated-propensity path yet.** The first validated envelope
+  requires logged propensities.
+- **No production healthcare-treatment claim.** Clinical/treatment examples, if
+  retained, are educational/experimental and must not be presented as a
+  validated production workflow.
+- **No validated general LLM/agent-routing claim yet.** Variable action sets,
+  changing model catalogues, multi-objective rewards and missing exploration can
+  violate the initial envelope. Agent/model-routing examples remain experimental
+  unless they satisfy the same validated contract.
+- **Offline evaluation does not replace online validation.** Even supported
+  offline evidence is not proof that a policy will win online.
+
+## Known pre-validation correctness work
+
+The audit identified material issues that affect historical result semantics,
+including the multi-action DR/SNDR outcome representation (#58) and rows without
+genuine OOF nuisance predictions (#280).
+
+When corrected releases are available, #300 requires explicit historical
+advisories describing affected configurations and which results should be rerun.
+The project will not minimize an estimand-affecting issue as a mere precision or
+bootstrap change.
+
+## Product principle
+
+The intended differentiator is not estimator count. It is making offline policy
+evidence difficult to misuse:
+
+> **Know when an offline policy estimate deserves to be believed — and get an
+> explicit refusal when the logs cannot support the question.**
+
+Until the validation gates and external review are complete, claims in README,
+PyPI metadata, examples and release notes should not exceed this page.

--- a/CLAIMS.md
+++ b/CLAIMS.md
@@ -76,6 +76,13 @@ The target semantics are evidence-oriented states such as:
 
 Exact names are being finalized under #245.
 
+**Migration note:** released versions still expose legacy deployment/experiment
+verdict names such as `deploy`, `ab_test`, and `do_not_deploy`, and some CLI/docs
+still describe exit codes in those terms. Those are compatibility-era semantics,
+not the target claim of the core library. Issue #245 owns their migration to the
+evidence-only state machine; until that work lands, callers must not interpret a
+legacy positive verdict as deployment or experiment authorization.
+
 A positive evidence state means that the statistical/evidence contract passed
 under the declared validation envelope. It does **not** mean that deployment or
 an online experiment is safe, ethical, approved, reversible, sufficiently
@@ -104,7 +111,8 @@ The public validation-lab work is tracked by #223.
 ## Current non-claims
 
 - **No deployment recommendation.** Core statistical output is not a deployment
-  or experiment-approval decision.
+  or experiment-approval decision. Legacy verdict labels remain temporarily for
+  compatibility while #245 migrates the public state machine.
 - **No guarantee from diagnostics.** ESS, overlap, Pareto-k, calibration and
   sensitivity are evidence signals. Their thresholds must be empirically
   validated; they are not proofs of correctness.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,80 @@
+# skdr-eval roadmap
+
+This roadmap is intentionally narrow. GitHub issues contain historical ideas,
+investigations and deferred work; an open or closed issue is not automatically a
+current product commitment.
+
+The current objective is to earn a defensible validated-v1 claim and prove that
+real practitioners have the required data/workflow before expanding breadth.
+
+## NOW — validated-v1 evidence path
+
+These are the critical path. Feature breadth does not outrank them.
+
+1. **Freeze the supported claim/envelope** — #297.
+2. **Explicit target policy/action distribution** — #279.
+3. **Genuine OOF nuisance predictions and explicit evaluation population** — #280.
+4. **Logged behavior propensities for the initial validated path** — #167.
+5. **Correct multi-action DR/SNDR outcome semantics** — #58.
+6. **Estimator-specific independent/reference agreement** — #281.
+7. **End-to-end inference + false-reassurance validation** — #62.
+8. **Fail-closed diagnostic/evidence states** — #259.
+9. **Evidence-status semantics, not deploy authorization** — #245.
+10. **Implementation maturity separate from run evidence quality** — #282.
+11. **Release validation and historical-correctness communication** — #295 / #300.
+
+No estimator/configuration becomes strongly validated merely because its code is
+merged. Promotion requires the validation evidence defined by the claim boundary.
+
+## NEXT — prove usefulness outside the maintainer loop
+
+Work here runs in parallel only where it does not distract from correctness.
+
+- **Public reproducible validation lab** — #223.
+- **Independent human methodological review** — #298.
+- **Data-ready design-partner / market validation** — #299.
+- **Stable evidence artifact/provenance surface** — #202 / #205 / #212.
+- **Determinism on the validated public surface** — #232.
+- **Public repository/adoption surface cleanup** — #301.
+- **Decide whether the project name still fits before 1.0** — #310.
+
+The important adoption signals are real evaluation decisions, repeat use,
+independent review and external contributions — not raw star count.
+
+## DEFERRED BY DEFAULT
+
+These ideas may be useful later, but they are not current commitments unless
+repeated external demand or validation needs pull them forward:
+
+- new estimator families / broad estimator breadth;
+- estimated-propensity promotion beyond the initial logged-propensity path;
+- sequential/offline-RL workflows;
+- slate/top-K expansion beyond separately validated experimental work;
+- multi-objective policy evaluation;
+- rolling/post-deploy monitoring;
+- A/B power planning;
+- interactive report workspaces;
+- LLM-generated summaries and badges;
+- plugin ecosystems;
+- broad MLflow/W&B/Aim integrations;
+- general LLM/agent-routing positioning;
+- broad performance/scale work that is not a demonstrated validation or adoption
+  bottleneck.
+
+Good ideas can remain documented without consuming active-roadmap attention.
+
+## Product decisions that can change the roadmap
+
+The strategy is deliberately falsifiable.
+
+- If the statistical/evidence-health validation fails, **narrow or redesign**;
+  do not weaken the validation bar.
+- If target teams usually lack behavior propensities/action provenance, consider
+  an **OPE-readiness/instrumentation** pivot.
+- If teams trust established estimator backends but value skdr-eval's evidence
+  workflow, make the **evidence layer over external backends** the product.
+- If data-ready teams do not use the artifact in real decisions, reconsider the
+  artifact/product thesis rather than adding more presentation features.
+
+See `CLAIMS.md` and `docs/strategy/evidence-first-v1.md` for the full claim,
+validation ladder, kill criteria and effort allocation.

--- a/changelog.d/297.changed.md
+++ b/changelog.d/297.changed.md
@@ -1,0 +1,1 @@
+Freeze public validation claims around the narrow evidence-first v1 envelope: implementation maturity, concrete-run evidence status, and organizational experiment/deployment decisions are now explicitly separate concerns while the DR/SNDR validation blockers remain open.

--- a/docs/research/design-partner-guide.md
+++ b/docs/research/design-partner-guide.md
@@ -1,0 +1,136 @@
+# Design-partner validation guide
+
+This guide operationalizes #299. The goal is to test whether the validated-v1 workflow solves a real practitioner problem for teams that actually have the data contract OPE requires.
+
+Do not optimize this research for GitHub stars, testimonials, or feature requests.
+
+## Who qualifies
+
+Prioritize practitioners who have operated or reviewed one-step decision systems such as:
+
+- recommender/personalization policies;
+- advertising/targeting/bandit systems;
+- routing/assignment policies with explicit exploration;
+- model/LLM routing only when the behavior action probability and available action set are genuinely logged.
+
+A useful participant has direct experience with at least one real online policy experiment or experiment-review workflow.
+
+## Interview questions
+
+Record concrete facts rather than opinions where possible.
+
+### Logging contract
+
+1. What is one row / decision in your logs?
+2. Is the action set explicit at decision time?
+3. Can the available/eligible actions vary per decision? If so, is that set logged?
+4. Is the behavior policy stochastic/randomized?
+5. Is the probability of the chosen action logged at decision time?
+6. Can you identify which logging-policy version/configuration produced the row?
+7. Can that propensity/action provenance be audited later?
+
+### Target policy
+
+8. How is the candidate represented today: action probabilities, scores, a deterministic rule, or only model predictions?
+9. Can you reconstruct the exact policy that would be evaluated online?
+10. Can the candidate choose actions that historical logging rarely/never selected?
+
+### Outcome
+
+11. What reward/outcome determines policy value?
+12. When does it become available?
+13. Is one scalar reward sufficient for the actual review decision?
+14. Are there important harms/guardrails not represented by that reward?
+
+### Current experiment-review workflow
+
+15. What evidence do reviewers require before approving an A/B test?
+16. What do you currently do when offline metrics look good but logging support is weak?
+17. Which counterfactual/OPE tooling, if any, do you already use?
+18. Which result would make you explicitly refuse to proceed?
+19. Where would a portable evidence artifact live: PR, ticket, experiment platform, notebook, dashboard, other?
+20. Who needs to understand it besides the model author?
+
+## Hands-on session
+
+For data-ready partners, avoid custom implementation first. Use the narrow validated-v1 workflow.
+
+Observe and timestamp:
+
+1. install/start;
+2. map log schema;
+3. run `doctor`/preflight;
+4. define the explicit target policy;
+5. reach first valid or explicitly refused evaluation;
+6. inspect the evidence artifact;
+7. use/share it in the real decision workflow if possible.
+
+Record every point where the participant needs maintainer help.
+
+## Session result template
+
+Do not store proprietary logs or sensitive values in this repository.
+
+```text
+participant/session id: anonymous identifier
+system/domain: recommender | ads | routing | other
+real online experimentation experience: yes/no
+
+DATA READINESS
+action set logged: yes/no/partial
+eligibility logged: yes/no/not-applicable
+chosen-action propensity logged: yes/no/partial
+logging policy provenance available: yes/no/partial
+target policy representable explicitly: yes/no/partial
+validated-v1 data contract satisfied: yes/no
+
+USABILITY
+time to valid preflight:
+time to first evidence artifact:
+maintainer interventions:
+blocking confusion:
+
+DECISION VALUE
+artifact entered a real review: yes/no
+changed/narrowed/blocked/informed decision: describe without sensitive details
+repeat-use intent: yes/no/unknown
+
+RECURRING NEEDS
+request(s):
+seen independently before: yes/no
+
+NON-ADOPTION REASON
+if not adopted, why:
+```
+
+## Aggregate metrics
+
+After approximately 15–20 interviews/observations, report:
+
+- share with valid logged propensities;
+- share with explicit action/eligibility provenance;
+- share satisfying the whole validated-v1 data contract;
+- median time to valid preflight;
+- median time to first evidence artifact;
+- percentage completing without maintainer intervention;
+- number of artifacts entering a real decision review;
+- repeat usage;
+- recurring adoption blockers.
+
+## Decision rules
+
+### Continue native product
+Multiple independent teams satisfy the data contract and value both the estimator path and evidence workflow.
+
+### Evidence-layer pivot
+Teams prefer established estimator backends but value skdr-eval's evidence, validation and artifact contract.
+
+### OPE-readiness pivot
+Most qualified teams lack propensity/action provenance and primarily need instrumentation/readiness diagnostics.
+
+### Narrow/stop
+Data-ready teams already solve the workflow adequately elsewhere and do not value the evidence layer enough to adopt it.
+
+## Kill criterion
+
+If fewer than roughly 3 of 15 qualified target teams have the validated-v1 data contract, explicitly reassess the addressable OPE market before adding product breadth.

--- a/docs/research/external-methodological-review.md
+++ b/docs/research/external-methodological-review.md
@@ -1,0 +1,100 @@
+# External methodological review packet
+
+This document operationalizes #298. The purpose is independent challenge, not endorsement marketing.
+
+## Review target
+
+Every review must identify the exact immutable commit/tag and validation-report version being reviewed.
+
+The reviewer is assessing whether the stated **validation envelope is defensible**, not whether `skdr-eval` is universally correct or safe for deployment.
+
+## Minimum reviewer perspectives
+
+Seek at least three independent perspectives:
+
+1. **OPE/contextual-bandit methods** — estimand, DR/SNDR formulas, behavior/target policy semantics, overlap and reference-validation design.
+2. **Causal/statistical ML** — nuisance fitting, OOF guarantees, inference, diagnostic calibration, confounding/non-claims.
+3. **Production experimentation/recommenders** — logging propensities, eligibility/action provenance, artifact usability and misuse risk.
+
+Reviewers should be independent of the implementation authorship they are evaluating.
+
+## Packet contents
+
+Provide:
+
+- exact source commit/tag;
+- `CLAIMS.md`;
+- validated-v1 envelope / strategy;
+- exact estimand and formula documentation;
+- explicit `Policy`/action-distribution contract;
+- behavior-propensity semantics;
+- effective evaluation-population rules;
+- known-ground-truth simulations;
+- estimator-specific reference-agreement reports;
+- bias/RMSE/coverage/false-reassurance validation report;
+- evidence-state and implementation-maturity schemas;
+- historical correctness advisories relevant to previous releases;
+- unsupported/non-claim list;
+- reproducibility instructions.
+
+## Questions for the methods reviewer
+
+- Is the target estimand defined unambiguously?
+- Does the implementation compute that estimand for deterministic and stochastic policies?
+- Are `q_obs` and `q_pi` action-specific and correctly composed?
+- Are behavior and target policy probabilities semantically distinct everywhere?
+- Is overlap/positivity handled honestly?
+- Are reference comparisons actually comparing equivalent estimators/configurations?
+- Are any reference backends being treated as an oracle rather than one line of evidence?
+- Which documented regimes should be removed from the validation envelope?
+
+## Questions for the statistical/causal reviewer
+
+- Does every evaluated row have the required non-leaky nuisance predictions?
+- Are the effective population and exclusions explicit?
+- What uncertainty is each interval actually claiming to include?
+- Are dependence assumptions named precisely enough?
+- Are diagnostics empirically calibrated against estimation error?
+- Is the false-reassurance metric defined meaningfully?
+- Are causal/unconfoundedness assumptions described without implying they can be verified from diagnostics?
+- Are any high-stakes/observational examples likely to be misread as validated causal guidance?
+
+## Questions for the production reviewer
+
+- Can a real logging system satisfy the propensity/action/eligibility contract without heroic reconstruction?
+- Is policy provenance auditable?
+- Does `doctor` fail early on the mistakes practitioners actually make?
+- Can a non-methods reviewer understand why evidence is unsupported?
+- Does the artifact fit an experiment-review workflow?
+- Does any language look like deployment/experiment authorization?
+- What would make this artifact useful enough to attach to a real decision record?
+
+## Required review output
+
+With reviewer permission, publish:
+
+- reviewer identity or role/background;
+- date;
+- exact commit/tag reviewed;
+- validation-report identifier;
+- major findings/objections;
+- severity/blocking status;
+- maintainer response;
+- resulting code/docs changes;
+- unresolved limitations;
+- reviewer conclusion on whether the **stated envelope** is defensible.
+
+Do not reduce findings to a testimonial quote.
+
+## Finding severity
+
+Suggested categories:
+
+- **Blocker** — estimand/inference/evidence claim is not defensible; blocks validation promotion/1.0.
+- **Major** — substantial misuse/correctness risk; must be resolved or narrow the envelope.
+- **Minor** — clarity/robustness improvement that does not invalidate the current envelope.
+- **Question** — requires explicit answer or documentation.
+
+## Promotion rule
+
+An unresolved blocker prevents `independently_validated` status. The response is to fix or narrow the claim, not weaken the review gate.

--- a/docs/strategy/evidence-first-v1.md
+++ b/docs/strategy/evidence-first-v1.md
@@ -1,0 +1,193 @@
+# Evidence-first v1 strategy
+
+This document records the product and validation strategy adopted after the August 2026 red-team review. It is intentionally falsifiable. If the validation or market evidence fails, the project should narrow, pivot, or stop rather than weaken the claim.
+
+## Product thesis
+
+`skdr-eval` should become the **evidence-quality layer for offline evaluation of discrete, one-step decision policies**.
+
+Its job is not to be the library with the largest estimator catalogue. Its job is to make it difficult to mistake a numerically produced estimate for usable evidence.
+
+The working promise is:
+
+> **Know when an offline policy estimate deserves to be believed.**
+
+A first-class outcome is an explicit refusal when the logs cannot support the question.
+
+## Validated-v1 envelope
+
+The first strong claim is deliberately narrow:
+
+- one-shot/contextual decisions;
+- finite discrete action set;
+- explicit action mapping and eligibility;
+- explicit target-policy action distribution;
+- scalar reward/outcome;
+- behavior propensity logged at decision time;
+- genuine OOF evaluation population;
+- corrected multi-action DR semantics;
+- inference only for dependence regimes explicitly validated by the project.
+
+Initial implementation candidate: **DR**. SNDR follows only after its estimator-specific validation and reference strategy are defensible. Other estimators and decision domains remain experimental until separately promoted.
+
+## Three separate decisions
+
+Never collapse these into one field:
+
+### 1. Implementation maturity
+
+Does the estimator/configuration have enough validation evidence?
+
+Examples: `experimental`, `validation_pending`, `reference_validated`, `independently_validated`.
+
+### 2. Evidence status
+
+Does this concrete run have enough support under the estimator's validation envelope?
+
+Examples: `estimate_supported`, `inconclusive`, `insufficient_evidence`, `unsupported`, `invalid_evaluation`.
+
+### 3. Organizational action
+
+Should a team run an online experiment or deploy?
+
+This requires risk, harm, reversibility, monitoring, traffic, regulatory and business inputs that the statistical core does not know. Any automatic organizational gate must be a separate policy layer over the evidence artifact.
+
+## Validation ladder
+
+A strong validation claim requires multiple kinds of evidence:
+
+1. formula/unit invariants;
+2. analytic known-ground-truth DGPs;
+3. randomized simulation parameter sweeps;
+4. estimator-specific cross-implementation/reference agreement where semantics genuinely match;
+5. bias/RMSE/coverage/interval-width/failure validation;
+6. false-reassurance and false-abstention validation of the evidence-health layer;
+7. appropriate public logged-policy datasets;
+8. retrospective offline-vs-online comparisons when available;
+9. independent human methodological review.
+
+Reference agreement is never treated as mathematical ground truth.
+
+## Diagnostic validation
+
+The evidence layer itself must be tested.
+
+Across broad known-ground-truth simulations, measure whether diagnostics such as overlap, ESS, Pareto-k, propensity quality and sensitivity actually discriminate regimes with large estimation error.
+
+Required metrics include:
+
+- bias;
+- RMSE;
+- empirical interval coverage;
+- interval width;
+- abstention/failure rate;
+- evidence-status distribution;
+- false reassurance: materially wrong estimate classified as supported;
+- false abstention / unnecessary conservatism where meaningful;
+- diagnostic-to-error association/discrimination.
+
+Thresholds that do not perform adequately must be revised rather than defended by convention.
+
+## Public validation lab
+
+Publish reproducible validation evidence, not a leaderboard.
+
+The validation site/report should show successful, failed and unsupported scenarios from the same machine-readable configuration. Releases making validation claims must identify the exact package commit/version and reference dependencies used to generate the evidence.
+
+## External review gate
+
+Before a 1.0 release or `independently_validated` status, obtain independent human review covering at least:
+
+- OPE/contextual-bandit estimator and estimand semantics;
+- causal/statistical inference and diagnostics;
+- production logging and experiment-review workflow.
+
+Publish material objections, maintainer responses and unresolved limitations. This is methodological review, not testimonials.
+
+## Design-partner validation
+
+Technical correctness cannot prove product-market fit.
+
+Interview approximately 15–20 qualified practitioners, then attempt hands-on use with at least five data-ready users/teams where possible. Measure:
+
+- whether behavior propensities/action provenance are actually available;
+- time to valid preflight;
+- time to first interpretable artifact;
+- maintainer assistance required;
+- whether the artifact changes or enters a real experiment-review decision;
+- repeat use;
+- recurring adoption blockers.
+
+Do not implement one-off requests unless the same problem recurs independently.
+
+## Product pivots are allowed
+
+Three outcomes remain legitimate:
+
+### Native product succeeds
+Users value both the native estimator path and the evidence workflow.
+
+### Evidence layer wins
+Users prefer established estimator backends but value skdr-eval's evidence/validation/artifact surface. Make external backends first-class rather than defending native code for its own sake.
+
+### OPE-readiness wins
+Qualified teams commonly lack valid behavior propensities/action provenance. Pivot toward instrumentation/readiness diagnostics rather than pretending the addressable OPE workflow is larger than it is.
+
+## Kill criteria
+
+- If DR cannot meet predeclared correctness/inferential/evidence-health thresholds, it does not receive validated status.
+- If evidence-health diagnostics frequently classify materially wrong estimates as supported, redesign the evidence layer.
+- If external reviewers identify unresolved fundamental estimand/inference problems, block 1.0 and narrow/redesign.
+- If fewer than roughly 3 of 15 qualified target teams have the required data contract, reassess the market and consider OPE-readiness tooling.
+- If data-ready users consistently prefer direct established tools and do not value the evidence artifact, pivot or stop building product/reporting breadth.
+- If first use consistently requires maintainer intervention, simplify before distribution.
+- If agent/model-routing traces routinely violate the validated envelope, keep that domain experimental.
+
+## Execution allocation until validation succeeds
+
+Approximate effort allocation:
+
+- **70%** correctness, inferential validation, evidence-health calibration and scope reduction;
+- **20%** external methodological/design-partner validation;
+- **10%** everything else.
+
+Net-new estimator/domain breadth is frozen unless it directly unblocks validated-v1 or is pulled by repeated external demand.
+
+## Deferred by default
+
+Until validated-v1 and design-partner evidence succeed, treat the following as deferred unless directly required by external validation:
+
+- plugin ecosystems;
+- interactive decision workspaces;
+- LLM-generated summaries;
+- shareable badges;
+- rolling monitoring;
+- A/B power planning;
+- multi-objective expansion;
+- broad agent-specific trace tooling;
+- broad performance work beyond demonstrated validation/adoption bottlenecks;
+- new estimator families.
+
+Preserve good ideas, but do not present them as current commitments.
+
+## Naming decision before 1.0
+
+The project must explicitly decide whether `skdr-eval` still fits a policy-first, implementation-agnostic direction. Renaming is not required now, but it must not become an accidental post-1.0 constraint.
+
+## Related work
+
+- #297 — validated-v1 envelope
+- #298 — independent methodological review
+- #299 — design-partner / market validation
+- #300 — historical correctness advisories
+- #301 — backlog/adoption reset
+- #279 — explicit Policy contract
+- #280 — genuine OOF population
+- #167 — logged propensities
+- #58 — corrected multi-action DR/SNDR estimand
+- #281 — estimator-specific reference agreement
+- #62 — end-to-end inference and false reassurance
+- #245 — evidence-state semantics
+- #259 — fail-closed diagnostic states
+- #282 — implementation maturity vs evidence quality
+- #223 — public validation lab

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,9 +1,8 @@
 site_name: skdr-eval
 site_description: >-
-  Practitioner-focused offline policy evaluation for sklearn-compatible
-  contextual-bandit policies — time-aware Doubly Robust (DR) and Stabilized
-  DR (SNDR) estimators, calibrated propensities, trust diagnostics, and
-  stakeholder evaluation cards.
+  Evidence-quality offline policy evaluation for finite, discrete one-step
+  decisions — explicit validation boundaries, diagnostics, reproducible
+  artifacts, and a validation-pending DR/SNDR path.
 site_url: https://skdr-eval.readthedocs.io/
 repo_url: https://github.com/dgenio/skdr-eval
 repo_name: dgenio/skdr-eval
@@ -106,6 +105,9 @@ nav:
       - Architecture tour: architecture.md
       - Write your own estimator: extending/add-an-estimator.md
   - Project:
+      - Evidence-first v1 strategy: strategy/evidence-first-v1.md
+      - Design-partner validation: research/design-partner-guide.md
+      - External methodological review: research/external-methodological-review.md
       - Launch readiness checklist: LAUNCH_CHECKLIST.md
       - API stability & road to 1.0: api-stability.md
       - Citing & DOI: zenodo.md


### PR DESCRIPTION
## Why

The August 2026 red-team review found that the public claim surface still overstates what the current pre-validation kernel can justify. In particular, implementation maturity, concrete-run evidence quality, and organizational experiment/deployment decisions must be separate concerns while #58/#280/#167/#279/#281/#62/#245/#259/#282 remain open.

## What this PR does

- rewrites `CLAIMS.md` around the narrow validated-v1 evidence envelope;
- states explicitly that DR/SNDR are currently `validation_pending`;
- removes deploy/experiment-authorization semantics from the public claim boundary;
- requires logged propensities for the initial validated path;
- makes the historical correctness implications of #58/#280 visible;
- demotes healthcare and general LLM/agent routing to experimental/non-validated positioning;
- adds `docs/strategy/evidence-first-v1.md` with the validation ladder, design-partner program, external-review gate, kill criteria, allowed pivots and 70/20/10 execution allocation;
- adds `docs/research/design-partner-guide.md` so #299 can be run consistently without collecting proprietary data;
- adds `docs/research/external-methodological-review.md` with the concrete review packet/questions/severity gate for #298;
- adds a changelog fragment.

## Deliberate non-goals

This PR does not implement the statistical kernel fixes or evidence-state migration. Those remain in the P0 issues. It also does not add new estimator/integration breadth.

## Related issues

#297 #298 #299 #300 #301 #279 #280 #167 #58 #281 #62 #245 #259 #282 #223

## Review focus

Please challenge whether any wording still implies more statistical validity, deployment safety, or domain support than the current validation state can justify.