### PR TITLE
[Duplicate of #307] feat: add explicit target-policy distribution contract

### DIFF
--- a/changelog.d/279.added.md
+++ b/changelog.d/279.added.md
@@ -1,0 +1,1 @@
+Added an explicit finite-discrete `Policy` action-distribution contract plus fail-closed validation for action vocabulary, normalization, eligibility, finiteness, and deterministic/stochastic target policies. This is the policy-construction seam for the validated-v1 redesign; the existing sklearn evaluator is not yet migrated to consume it.

--- a/src/skdr_eval/policy.py
+++ b/src/skdr_eval/policy.py
@@ -1,0 +1,281 @@
+"""Explicit target-policy contracts for one-step offline policy evaluation.
+
+This module defines the policy boundary required by the validated-v1 roadmap
+(#279 / #297).  A target policy is represented by the probability distribution
+it would use over the *explicit* action vocabulary for each evaluated context.
+
+The contract is deliberately independent of outcome-model scores.  A regression
+or ranking model may be adapted into a :class:`Policy`, but the validated OPE
+kernel must consume the resulting action distribution rather than infer a policy
+from arbitrary prediction semantics.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+
+from .exceptions import DataValidationError
+
+
+@runtime_checkable
+class Policy(Protocol):
+    """Protocol for an explicit finite-discrete target policy.
+
+    Implementations return one probability row per context and one column per
+    action in the supplied ``actions`` vocabulary.  Deterministic policies use
+    one-hot rows; stochastic policies return ordinary categorical
+    distributions.
+
+    ``eligible_actions`` is an optional boolean matrix with shape
+    ``(n_rows, n_actions)``.  When supplied, implementations must put exactly
+    zero probability on ineligible actions.
+    """
+
+    def action_distribution(
+        self,
+        contexts: np.ndarray,
+        *,
+        actions: Sequence[str],
+        eligible_actions: np.ndarray | None = None,
+    ) -> np.ndarray: ...
+
+
+PolicyCallable = Callable[
+    [np.ndarray, Sequence[str], np.ndarray | None],
+    np.ndarray,
+]
+
+
+@dataclass(frozen=True)
+class CallablePolicy:
+    """Small adapter for a callable that already produces action probabilities.
+
+    The callable receives ``(contexts, actions, eligible_actions)`` and must
+    return an ``(n_rows, n_actions)`` array.  Output validation is performed by
+    :func:`resolve_action_distribution`, not by this adapter, so every policy
+    implementation is held to the same contract.
+    """
+
+    fn: PolicyCallable
+    name: str | None = None
+
+    def action_distribution(
+        self,
+        contexts: np.ndarray,
+        *,
+        actions: Sequence[str],
+        eligible_actions: np.ndarray | None = None,
+    ) -> np.ndarray:
+        return np.asarray(self.fn(contexts, actions, eligible_actions), dtype=np.float64)
+
+
+def _coerce_eligibility(
+    eligible_actions: np.ndarray | None,
+    *,
+    n_rows: int,
+    n_actions: int,
+) -> np.ndarray:
+    """Return a validated boolean eligibility matrix.
+
+    ``None`` means every action is eligible.  A row with no eligible actions is
+    invalid for the explicit-policy contract: there is no categorical
+    distribution that can both sum to one and assign zero probability to every
+    ineligible action.
+    """
+
+    if eligible_actions is None:
+        return np.ones((n_rows, n_actions), dtype=bool)
+
+    eligibility = np.asarray(eligible_actions)
+    expected = (n_rows, n_actions)
+    if eligibility.shape != expected:
+        raise DataValidationError(
+            "eligible_actions must have shape "
+            f"{expected}; got {eligibility.shape}"
+        )
+
+    if eligibility.dtype == np.bool_:
+        eligibility_bool = eligibility.astype(bool, copy=False)
+    else:
+        if not np.all(np.isin(eligibility, (0, 1))):
+            raise DataValidationError(
+                "eligible_actions must contain only booleans or 0/1 values"
+            )
+        eligibility_bool = eligibility.astype(bool)
+
+    empty_rows = np.flatnonzero(~eligibility_bool.any(axis=1))
+    if empty_rows.size:
+        preview = empty_rows[:5].tolist()
+        raise DataValidationError(
+            "Every evaluated row must have at least one eligible action; "
+            f"rows without eligible actions include {preview}"
+        )
+
+    return eligibility_bool
+
+
+def validate_action_distribution(
+    probabilities: np.ndarray,
+    *,
+    n_rows: int,
+    actions: Sequence[str],
+    eligible_actions: np.ndarray | None = None,
+    atol: float = 1e-10,
+) -> np.ndarray:
+    """Validate and return a target-policy action distribution.
+
+    Parameters
+    ----------
+    probabilities:
+        Candidate probability matrix with shape ``(n_rows, n_actions)``.
+    n_rows:
+        Number of evaluated contexts.
+    actions:
+        Explicit action vocabulary.  Column ``j`` in ``probabilities`` refers
+        to ``actions[j]``; duplicate action labels are rejected.
+    eligible_actions:
+        Optional boolean/0-1 eligibility matrix.  Probability on an ineligible
+        action is a hard error rather than being silently renormalized away.
+    atol:
+        Absolute tolerance used only for floating-point normalization and
+        effectively-zero eligibility checks.
+
+    Returns
+    -------
+    np.ndarray
+        A float64 matrix satisfying the explicit policy contract.  The function
+        does **not** silently clip, fill, or renormalize invalid input.
+
+    Raises
+    ------
+    DataValidationError
+        If shape, action vocabulary, finiteness, non-negativity,
+        normalization, or eligibility constraints are violated.
+    """
+
+    if not isinstance(n_rows, int) or n_rows < 0:
+        raise DataValidationError(f"n_rows must be a non-negative integer; got {n_rows!r}")
+    if not np.isfinite(atol) or atol < 0:
+        raise DataValidationError(f"atol must be finite and non-negative; got {atol!r}")
+
+    action_tuple = tuple(actions)
+    if not action_tuple:
+        raise DataValidationError("actions must contain at least one action")
+    if len(set(action_tuple)) != len(action_tuple):
+        raise DataValidationError("actions must be unique and ordered explicitly")
+
+    n_actions = len(action_tuple)
+    probs = np.asarray(probabilities, dtype=np.float64)
+    expected = (n_rows, n_actions)
+    if probs.shape != expected:
+        raise DataValidationError(
+            f"policy probabilities must have shape {expected}; got {probs.shape}"
+        )
+
+    if not np.all(np.isfinite(probs)):
+        bad = np.argwhere(~np.isfinite(probs))[0]
+        raise DataValidationError(
+            "policy probabilities must be finite; first non-finite value at "
+            f"row={int(bad[0])}, action={action_tuple[int(bad[1])]!r}"
+        )
+
+    negative = np.argwhere(probs < -atol)
+    if negative.size:
+        bad = negative[0]
+        raise DataValidationError(
+            "policy probabilities must be non-negative; first negative value at "
+            f"row={int(bad[0])}, action={action_tuple[int(bad[1])]!r}"
+        )
+
+    # Tiny negative floating-point noise inside tolerance is accepted as zero,
+    # but material invalidity is never repaired silently.
+    probs = np.where(np.abs(probs) <= atol, 0.0, probs)
+
+    eligibility = _coerce_eligibility(
+        eligible_actions,
+        n_rows=n_rows,
+        n_actions=n_actions,
+    )
+    ineligible_mass = np.argwhere((~eligibility) & (probs > atol))
+    if ineligible_mass.size:
+        bad = ineligible_mass[0]
+        raise DataValidationError(
+            "target policy assigns positive probability to an ineligible action; "
+            f"row={int(bad[0])}, action={action_tuple[int(bad[1])]!r}, "
+            f"probability={float(probs[tuple(bad)])}"
+        )
+
+    row_sums = probs.sum(axis=1)
+    bad_rows = np.flatnonzero(~np.isclose(row_sums, 1.0, rtol=0.0, atol=atol))
+    if bad_rows.size:
+        row = int(bad_rows[0])
+        raise DataValidationError(
+            "target-policy probabilities must sum to 1 on every row; "
+            f"row {row} sums to {float(row_sums[row])}"
+        )
+
+    return probs
+
+
+def resolve_action_distribution(
+    policy: Policy | np.ndarray,
+    contexts: np.ndarray,
+    *,
+    actions: Sequence[str],
+    eligible_actions: np.ndarray | None = None,
+    atol: float = 1e-10,
+) -> np.ndarray:
+    """Resolve a policy object or explicit matrix into validated probabilities.
+
+    This is the intended seam between policy construction and the statistical
+    kernel.  The kernel should consume only the returned matrix and explicit
+    action vocabulary; it should not reinterpret model scores.
+    """
+
+    contexts_array = np.asarray(contexts)
+    if contexts_array.ndim == 0:
+        raise DataValidationError("contexts must have a row dimension")
+    n_rows = int(contexts_array.shape[0])
+
+    if isinstance(policy, np.ndarray):
+        raw = policy
+    else:
+        action_distribution = getattr(policy, "action_distribution", None)
+        if action_distribution is None or not callable(action_distribution):
+            raise DataValidationError(
+                "policy must be an explicit probability matrix or implement "
+                "action_distribution(contexts, *, actions, eligible_actions)"
+            )
+        try:
+            raw = action_distribution(
+                contexts_array,
+                actions=tuple(actions),
+                eligible_actions=eligible_actions,
+            )
+        except DataValidationError:
+            raise
+        except Exception as exc:
+            raise DataValidationError(
+                f"policy.action_distribution failed: {exc}"
+            ) from exc
+
+    return validate_action_distribution(
+        np.asarray(raw),
+        n_rows=n_rows,
+        actions=actions,
+        eligible_actions=eligible_actions,
+        atol=atol,
+    )
+
+
+__all__ = [
+    "CallablePolicy",
+    "Policy",
+    "PolicyCallable",
+    "resolve_action_distribution",
+    "validate_action_distribution",
+]

--- a/tests/test_policy_contract.py
+++ b/tests/test_policy_contract.py
@@ -1,0 +1,203 @@
+"""Tests for the explicit target-policy contract (#279)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from skdr_eval.exceptions import DataValidationError
+from skdr_eval.policy import (
+    CallablePolicy,
+    Policy,
+    resolve_action_distribution,
+    validate_action_distribution,
+)
+
+
+def _contexts(n: int = 3) -> np.ndarray:
+    return np.arange(n * 2, dtype=np.float64).reshape(n, 2)
+
+
+def test_explicit_matrix_round_trips_without_renormalization() -> None:
+    probs = np.array(
+        [
+            [1.0, 0.0],
+            [0.25, 0.75],
+            [0.0, 1.0],
+        ]
+    )
+    resolved = resolve_action_distribution(
+        probs,
+        _contexts(),
+        actions=("a", "b"),
+    )
+    np.testing.assert_array_equal(resolved, probs)
+
+
+def test_deterministic_policy_is_one_hot_distribution() -> None:
+    probs = np.array([[1.0, 0.0], [0.0, 1.0]])
+    out = validate_action_distribution(
+        probs,
+        n_rows=2,
+        actions=("a", "b"),
+    )
+    np.testing.assert_array_equal(out, probs)
+
+
+def test_callable_policy_satisfies_protocol_and_receives_vocabulary() -> None:
+    seen: dict[str, object] = {}
+
+    def fn(
+        contexts: np.ndarray,
+        actions,
+        eligible_actions: np.ndarray | None,
+    ) -> np.ndarray:
+        seen["shape"] = contexts.shape
+        seen["actions"] = tuple(actions)
+        seen["elig"] = eligible_actions
+        return np.array([[0.5, 0.5], [1.0, 0.0], [0.0, 1.0]])
+
+    policy = CallablePolicy(fn=fn, name="candidate")
+    assert isinstance(policy, Policy)
+
+    elig = np.array([[1, 1], [1, 0], [0, 1]], dtype=bool)
+    out = resolve_action_distribution(
+        policy,
+        _contexts(),
+        actions=("left", "right"),
+        eligible_actions=elig,
+    )
+    assert seen["shape"] == (3, 2)
+    assert seen["actions"] == ("left", "right")
+    assert seen["elig"] is elig
+    np.testing.assert_allclose(out.sum(axis=1), 1.0)
+
+
+def test_duplicate_action_labels_rejected() -> None:
+    with pytest.raises(DataValidationError, match="unique"):
+        validate_action_distribution(
+            np.array([[0.5, 0.5]]),
+            n_rows=1,
+            actions=("a", "a"),
+        )
+
+
+def test_wrong_shape_rejected() -> None:
+    with pytest.raises(DataValidationError, match="shape"):
+        validate_action_distribution(
+            np.array([[1.0, 0.0, 0.0]]),
+            n_rows=1,
+            actions=("a", "b"),
+        )
+
+
+@pytest.mark.parametrize("bad", [np.nan, np.inf, -np.inf])
+def test_non_finite_probability_rejected(bad: float) -> None:
+    probs = np.array([[1.0, 0.0], [bad, 0.0]])
+    with pytest.raises(DataValidationError, match="finite"):
+        validate_action_distribution(
+            probs,
+            n_rows=2,
+            actions=("a", "b"),
+        )
+
+
+def test_material_negative_probability_rejected() -> None:
+    with pytest.raises(DataValidationError, match="non-negative"):
+        validate_action_distribution(
+            np.array([[1.1, -0.1]]),
+            n_rows=1,
+            actions=("a", "b"),
+        )
+
+
+def test_tiny_float_noise_is_zeroed_but_not_renormalized() -> None:
+    probs = np.array([[1.0 + 1e-12, -1e-12]])
+    out = validate_action_distribution(
+        probs,
+        n_rows=1,
+        actions=("a", "b"),
+        atol=1e-10,
+    )
+    np.testing.assert_array_equal(out, np.array([[1.0 + 1e-12, 0.0]]))
+
+
+def test_non_normalized_row_rejected_instead_of_repaired() -> None:
+    with pytest.raises(DataValidationError, match="sum to 1"):
+        validate_action_distribution(
+            np.array([[0.4, 0.4]]),
+            n_rows=1,
+            actions=("a", "b"),
+        )
+
+
+def test_positive_mass_on_ineligible_action_rejected() -> None:
+    with pytest.raises(DataValidationError, match="ineligible"):
+        validate_action_distribution(
+            np.array([[0.8, 0.2]]),
+            n_rows=1,
+            actions=("a", "b"),
+            eligible_actions=np.array([[1, 0]]),
+        )
+
+
+def test_numeric_zero_one_eligibility_is_accepted() -> None:
+    out = validate_action_distribution(
+        np.array([[1.0, 0.0], [0.0, 1.0]]),
+        n_rows=2,
+        actions=("a", "b"),
+        eligible_actions=np.array([[1, 0], [0, 1]], dtype=np.int64),
+    )
+    np.testing.assert_array_equal(out, np.eye(2))
+
+
+def test_non_binary_eligibility_rejected() -> None:
+    with pytest.raises(DataValidationError, match="0/1"):
+        validate_action_distribution(
+            np.array([[1.0, 0.0]]),
+            n_rows=1,
+            actions=("a", "b"),
+            eligible_actions=np.array([[1.0, 0.5]]),
+        )
+
+
+def test_empty_eligibility_row_fails_closed() -> None:
+    with pytest.raises(DataValidationError, match="at least one eligible"):
+        validate_action_distribution(
+            np.array([[1.0, 0.0]]),
+            n_rows=1,
+            actions=("a", "b"),
+            eligible_actions=np.array([[0, 0]]),
+        )
+
+
+def test_policy_without_action_distribution_rejected() -> None:
+    class NotAPolicy:
+        pass
+
+    with pytest.raises(DataValidationError, match="action_distribution"):
+        resolve_action_distribution(
+            NotAPolicy(),  # type: ignore[arg-type]
+            _contexts(1),
+            actions=("a", "b"),
+        )
+
+
+def test_policy_failure_is_wrapped_as_data_validation_error() -> None:
+    class BrokenPolicy:
+        def action_distribution(
+            self,
+            contexts: np.ndarray,
+            *,
+            actions,
+            eligible_actions=None,
+        ) -> np.ndarray:
+            del contexts, actions, eligible_actions
+            raise RuntimeError("boom")
+
+    with pytest.raises(DataValidationError, match="boom"):
+        resolve_action_distribution(
+            BrokenPolicy(),
+            _contexts(1),
+            actions=("a", "b"),
+        )


### PR DESCRIPTION
## Closed in favor of PR #307

Both branches independently implement the same #279 foundation without changing estimator numerics.

PR #307 is the canonical implementation because it is the stronger public contract:

- explicit runtime-checkable `Policy` protocol;
- fail-closed `validate_action_distribution`;
- `ExplicitPolicy` binds a probability matrix to an immutable action vocabulary/order, preventing silent column reinterpretation;
- backend-neutral context handling;
- one `resolve_action_distribution` seam for future native/reference evaluators;
- dedicated `docs/concepts/policy-contract.md`;
- focused contract tests and changelog fragment;
- currently mergeable against the repository state.

This branch's `CallablePolicy` adapter can be reconsidered later only if real callers need it; it is not worth maintaining a second overlapping public abstraction now.

No work from this PR is required for #279 beyond what #307 already covers.