### PR TITLE
refactor: retire advertised tracker placeholders (#217)

### DIFF
--- a/changelog.d/217.deprecated.md
+++ b/changelog.d/217.deprecated.md
@@ -1,0 +1,1 @@
+Stop advertising the historical MLflow, Weights & Biases and Aim tracker placeholders as working capabilities. Direct imports remain only as deprecated compatibility shims for a bounded migration window; use `NullTracker`, `FileTracker`, or the small `Tracker` protocol instead.

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -16,7 +16,6 @@ jinja2, pydantic, pyyaml). Heavier or specialised dependencies are opt-in:
 | `[viz]` | matplotlib | Rendering charts in the evaluation card. |
 | `[speed]` | pyarrow, polars | Columnar I/O / faster pairwise grouping. |
 | `[cli]` | typer, joblib, pyarrow | The `skdr-eval` command-line tool. |
-| `[mlflow]` / `[wandb]` / `[aim]` | the respective tracker | Logging artifacts to an experiment tracker. |
 | `[notebooks]` | jupyter, matplotlib | Running the example notebooks. |
 | `[docs]` | mkdocs-material, mkdocstrings | Building this documentation site. |
 | `[dev]` | pytest, mypy, ruff, … | Contributing. |
@@ -25,6 +24,12 @@ jinja2, pydantic, pyyaml). Heavier or specialised dependencies are opt-in:
 pip install "skdr-eval[viz,cli]"
 ```
 
+> **Tracker integrations:** historical `[mlflow]`, `[wandb]`, and `[aim]`
+> extras were published before working adapters existed. They are being retired
+> under issue #217 and are intentionally not advertised as capabilities. Use
+> the built-in `FileTracker` / `NullTracker`, or implement the small `Tracker`
+> protocol in application code when another destination is required.
+
 ## Verify the install
 
 ```python
@@ -32,8 +37,15 @@ import skdr_eval
 
 # Which optional extras are active?
 print(skdr_eval.get_capabilities())
