### PR TITLE
[Superseded by #317] ci: validate exact release tag before Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,54 +5,111 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing immutable release tag to validate and publish (for example v0.13.0)'
+        required: true
+        type: string
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     environment: release
     permissions:
       id-token: write
       contents: write
 
     steps:
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: Resolve release tag
+      id: release
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+          TAG='${{ inputs.tag }}'
+        else
+          TAG='${{ github.ref_name }}'
+        fi
+        if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+          echo "ERROR: release tag must look like vX.Y.Z (optionally with a prerelease suffix); got '$TAG'"
+          exit 1
+        fi
+        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+        echo "Release tag: $TAG"
+
+    - name: Check out exact release tag
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
+        ref: ${{ steps.release.outputs.tag }}
         fetch-depth: 0
+        persist-credentials: false
+
+    - name: Verify immutable tag source
+      shell: bash
+      run: |
+        set -euo pipefail
+        TAG='${{ steps.release.outputs.tag }}'
+        git fetch --force --tags origin
+        TAG_COMMIT="$(git rev-list -n 1 "$TAG")"
+        HEAD_COMMIT="$(git rev-parse HEAD)"
+        echo "Tag commit:  $TAG_COMMIT"
+        echo "Checked out: $HEAD_COMMIT"
+        if [[ "$HEAD_COMMIT" != "$TAG_COMMIT" ]]; then
+          echo "ERROR: checkout is not the commit referenced by $TAG"
+          exit 1
+        fi
+        if [[ -n "$(git status --porcelain)" ]]; then
+          echo "ERROR: release checkout is not clean"
+          git status --porcelain
+          exit 1
+        fi
+        git describe --tags --exact-match HEAD
 
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: "3.11"
 
-    - name: Install build dependencies
+    - name: Install release validation dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install build twine setuptools_scm
+        python -m pip install -e '.[dev]'
+
+    - name: Validate exact tagged source
+      timeout-minutes: 60
+      run: |
+        set -euo pipefail
+        make lint
+        ruff format --check src/ tests/ examples/
+        make typecheck
+        pytest -q
+        make citation-check
+        make smoke
 
     - name: Verify git state for clean versioning
       run: |
+        set -euo pipefail
         git status --porcelain
         git describe --tags --long --dirty
         python -c "import setuptools_scm; print(setuptools_scm.get_version())"
-
-    - name: Clean working directory for setuptools-scm
-      run: |
-        git clean -fd
-        if [ -n "$(git status --porcelain)" ]; then
-          echo "Warning: Working directory has uncommitted changes"
+        if [[ -n "$(git status --porcelain)" ]]; then
+          echo "ERROR: validation changed the release source tree"
           git status --porcelain
+          exit 1
         fi
-        git describe --tags --long --dirty
 
-    - name: Build package
+    - name: Build package once
       run: python -m build
 
     - name: Verify built version matches tag
+      shell: bash
       run: |
+        set -euo pipefail
         BUILT_VERSION=$(python -c "
         import zipfile, os
         for file in os.listdir('dist'):
@@ -68,43 +125,36 @@ jobs:
                             break
                 break
         ")
-        TAG_VERSION=${GITHUB_REF#refs/tags/}
+        TAG_VERSION='${{ steps.release.outputs.tag }}'
         TAG_VERSION=${TAG_VERSION#v}
         echo "Built version: $BUILT_VERSION"
         echo "Tag version: $TAG_VERSION"
         if [[ "$BUILT_VERSION" != "$TAG_VERSION" ]]; then
-          echo "ERROR: Built version does not match tag"
+          echo "ERROR: built version does not match tag"
           exit 1
         fi
 
     - name: Check package
       run: twine check dist/*
 
-    - name: Publish to PyPI (Trusted Publishing)
+    - name: Upload verified build artifacts
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: dist-${{ steps.release.outputs.tag }}-${{ github.run_number }}
+        path: dist/
+        if-no-files-found: error
+
+    - name: Publish verified artifacts to PyPI (Trusted Publishing)
       id: pypi-publish
-      continue-on-error: true
       uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
       with:
         print-hash: true
 
-    - name: Fallback - Manual PyPI publish instructions
-      if: steps.pypi-publish.outcome == 'failure'
-      run: |
-        echo "Trusted Publishing failed. Manual upload required."
-        exit 1
-
-    - name: Upload build artifacts (for manual fallback)
-      if: always()
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: dist-${{ github.run_number }}
-        path: dist/
-
     - name: Create GitHub Release
-      if: startsWith(github.ref, 'refs/tags/v')
       uses: softprops/action-gh-release@7c4723f7a335432393329f8f1c564994ce50185d # v3
       with:
+        tag_name: ${{ steps.release.outputs.tag }}
         files: dist/*
         generate_release_notes: false
-        body_path: RELEASE_NOTES_${{ github.ref_name }}.md
+        body_path: RELEASE_NOTES_${{ steps.release.outputs.tag }}.md
         fail_on_unmatched_files: false


### PR DESCRIPTION
## Superseded by refreshed PR #317

This branch was created before five subsequent `main` commits (#303, #305, #307, #315, #316) and became artificially diverged even though the release workflow itself had not changed.

PR #317 reapplies the same #295 hardening cleanly on current `main` and is the canonical review target.

No intended release-integrity behavior is lost.