### PR TITLE
feat: introduce explicit target-policy contract (#279)

### DIFF
--- a/changelog.d/279.added.md
+++ b/changelog.d/279.added.md
@@ -1,0 +1,1 @@
+Add the backend-neutral `skdr_eval.policy` contract for explicit target action distributions, including strict action-order, probability-simplex, row-count, and eligibility validation plus an `ExplicitPolicy` convenience implementation. Estimator wiring remains validation-pending follow-up work under #279/#58.

--- a/docs/concepts/policy-contract.md
+++ b/docs/concepts/policy-contract.md
@@ -1,0 +1,92 @@
+# Explicit target-policy contract
+
+The validated one-step OPE path must evaluate an **explicit decision policy**.
+A prediction model, score, or outcome regressor is not automatically the policy
+that would be run online.
+
+Issue #279 introduces the representation seam before the estimator kernel is
+migrated to consume it.
+
+## Contract
+
+A policy returns an action-probability matrix:
+
+```python
+class Policy(Protocol):
+    def action_distribution(
+        self,
+        contexts,
+        *,
+        actions,
+        eligible_actions=None,
+    ) -> np.ndarray:
+        ...
+```
+
+The matrix has shape `(n_rows, n_actions)` and its columns are in exactly the
+order supplied by `actions`.
+
+Every row must:
+
+- contain finite probabilities;
+- contain no negative probabilities;
+- sum to one;
+- assign zero probability to ineligible actions.
+
+Deterministic policies are ordinary one-hot distributions. They do not use a
+separate estimand.
+
+## Already-computed probabilities
+
+When another model or service has already produced the exact candidate action
+probabilities, bind them to the action vocabulary explicitly:
+
+```python
+from skdr_eval.policy import ExplicitPolicy
+
+candidate = ExplicitPolicy(
+    candidate_probabilities,
+    actions=("control", "offer_a", "offer_b"),
+    name="candidate-v17",
+)
+```
+
+If a later caller requests the same probability matrix under a different action
+ordering, evaluation fails instead of silently reinterpreting the columns.
+
+## One resolver for native and reference backends
+
+```python
+from skdr_eval.policy import resolve_action_distribution
+
+pi = resolve_action_distribution(
+    candidate,
+    contexts,
+    actions=("control", "offer_a", "offer_b"),
+    eligible_actions=eligibility,
+)
+```
+
+Native estimators and estimator-specific reference adapters should resolve the
+policy through this seam rather than independently interpreting model scores.
+This is necessary for meaningful cross-implementation agreement: both sides must
+be evaluating the same target distribution over the same ordered action space.
+
+## What this does not do yet
+
+This contract PR deliberately does **not** change DR/SNDR mathematics and does
+not make the current `evaluate_sklearn_models` path validated. Follow-up work
+must:
+
+1. migrate the standard evaluator to consume an explicit policy or action
+   probability matrix;
+2. deprecate implicit policy induction from arbitrary outcome-model scores in
+   the validated path;
+3. record policy type, action mapping and safe configuration/provenance in the
+   evidence artifact;
+4. use the same resolved distribution in #58 corrected multi-action DR and #281
+   estimator-specific reference agreement.
+
+Until those migrations and the remaining validation gates land, this module is
+the explicit **contract seam**, not evidence that the estimator path is already
+validated.

--- a/src/skdr_eval/policy.py
+++ b/src/skdr_eval/policy.py
@@ -1,0 +1,239 @@
+"""Explicit target-policy contract for one-step offline policy evaluation.
+
+The validated OPE path must evaluate the policy the caller actually intends to
+study, not infer a policy implicitly from arbitrary model scores. This module
+provides the small representation/validation seam tracked by issue #279 without
+changing any estimator mathematics.
+
+The contract is intentionally backend-neutral so native estimators and external
+reference implementations can consume the exact same action distribution.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+import numpy as np
+
+from .exceptions import DataValidationError
+
+
+@runtime_checkable
+class Policy(Protocol):
+    """One-step target policy represented as action probabilities.
+
+    Implementations return a matrix with shape ``(n_rows, n_actions)`` in the
+    exact order supplied by ``actions``. Deterministic policies use one-hot
+    rows; stochastic policies use any valid probability simplex.
+
+    ``eligible_actions`` is an optional boolean matrix with the same shape.
+    Policies must assign zero probability to ineligible actions.
+    """
+
+    def action_distribution(
+        self,
+        contexts: Any,
+        *,
+        actions: list[str] | tuple[str, ...],
+        eligible_actions: np.ndarray | None = None,
+    ) -> np.ndarray: ...
+
+
+def _n_rows(contexts: Any) -> int:
+    """Return a context row count without constraining the frame backend."""
+    try:
+        return len(contexts)
+    except TypeError as exc:  # pragma: no cover - defensive protocol boundary
+        raise DataValidationError("contexts must be a sized row collection") from exc
+
+
+def validate_action_distribution(
+    probabilities: Any,
+    *,
+    actions: list[str] | tuple[str, ...],
+    n_rows: int | None = None,
+    eligible_actions: np.ndarray | None = None,
+    atol: float = 1e-10,
+) -> np.ndarray:
+    """Validate and normalize the representation contract, not the policy itself.
+
+    Parameters
+    ----------
+    probabilities:
+        Candidate ``(n_rows, n_actions)`` probability matrix.
+    actions:
+        Ordered action vocabulary that defines the matrix columns.
+    n_rows:
+        Optional expected row count.
+    eligible_actions:
+        Optional boolean matrix. Ineligible actions must receive probability
+        zero (within ``atol``), and every row must contain at least one eligible
+        action.
+    atol:
+        Absolute tolerance for row normalization and eligibility-zero checks.
+
+    Returns
+    -------
+    np.ndarray
+        A float64 probability matrix after validation. Values are not clipped or
+        renormalized: an invalid target policy fails closed rather than being
+        silently repaired.
+    """
+    action_tuple = tuple(actions)
+    if not action_tuple:
+        raise DataValidationError("actions must contain at least one action")
+    if len(set(action_tuple)) != len(action_tuple):
+        raise DataValidationError("actions must be unique and order-stable")
+    if any(not isinstance(action, str) or not action for action in action_tuple):
+        raise DataValidationError("actions must be non-empty strings")
+
+    try:
+        probs = np.asarray(probabilities, dtype=float)
+    except (TypeError, ValueError) as exc:
+        raise DataValidationError("policy probabilities must be numeric") from exc
+
+    if probs.ndim != 2:
+        raise DataValidationError(
+            "policy probabilities must be a 2D (n_rows, n_actions) matrix"
+        )
+    if probs.shape[1] != len(action_tuple):
+        raise DataValidationError(
+            "policy probability columns do not match the supplied action vocabulary: "
+            f"got {probs.shape[1]} columns for {len(action_tuple)} actions"
+        )
+    if n_rows is not None and probs.shape[0] != n_rows:
+        raise DataValidationError(
+            f"policy probability rows must match contexts: got {probs.shape[0]}, "
+            f"expected {n_rows}"
+        )
+    if not np.all(np.isfinite(probs)):
+        raise DataValidationError("policy probabilities must all be finite")
+    if np.any(probs < -atol):
+        raise DataValidationError("policy probabilities must be non-negative")
+
+    row_sums = probs.sum(axis=1)
+    if not np.allclose(row_sums, 1.0, atol=atol, rtol=0.0):
+        bad = np.flatnonzero(~np.isclose(row_sums, 1.0, atol=atol, rtol=0.0))
+        preview = bad[:5].tolist()
+        raise DataValidationError(
+            "each policy probability row must sum to 1; "
+            f"invalid row indices include {preview}"
+        )
+
+    if eligible_actions is not None:
+        elig = np.asarray(eligible_actions)
+        if elig.shape != probs.shape:
+            raise DataValidationError(
+                "eligible_actions must have the same shape as policy probabilities"
+            )
+        if elig.dtype != np.bool_:
+            # Accept clean 0/1 masks, but reject arbitrary truthy numeric values.
+            if not np.all(np.isin(elig, [0, 1])):
+                raise DataValidationError(
+                    "eligible_actions must be boolean or contain only 0/1 values"
+                )
+            elig = elig.astype(bool)
+        if np.any(elig.sum(axis=1) == 0):
+            raise DataValidationError("every row must have at least one eligible action")
+        if np.any(np.abs(probs[~elig]) > atol):
+            raise DataValidationError(
+                "target policy assigns non-zero probability to an ineligible action"
+            )
+
+    # Avoid propagating harmless negative signed-zero / tiny round-off values
+    # without silently correcting genuinely invalid rows (caught above).
+    result = probs.copy()
+    result[np.abs(result) <= atol] = 0.0
+    return result
+
+
+@dataclass(frozen=True)
+class ExplicitPolicy:
+    """An explicit target policy backed by a fixed probability matrix.
+
+    This class is primarily useful when candidate action probabilities have
+    already been computed by another model/service. It binds the probability
+    columns to an explicit action vocabulary so action reordering cannot be
+    silently accepted.
+    """
+
+    probabilities: np.ndarray
+    actions: tuple[str, ...]
+    name: str | None = None
+
+    def __init__(
+        self,
+        probabilities: Any,
+        *,
+        actions: list[str] | tuple[str, ...],
+        name: str | None = None,
+    ) -> None:
+        action_tuple = tuple(actions)
+        validated = validate_action_distribution(probabilities, actions=action_tuple)
+        object.__setattr__(self, "probabilities", validated)
+        object.__setattr__(self, "actions", action_tuple)
+        object.__setattr__(self, "name", name)
+
+    def action_distribution(
+        self,
+        contexts: Any,
+        *,
+        actions: list[str] | tuple[str, ...],
+        eligible_actions: np.ndarray | None = None,
+    ) -> np.ndarray:
+        requested = tuple(actions)
+        if requested != self.actions:
+            raise DataValidationError(
+                "requested action vocabulary/order does not match ExplicitPolicy: "
+                f"expected {self.actions!r}, got {requested!r}"
+            )
+        return validate_action_distribution(
+            self.probabilities,
+            actions=requested,
+            n_rows=_n_rows(contexts),
+            eligible_actions=eligible_actions,
+        )
+
+
+def resolve_action_distribution(
+    policy: Policy | np.ndarray,
+    contexts: Any,
+    *,
+    actions: list[str] | tuple[str, ...],
+    eligible_actions: np.ndarray | None = None,
+) -> np.ndarray:
+    """Resolve a Policy object or explicit matrix through one validation seam.
+
+    Future native/reference evaluators should call this helper rather than
+    interpreting model scores independently. Passing a raw matrix is supported
+    as a convenience but receives the same validation as a ``Policy`` object.
+    """
+    n_rows = _n_rows(contexts)
+    if isinstance(policy, np.ndarray):
+        return validate_action_distribution(
+            policy,
+            actions=actions,
+            n_rows=n_rows,
+            eligible_actions=eligible_actions,
+        )
+
+    action_distribution = getattr(policy, "action_distribution", None)
+    if action_distribution is None or not callable(action_distribution):
+        raise DataValidationError(
+            "policy must implement action_distribution(...) or be a numpy matrix"
+        )
+    probabilities = action_distribution(
+        contexts,
+        actions=actions,
+        eligible_actions=eligible_actions,
+    )
+    return validate_action_distribution(
+        probabilities,
+        actions=actions,
+        n_rows=n_rows,
+        eligible_actions=eligible_actions,
+    )
+
+
+__all__ = ["ExplicitPolicy", "Policy", "resolve_action_distribution", "validate_action_distribution"]

--- a/src/skdr_eval/policy.py
+++ b/src/skdr_eval/policy.py
@@ -56,7 +56,7 @@ def validate_action_distribution(
     eligible_actions: np.ndarray | None = None,
     atol: float = 1e-10,
 ) -> np.ndarray:
-    """Validate and normalize the representation contract, not the policy itself.
+    """Validate the target-policy representation without silently repairing it.
 
     Parameters
     ----------
@@ -155,7 +155,8 @@ class ExplicitPolicy:
     This class is primarily useful when candidate action probabilities have
     already been computed by another model/service. It binds the probability
     columns to an explicit action vocabulary so action reordering cannot be
-    silently accepted.
+    silently accepted. The stored probability matrix is copied and marked
+    read-only so policy state cannot change after construction.
     """
 
     probabilities: np.ndarray
@@ -171,6 +172,7 @@ class ExplicitPolicy:
     ) -> None:
         action_tuple = tuple(actions)
         validated = validate_action_distribution(probabilities, actions=action_tuple)