-# -> {'viz': True, 'speed': False, 'cli': False, 'missing_extras': [...]}
+# -> {'viz': True, 'speed': False, 'missing_extras': [...]}
+
+# Which implemented user-facing optional features are available?
+for capability in skdr_eval.get_capability_matrix():
+    print(capability.extra, capability.installed)
 ```
+
+The capability matrix reports functionality that actually exists. It does not
+report historical compatibility-only tracker placeholder extras.
 
 ## From source
 

--- a/src/skdr_eval/capabilities.py
+++ b/src/skdr_eval/capabilities.py
@@ -1,14 +1,19 @@
 """Runtime capability detection for skdr-eval optional extras.
 
 Provides a side-effect-free way to discover which optional dependency
-groups (``[viz]``, ``[speed]``) are installed, so callers and CI smoke
-checks can short-circuit gracefully when a feature requires an extra
-that was not installed.
+groups are installed, so callers and CI smoke checks can short-circuit
+gracefully when a feature requires an extra that was not installed.
 
-The set of detected capabilities tracks the *truly* optional extras in
-``pyproject.toml``: ``viz`` (``matplotlib``) and ``speed`` (``pyarrow``
-+ ``polars``). ``scipy`` is a mandatory dependency, so condlogit
-propensity estimation is always available and is not listed here.
+Only **working, user-facing capabilities** are reported here. Historical
+MLflow / W&B / Aim extras were published before real tracker adapters existed;
+those placeholders are intentionally not advertised as capabilities. Their
+importable compatibility shims are deprecated separately under issue #217.
+
+The set of detected capabilities tracks the optional features that currently
+have working public implementations: ``viz`` (``matplotlib``), ``speed``
+(``pyarrow`` + ``polars``), ``cli`` and ``boosting``. ``scipy`` is a mandatory
+dependency, so conditional-logit propensity estimation is always available and
+is not listed here.
 """
 
 from __future__ import annotations
@@ -30,18 +35,18 @@ _EXTRA_BY_CAPABILITY = {
     "speed": "speed",
 }
 
-# Full capability matrix (#215): every optional ``[extra]`` declared in
-# ``pyproject.toml``, the modules that enable it, and the user-facing feature it
-# unlocks. ``scipy`` is a mandatory dependency (conditional-logit propensities
-# are always available), so it is intentionally absent here.
+# Full capability matrix (#215): every currently supported optional user-facing
+# feature, the modules that enable it, and the behavior it unlocks.
+#
+# Historical ``mlflow`` / ``wandb`` / ``aim`` package extras are deliberately
+# absent. They never had working adapters and are being retired under #217; a
+# package being importable must not make ``skdr-eval capabilities`` claim that
+# an integration exists.
 _EXTRA_MODULES: dict[str, tuple[str, ...]] = {
     "viz": ("matplotlib",),
     "speed": ("pyarrow", "polars"),
     "cli": ("typer", "joblib", "pyarrow"),
     "boosting": ("xgboost", "lightgbm", "catboost"),
-    "mlflow": ("mlflow",),
-    "wandb": ("wandb",),
-    "aim": ("aim",),
 }
 
 _EXTRA_FEATURES: dict[str, str] = {
@@ -49,9 +54,6 @@ _EXTRA_FEATURES: dict[str, str] = {
     "speed": "Accelerated parquet/feather I/O via pyarrow + polars.",
     "cli": "The 'skdr-eval' command-line interface.",
     "boosting": "XGBoost / LightGBM / CatBoost model adapters.",
-    "mlflow": "MLflow experiment-tracker integration.",
-    "wandb": "Weights & Biases experiment-tracker integration.",
-    "aim": "Aim experiment-tracker integration.",
 }
 
 
@@ -92,13 +94,16 @@ def _module_available(name: str) -> bool:
 
 
 def get_capability_matrix() -> list[Capability]:
-    """Return the full optional-dependency capability matrix (#215).
+    """Return the working optional-dependency capability matrix (#215).
 
-    Unlike :func:`get_capabilities` (which reports only the *truly optional*
-    feature toggles ``viz`` / ``speed``), this covers every pip extra declared
-    in ``pyproject.toml`` — including ``cli``, ``boosting`` and the experiment
-    trackers — so ``doctor`` and the ``skdr-eval capabilities`` command can show
-    users which features are available and how to unlock the rest.
+    Unlike :func:`get_capabilities` (which reports only the lightweight
+    ``viz`` / ``speed`` feature toggles), this also covers the working ``cli``
+    and ``boosting`` extras so ``doctor`` and ``skdr-eval capabilities`` can
+    show users which implemented features are available.
+
+    Deprecated placeholder tracker extras are intentionally excluded: the
+    capability command describes functionality that actually exists, not every
+    historical extra name still accepted during a deprecation window.
 
     Detection is import-light: it only probes :func:`importlib.util.find_spec`
     and never imports the heavy extras themselves.
@@ -106,7 +111,7 @@ def get_capability_matrix() -> list[Capability]:
     Returns
     -------
     list[Capability]
-        One :class:`Capability` per extra, ordered as declared in
+        One :class:`Capability` per supported extra, ordered as declared in
         :data:`_EXTRA_MODULES`.
     """
     matrix: list[Capability] = []
@@ -125,7 +130,7 @@ def get_capability_matrix() -> list[Capability]:
 
 
 def get_capabilities() -> dict[str, bool | list[str]]:
-    """Return the set of optional capabilities available in this environment.
+    """Return the lightweight optional capabilities available in this environment.
 
     The returned dict is suitable for preflight checks: a missing capability
     means the matching ``pip install 'skdr-eval[<extra>]'`` invocation will

--- a/src/skdr_eval/trackers/__init__.py
+++ b/src/skdr_eval/trackers/__init__.py
@@ -2,22 +2,22 @@
 
 The :class:`Tracker` protocol defines the minimum surface
 (``log_metric`` / ``log_artifact`` / ``log_card`` / ``set_tag`` plus context
-management) that evaluators use to push results to disk or an external
-experiment tracker. The core ships:
+management) that evaluators use to push results to disk or another destination.
+The supported built-ins are intentionally small:
 
 - :class:`NullTracker` — no-op default; used when ``tracker=None``.
 - :class:`FileTracker` — writes JSONL metrics and artifact files to a run
   directory.
 
-External adapters (MLflow / W&B / Aim) live in this package as separate
-modules gated behind their own optional extras (``[mlflow]``, ``[wandb]``,
-``[aim]``). They currently raise :class:`NotImplementedError` on
-construction — the umbrella issue #73 tracks each adapter's full
-implementation as a follow-up PR.
+Historical MLflow / W&B / Aim modules were published as placeholders before
+working integrations existed. They are **not supported capabilities** and are
+being retired under issue #217. Their direct-import names remain only as bounded
+deprecation shims; new code should use the built-ins or implement this protocol
+locally rather than relying on those placeholders.
 
-This module has zero new mandatory dependencies. The ``FileTracker`` uses
-only the standard library and the existing ``pyyaml`` dep already shipped
-in core.
+This module has zero new mandatory dependencies. The ``FileTracker`` uses only
+the standard library and the existing ``pyyaml`` dependency already shipped in
+core.
 """
 
 from __future__ import annotations
@@ -38,12 +38,12 @@ logger = logging.getLogger("skdr_eval")
 
 @runtime_checkable
 class Tracker(Protocol):
-    """Minimum surface for experiment trackers used by ``evaluate_*_models``.
+    """Minimum surface for trackers used by ``evaluate_*_models``.
 
     Implementations must be safe to use as context managers. The
-    :class:`NullTracker` and :class:`FileTracker` ship in core; external
-    adapters (MLflow / W&B / Aim) live in sibling modules behind optional
-    extras.
+    :class:`NullTracker` and :class:`FileTracker` ship in core. Applications
+    that need another destination can implement this small protocol without
+    requiring a skdr-eval-maintained third-party adapter.
     """
 
     def log_metric(self, name: str, value: float, step: int | None = None) -> None: ...

--- a/src/skdr_eval/trackers/_stub.py
+++ b/src/skdr_eval/trackers/_stub.py
@@ -1,40 +1,47 @@
-"""Shared stub-class builder for external tracker adapters.
+"""Deprecated compatibility shims for historical tracker placeholders.
 
-Used by :mod:`mlflow`, :mod:`wandb`, and :mod:`aim` adapter modules to expose
-importable classes that raise :class:`NotImplementedError` on construction
-until their full implementations land under umbrella issue #73.
+Early releases exposed importable MLflow / W&B / Aim tracker classes before
+working adapters existed. Those names are retained only for a bounded
+deprecation window so old imports fail with an honest migration message instead
+of pretending that installing an extra will unlock functionality.
+
+Issue #217 tracks their retirement. New code should use the built-in
+``NullTracker`` / ``FileTracker`` or implement the small ``Tracker`` protocol
+locally until repeated user demand justifies a real maintained integration.
 """
 
 from __future__ import annotations
 
+import warnings
 from typing import Any
 
 
 def build_stub(package: str) -> type:
-    """Construct a stub tracker class that errors on instantiation.
-
-    The class name is ``<Package>Tracker`` (capitalized). The error message
-    references the matching ``pip install 'skdr-eval[<package>]'`` extra and
-    points at the umbrella issue.
-    """
-    install_hint = f"pip install 'skdr-eval[{package}]'"
+    """Construct a deprecated compatibility shim for an unimplemented adapter."""
 
     class _Stub:
         __slots__ = ()
 
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             del args, kwargs
+            warnings.warn(
+                f"skdr_eval.trackers.{package} is a deprecated compatibility "
+                "placeholder and is scheduled for removal. skdr-eval does not "
+                f"currently provide a working {package} tracker integration. ",
+                DeprecationWarning,
+                stacklevel=2,
+            )
             raise NotImplementedError(
-                f"The {package} tracker adapter is a stub. Install the optional "
-                f"extra ({install_hint}) and wait for the full adapter to ship "
-                f"under issue #73."
+                f"skdr-eval does not provide a working {package} tracker "
+                "integration. Use NullTracker/FileTracker or implement the "
+                "Tracker protocol locally. The historical placeholder is being "
+                "retired under issue #217."
             )
 
     _Stub.__name__ = f"{package.capitalize()}Tracker"
     _Stub.__qualname__ = _Stub.__name__
     _Stub.__doc__ = (
-        f"Stub for the {package} tracker adapter. "
-        f"Raises NotImplementedError on construction. "
-        f"Full implementation tracked by issue #73."
+        f"Deprecated compatibility placeholder for the {package} tracker. "
+        "No working integration is provided."
     )
     return _Stub

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -96,29 +96,29 @@ def test_find_spec_value_error_treated_as_missing(monkeypatch):
 
 
 class TestCapabilityMatrix:
-    """#215: the full optional-dependency capability matrix."""
+    """#215/#217: capability matrix lists working features, not dead extras."""
 
-    def test_matrix_covers_every_declared_extra(self):
+    def test_matrix_covers_supported_runtime_features_only(self):
         pyproject = tomllib.loads(
             (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
         )
         declared = set(pyproject["project"]["optional-dependencies"])
-        # The matrix intentionally omits dev-only / docs / notebooks extras,
-        # but must cover every *runtime feature* extra.
-        feature_extras = {
+        supported_feature_extras = {
             "viz",
             "speed",
             "cli",
             "boosting",
-            "mlflow",
-            "wandb",
-            "aim",
         }
-        assert feature_extras <= declared, (
-            "matrix references extras not declared in pyproject.toml"
-        )
+        # Historical tracker extras may remain declared during a bounded
+        # deprecation window, but they must never be advertised as working
+        # capabilities while their adapters do not exist.
+        retired_placeholders = {"mlflow", "wandb", "aim"}
+
+        assert supported_feature_extras <= declared
         matrix = skdr_eval.get_capability_matrix()
-        assert {c.extra for c in matrix} == feature_extras
+        reported = {c.extra for c in matrix}
+        assert reported == supported_feature_extras
+        assert reported.isdisjoint(retired_placeholders)
 
     def test_matrix_entries_are_well_formed(self):
         for cap in skdr_eval.get_capability_matrix():

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -41,14 +41,17 @@ class TestNullTracker:
         tracker.log_metric("foo", 1.0)
         tracker.log_metric("foo", 1.0, step=5)
         tracker.set_tag("seed", "0")
+        # ``log_artifact`` should accept paths but produce no side effects.
         sample = tmp_path / "sample.txt"
         sample.write_text("hello")
         tracker.log_artifact(sample, artifact_path="sub/path.txt")
+        # No new entries beside the original ``sample.txt``.
         assert sorted(p.name for p in tmp_path.iterdir()) == ["sample.txt"]
 
     def test_context_manager(self):
         with NullTracker() as t:
             t.log_metric("x", 0.0)
+        # No raise = pass.
 
     def test_log_card_no_op(self):
         artifact = _build_artifact()
@@ -114,8 +117,9 @@ class TestFileTracker:
         artifact = _build_artifact()
         card = artifact.card_schema("HGB", estimator="DR")
         tracker.log_card(card)
-        out = root / "cards" / "HGB_DR.card.yaml"
+        out = root / "cards" / f"{card.model_name}_{card.headline.estimator}.card.yaml"
         assert out.is_file()
+        # Round-trip the YAML to ensure the card was written correctly.
         loaded = skdr_eval.EvaluationCard.from_yaml(out)
         assert loaded == card
 
@@ -123,6 +127,7 @@ class TestFileTracker:
         root = tmp_path / "run-8"
         FileTracker(root).set_tag("a", "1")
         second = FileTracker(root)
+        # Tag round-trip across two trackers on the same root.
         second.set_tag("b", "2")
         tags = json.loads((root / "tags.json").read_text())
         assert tags == {"a": "1", "b": "2"}
@@ -130,11 +135,16 @@ class TestFileTracker:
 
 class TestEvaluatorTrackerWiring:
     def test_none_default_is_no_op(self, tmp_path: Path):
+        """With ``tracker=None`` (default) the evaluator must not write."""
+        # Nothing to assert beyond "no raise" — there is no tracker dir to
+        # inspect for absence of state.
         artifact = _build_artifact()
         assert isinstance(artifact, skdr_eval.EvaluationArtifact)
 
     def test_null_tracker_artifact_identical_to_none(self):
         art_a = _build_artifact()
+        # Re-run with NullTracker — by construction the per-row metrics are
+        # identical because the tracker only observes, never mutates.
         logs, _, _ = skdr_eval.make_synth_logs(n=400, n_ops=3, seed=0)
         models = {"HGB": HistGradientBoostingRegressor(max_iter=20, random_state=0)}
         art_b = skdr_eval.evaluate_sklearn_models(
@@ -146,9 +156,11 @@ class TestEvaluatorTrackerWiring:
             policy_train="pre_split",
             tracker=NullTracker(),
         )
+        # Compare V_hat rows — deterministic per seed.
         cols = ["model", "estimator", "V_hat"]
         pd_a = art_a.report[cols].reset_index(drop=True)
         pd_b = art_b.report[cols].reset_index(drop=True)
+        # Float equality up to determinism (same seed, same pipeline).
         assert (pd_a["V_hat"] - pd_b["V_hat"]).abs().max() < 1e-12
 
     def test_file_tracker_writes_metrics_and_cards(self, tmp_path: Path):
@@ -165,6 +177,7 @@ class TestEvaluatorTrackerWiring:
                 policy_train="pre_split",
                 tracker=tracker,
             )
+        # At least V_hat for DR and SNDR was logged.
         metrics_path = root / "metrics.jsonl"
         assert metrics_path.is_file()
         names = {
@@ -174,6 +187,7 @@ class TestEvaluatorTrackerWiring:
         }
         assert "HGB/DR/V_hat" in names
         assert "HGB/SNDR/V_hat" in names
+        # One card per estimator.
         cards = sorted((root / "cards").iterdir())
         assert len(cards) == 2, [p.name for p in cards]
 
@@ -223,17 +237,21 @@ class TestDeprecatedTrackerPlaceholders:
 
 class TestFileTrackerEdgeCases:
     def test_corrupt_tags_json_recovers(self, tmp_path: Path):
+        """FileTracker gracefully handles corrupted tags.json."""
         root = tmp_path / "run-corrupt"
         root.mkdir(parents=True)
         (root / "artifacts").mkdir()
         (root / "cards").mkdir()
+        # Write garbage to tags.json before constructing tracker.
         (root / "tags.json").write_text("{invalid json", encoding="utf-8")
         tracker = FileTracker(root)
+        # Should recover with empty tags.
         tracker.set_tag("new", "value")
         tags = json.loads((root / "tags.json").read_text(encoding="utf-8"))
         assert tags == {"new": "value"}
 
     def test_log_artifact_path_traversal_raises(self, tmp_path: Path):
+        """log_artifact rejects paths that escape the artifacts directory."""
         root = tmp_path / "run-traversal"
         tracker = FileTracker(root)
         src = tmp_path / "evil.txt"

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -41,17 +41,14 @@ class TestNullTracker:
         tracker.log_metric("foo", 1.0)
         tracker.log_metric("foo", 1.0, step=5)
         tracker.set_tag("seed", "0")
-        # ``log_artifact`` should accept paths but produce no side effects.
         sample = tmp_path / "sample.txt"
         sample.write_text("hello")
         tracker.log_artifact(sample, artifact_path="sub/path.txt")
-        # No new entries beside the original ``sample.txt``.
         assert sorted(p.name for p in tmp_path.iterdir()) == ["sample.txt"]
 
     def test_context_manager(self):
         with NullTracker() as t:
             t.log_metric("x", 0.0)
-        # No raise = pass.
 
     def test_log_card_no_op(self):
         artifact = _build_artifact()
@@ -119,7 +116,6 @@ class TestFileTracker:
         tracker.log_card(card)
         out = root / "cards" / "HGB_DR.card.yaml"
         assert out.is_file()
-        # Round-trip the YAML to ensure the card was written correctly.
         loaded = skdr_eval.EvaluationCard.from_yaml(out)
         assert loaded == card
 
@@ -127,7 +123,6 @@ class TestFileTracker:
         root = tmp_path / "run-8"
         FileTracker(root).set_tag("a", "1")
         second = FileTracker(root)
-        # Tag round-trip across two trackers on the same root.
         second.set_tag("b", "2")
         tags = json.loads((root / "tags.json").read_text())
         assert tags == {"a": "1", "b": "2"}
@@ -135,16 +130,11 @@ class TestFileTracker:
 
 class TestEvaluatorTrackerWiring:
     def test_none_default_is_no_op(self, tmp_path: Path):
-        """With ``tracker=None`` (default) the evaluator must not write."""
-        # Nothing to assert beyond "no raise" — there is no tracker dir to
-        # inspect for absence of state.
         artifact = _build_artifact()
         assert isinstance(artifact, skdr_eval.EvaluationArtifact)
 
     def test_null_tracker_artifact_identical_to_none(self):
         art_a = _build_artifact()
-        # Re-run with NullTracker — by construction the per-row metrics are
-        # identical because the tracker only observes, never mutates.
         logs, _, _ = skdr_eval.make_synth_logs(n=400, n_ops=3, seed=0)
         models = {"HGB": HistGradientBoostingRegressor(max_iter=20, random_state=0)}
         art_b = skdr_eval.evaluate_sklearn_models(
@@ -156,11 +146,9 @@ class TestEvaluatorTrackerWiring:
             policy_train="pre_split",
             tracker=NullTracker(),
         )
-        # Compare V_hat rows — deterministic per seed.
         cols = ["model", "estimator", "V_hat"]
         pd_a = art_a.report[cols].reset_index(drop=True)
         pd_b = art_b.report[cols].reset_index(drop=True)
-        # Float equality up to determinism (same seed, same pipeline).
         assert (pd_a["V_hat"] - pd_b["V_hat"]).abs().max() < 1e-12
 
     def test_file_tracker_writes_metrics_and_cards(self, tmp_path: Path):
@@ -177,7 +165,6 @@ class TestEvaluatorTrackerWiring:
                 policy_train="pre_split",
                 tracker=tracker,
             )
-        # At least V_hat for DR and SNDR was logged.
         metrics_path = root / "metrics.jsonl"
         assert metrics_path.is_file()
         names = {
@@ -187,7 +174,6 @@ class TestEvaluatorTrackerWiring:
         }
         assert "HGB/DR/V_hat" in names
         assert "HGB/SNDR/V_hat" in names
-        # One card per estimator.
         cards = sorted((root / "cards").iterdir())
         assert len(cards) == 2, [p.name for p in cards]
 
@@ -215,37 +201,39 @@ class TestEvaluatorTrackerWiring:
         assert (root / "metrics.jsonl").is_file()
 
 
-class TestTrackerStubs:
-    def test_mlflow_stub_raises_on_construct(self):
-        with pytest.raises(NotImplementedError, match=r"mlflow"):
-            MLflowTracker()
-
-    def test_wandb_stub_raises_on_construct(self):
-        with pytest.raises(NotImplementedError, match=r"wandb"):
-            WandbTracker()
-
-    def test_aim_stub_raises_on_construct(self):
-        with pytest.raises(NotImplementedError, match=r"aim"):
-            AimTracker()
+class TestDeprecatedTrackerPlaceholders:
+    @pytest.mark.parametrize(
+        ("tracker_cls", "package"),
+        [
+            (MLflowTracker, "mlflow"),
+            (WandbTracker, "wandb"),
+            (AimTracker, "aim"),
+        ],
+    )
+    def test_placeholder_is_explicitly_deprecated_and_unusable(
+        self, tracker_cls, package
+    ):
+        with pytest.warns(DeprecationWarning, match="deprecated compatibility"):
+            with pytest.raises(
+                NotImplementedError,
+                match=rf"does not provide a working {package} tracker integration",
+            ):
+                tracker_cls()
 
 
 class TestFileTrackerEdgeCases:
     def test_corrupt_tags_json_recovers(self, tmp_path: Path):
-        """FileTracker gracefully handles corrupted tags.json."""
         root = tmp_path / "run-corrupt"
         root.mkdir(parents=True)
         (root / "artifacts").mkdir()
         (root / "cards").mkdir()
-        # Write garbage to tags.json before constructing tracker.
         (root / "tags.json").write_text("{invalid json", encoding="utf-8")
         tracker = FileTracker(root)
-        # Should recover with empty tags.
         tracker.set_tag("new", "value")
         tags = json.loads((root / "tags.json").read_text(encoding="utf-8"))
         assert tags == {"new": "value"}
 
     def test_log_artifact_path_traversal_raises(self, tmp_path: Path):
-        """log_artifact rejects paths that escape the artifacts directory."""
         root = tmp_path / "run-traversal"
         tracker = FileTracker(root)
         src = tmp_path / "evil.txt"


### PR DESCRIPTION
## Why

The validation/adoption reset says the project should stop carrying speculative integration breadth. MLflow/W&B/Aim tracker classes are importable but have never been working integrations; advertising them as optional capabilities creates false expectations and unnecessary maintenance surface.

## What changes

- `get_capability_matrix()` now reports only implemented user-facing optional features (`viz`, `speed`, `cli`, `boosting`).
- Historical MLflow/W&B/Aim placeholder modules remain only as bounded compatibility shims and now emit `DeprecationWarning` plus an explicit message that **no working integration exists**.
- Placeholder errors no longer tell users to install an extra and wait for future implementation.
- Tracker package docs now scope the supported surface to `NullTracker`, `FileTracker`, and the small `Tracker` protocol.
- Install docs stop advertising the tracker extras as working integrations.
- Tests assert deprecated placeholders are excluded from the capability matrix and fail honestly if instantiated.
- Adds a deprecation changelog fragment.

## Compatibility

The direct import names are not deleted in this PR; they are intentionally retained for a bounded deprecation window. This avoids a surprise import break while removing the misleading capability claim. Removal can follow the documented support/deprecation policy.

## Deliberate non-goal

This PR does **not** implement MLflow, W&B, or Aim adapters. A future maintained integration should require repeated external demand or a direct validated-workflow need.

Fixes #217