+        validated.setflags(write=False)
         object.__setattr__(self, "probabilities", validated)
         object.__setattr__(self, "actions", action_tuple)
         object.__setattr__(self, "name", name)
@@ -236,4 +238,9 @@ def resolve_action_distribution(
     )
 
 
-__all__ = ["ExplicitPolicy", "Policy", "resolve_action_distribution", "validate_action_distribution"]
+__all__ = [
+    "ExplicitPolicy",
+    "Policy",
+    "resolve_action_distribution",
+    "validate_action_distribution",
+]

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -27,6 +27,29 @@ def test_explicit_policy_satisfies_protocol_and_preserves_distribution():
     assert policy.name == "candidate-v1"
 
 
+def test_explicit_policy_probability_state_is_read_only():
+    source = np.array([[0.2, 0.8]])
+    policy = ExplicitPolicy(source, actions=("control", "candidate"))
+
+    # Construction copies the caller's array, so mutating the source cannot
+    # change the policy that was bound to this action vocabulary.
+    source[0, 0] = 1.0
+    np.testing.assert_allclose(policy.probabilities, [[0.2, 0.8]])
+    assert policy.probabilities.flags.writeable is False
+
+    with pytest.raises(ValueError):
+        policy.probabilities[0, 0] = 1.0
+
+    # Resolved output is a fresh validated copy; callers may manipulate their
+    # local result without mutating the immutable policy state.
+    resolved = policy.action_distribution(
+        np.zeros((1, 1)), actions=("control", "candidate")
+    )
+    assert resolved.flags.writeable is True
+    resolved[0, 0] = 0.3
+    np.testing.assert_allclose(policy.probabilities, [[0.2, 0.8]])
+
+
 def test_deterministic_one_hot_is_same_contract_as_stochastic_policy():
     deterministic = np.array([[0.0, 1.0], [1.0, 0.0]])
     resolved = validate_action_distribution(deterministic, actions=("left", "right"))
@@ -110,9 +133,7 @@ def test_malformed_eligibility_values_fail():
 def test_resolver_accepts_raw_numpy_matrix_through_same_validation():
     contexts = np.zeros((2, 4))
     probs = np.array([[0.7, 0.3], [0.1, 0.9]])
-    resolved = resolve_action_distribution(
-        probs, contexts, actions=("a", "b")
-    )
+    resolved = resolve_action_distribution(probs, contexts, actions=("a", "b"))
     np.testing.assert_allclose(resolved, probs)
 
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,148 @@
+"""Contract tests for explicit target-policy action distributions (#279)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from skdr_eval.exceptions import DataValidationError
+from skdr_eval.policy import (
+    ExplicitPolicy,
+    Policy,
+    resolve_action_distribution,
+    validate_action_distribution,
+)
+
+
+ACTIONS = ("a", "b", "c")
+
+
+def test_explicit_policy_satisfies_protocol_and_preserves_distribution():
+    probs = np.array([[1.0, 0.0, 0.0], [0.1, 0.2, 0.7]])
+    policy = ExplicitPolicy(probs, actions=ACTIONS, name="candidate-v1")
+
+    assert isinstance(policy, Policy)
+    resolved = policy.action_distribution(np.zeros((2, 4)), actions=ACTIONS)
+    np.testing.assert_allclose(resolved, probs)
+    assert policy.name == "candidate-v1"
+
+
+def test_deterministic_one_hot_is_same_contract_as_stochastic_policy():
+    deterministic = np.array([[0.0, 1.0], [1.0, 0.0]])
+    resolved = validate_action_distribution(deterministic, actions=("left", "right"))
+    np.testing.assert_array_equal(resolved, deterministic)
+
+
+def test_reordered_actions_fail_closed():
+    policy = ExplicitPolicy([[0.2, 0.8]], actions=("control", "candidate"))
+    with pytest.raises(DataValidationError, match="vocabulary/order"):
+        policy.action_distribution(
+            np.zeros((1, 2)), actions=("candidate", "control")
+        )
+
+
+@pytest.mark.parametrize(
+    ("probabilities", "message"),
+    [
+        ([0.5, 0.5], "2D"),
+        ([[0.5, 0.5, 0.0]], "columns"),
+        ([[0.5, np.nan]], "finite"),
+        ([[-0.1, 1.1]], "non-negative"),
+        ([[0.4, 0.4]], "sum to 1"),
+    ],
+)
+def test_invalid_probability_matrices_fail(probabilities, message):
+    with pytest.raises(DataValidationError, match=message):
+        validate_action_distribution(probabilities, actions=("a", "b"))
+
+
+def test_action_vocabulary_must_be_non_empty_unique_strings():
+    with pytest.raises(DataValidationError, match="at least one"):
+        validate_action_distribution(np.empty((1, 0)), actions=())
+    with pytest.raises(DataValidationError, match="unique"):
+        validate_action_distribution([[0.5, 0.5]], actions=("a", "a"))
+    with pytest.raises(DataValidationError, match="non-empty strings"):
+        validate_action_distribution([[1.0]], actions=("",))
+
+
+def test_context_row_count_must_match_probability_rows():
+    policy = ExplicitPolicy([[0.5, 0.5], [0.2, 0.8]], actions=("a", "b"))
+    with pytest.raises(DataValidationError, match="rows must match contexts"):
+        policy.action_distribution(np.zeros((3, 2)), actions=("a", "b"))
+
+
+def test_ineligible_actions_must_receive_zero_probability():
+    probs = np.array([[0.8, 0.2], [0.0, 1.0]])
+    eligibility = np.array([[1, 0], [0, 1]])
+    with pytest.raises(DataValidationError, match="ineligible action"):
+        validate_action_distribution(
+            probs, actions=("a", "b"), eligible_actions=eligibility
+        )
+
+
+def test_valid_variable_eligibility_is_preserved():
+    probs = np.array([[1.0, 0.0, 0.0], [0.0, 0.25, 0.75]])
+    eligibility = np.array([[True, False, False], [False, True, True]])
+    resolved = validate_action_distribution(
+        probs, actions=ACTIONS, eligible_actions=eligibility
+    )
+    np.testing.assert_array_equal(resolved, probs)
+
+
+def test_rows_with_no_eligible_actions_fail():
+    with pytest.raises(DataValidationError, match="at least one eligible"):
+        validate_action_distribution(
+            [[1.0, 0.0]],
+            actions=("a", "b"),
+            eligible_actions=np.array([[0, 0]]),
+        )
+
+
+def test_malformed_eligibility_values_fail():
+    with pytest.raises(DataValidationError, match="boolean or contain only 0/1"):
+        validate_action_distribution(
+            [[0.5, 0.5]],
+            actions=("a", "b"),
+            eligible_actions=np.array([[1, 2]]),
+        )
+
+
+def test_resolver_accepts_raw_numpy_matrix_through_same_validation():
+    contexts = np.zeros((2, 4))
+    probs = np.array([[0.7, 0.3], [0.1, 0.9]])
+    resolved = resolve_action_distribution(
+        probs, contexts, actions=("a", "b")
+    )
+    np.testing.assert_allclose(resolved, probs)
+
+
+def test_resolver_accepts_custom_policy_and_revalidates_output():
+    class CustomPolicy:
+        def action_distribution(self, contexts, *, actions, eligible_actions=None):
+            del actions, eligible_actions
+            return np.tile([0.25, 0.75], (len(contexts), 1))
+
+    resolved = resolve_action_distribution(
+        CustomPolicy(), np.zeros((3, 1)), actions=("a", "b")
+    )
+    np.testing.assert_allclose(resolved, np.tile([0.25, 0.75], (3, 1)))
+
+
+def test_resolver_rejects_object_without_policy_contract():
+    with pytest.raises(DataValidationError, match="must implement action_distribution"):
+        resolve_action_distribution(object(), np.zeros((1, 1)), actions=("a", "b"))
+
+
+def test_policy_output_cannot_bypass_eligibility_validation():
+    class BadPolicy:
+        def action_distribution(self, contexts, *, actions, eligible_actions=None):
+            del contexts, actions, eligible_actions
+            return np.array([[0.5, 0.5]])
+
+    with pytest.raises(DataValidationError, match="ineligible action"):
+        resolve_action_distribution(
+            BadPolicy(),
+            np.zeros((1, 1)),
+            actions=("a", "b"),
+            eligible_actions=np.array([[True, False]]),
+        )


### PR DESCRIPTION
## Why

The validated one-step OPE path must evaluate the policy the caller actually intends to study. A prediction model or score is not automatically a decision policy, and native/reference backends must not independently reinterpret model outputs.

This PR establishes the #279 representation/validation seam **without changing estimator mathematics yet**.

## What changes

- adds `skdr_eval.policy.Policy`, a runtime-checkable protocol whose `action_distribution(...)` returns `(n_rows, n_actions)` probabilities in an explicit action order;
- adds `validate_action_distribution(...)` with fail-closed checks for dimensions, row count, finite/non-negative values, row normalization, action vocabulary uniqueness, and eligibility;
- adds `ExplicitPolicy` for already-computed candidate probability matrices, binding columns to an immutable ordered action vocabulary;
- adds `resolve_action_distribution(...)` so future native and reference evaluators can consume policy objects or explicit matrices through one semantic seam;
- deterministic policies use the same one-hot probability contract as stochastic policies;
- adds contract tests covering reordered actions, malformed distributions, row mismatch, variable eligibility, custom policies, and attempts to bypass validation;
- adds `docs/concepts/policy-contract.md` and a changelog fragment.

## Deliberate sequencing

This PR does **not** yet wire the contract into `evaluate_sklearn_models`, change DR/SNDR contributions, or claim a validated estimator path. That migration should be reviewed separately so #58 can correct `q_obs`/`q_pi` against this explicit target distribution and #281 can guarantee that native/reference backends evaluate exactly the same policy.

## Statistical change?

No estimator formula or numerical default changes in this PR. This is a representation and validation contract that future statistical changes will depend on.

Partially addresses #279; follow-up evaluator/provenance migration remains required.