### PR TITLE
feat: add logged behavior propensity contract (#167)

### DIFF
--- a/changelog.d/167.added.md
+++ b/changelog.d/167.added.md
@@ -1,0 +1,1 @@
+Added a fail-closed `LoggedActionPropensity` contract for the behavior policy's recorded probability of the observed action, with provenance metadata and exact observed-action importance-ratio support. The existing evaluator is not yet migrated to consume this contract, so #167 remains open until end-to-end integration.

--- a/src/skdr_eval/propensity_contract.py
+++ b/src/skdr_eval/propensity_contract.py
@@ -1,0 +1,169 @@
+"""Behavior-propensity contracts for the validated one-step OPE path.
+
+The first validated-v1 path requires the probability of the *observed action*
+to have been recorded by the logging policy at decision time (#167 / #297).
+This module deliberately models that quantity as a one-dimensional vector
+rather than fabricating a dense behavior-policy matrix that the logs may never
+have contained.
+
+Estimated behavior propensities remain a separate, validation-pending workflow.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+from .exceptions import DataValidationError
+
+
+@dataclass(frozen=True)
+class LoggedActionPropensity:
+    """Validated logged probability of the observed action.
+
+    Parameters
+    ----------
+    values:
+        Probability assigned by the behavior/logging policy to the action that
+        was actually taken on each row. Shape ``(n_rows,)`` with values in
+        ``(0, 1]``.
+    source:
+        Provenance category. ``"logged"`` means captured at decision time and
+        is the only source eligible for the initial validated-v1 path.
+    field_name:
+        Optional column/input identifier such as ``"propensity"``. This is
+        metadata only; raw data are not stored here.
+    policy_id:
+        Optional safe identifier for the logging-policy version/configuration.
+    """
+
+    values: np.ndarray
+    source: Literal["logged"] = "logged"
+    field_name: str | None = None
+    policy_id: str | None = None
+
+    @property
+    def n_rows(self) -> int:
+        return int(self.values.shape[0])
+
+
+def validate_logged_action_propensity(
+    values: np.ndarray,
+    *,
+    n_rows: int | None = None,
+    field_name: str | None = None,
+    policy_id: str | None = None,
+) -> LoggedActionPropensity:
+    """Validate logged probabilities for the observed actions.
+
+    This function performs **no clipping, filling, smoothing, estimation, or
+    renormalization**. Missing or invalid behavior probabilities are a data
+    contract failure for the validated path.
+
+    Parameters
+    ----------
+    values:
+        One probability per evaluated decision: ``P_behavior(A_i | X_i)``.
+    n_rows:
+        Optional expected row count. When supplied, shape must be exactly
+        ``(n_rows,)``.
+    field_name:
+        Optional source column/input name for provenance.
+    policy_id:
+        Optional safe logging-policy version identifier.
+
+    Returns
+    -------
+    LoggedActionPropensity
+        Immutable validated propensity object.
+
+    Raises
+    ------
+    DataValidationError
+        If dimensionality, row count, finiteness, missingness, or probability
+        bounds violate the logged-propensity contract.
+    """
+
+    if n_rows is not None and (not isinstance(n_rows, int) or n_rows < 0):
+        raise DataValidationError(
+            f"n_rows must be a non-negative integer or None; got {n_rows!r}"
+        )
+
+    arr = np.asarray(values, dtype=np.float64)
+    if arr.ndim != 1:
+        raise DataValidationError(
+            "logged action propensity must be a one-dimensional vector with "
+            f"one value per decision; got shape {arr.shape}"
+        )
+    if n_rows is not None and arr.shape != (n_rows,):
+        raise DataValidationError(
+            f"logged action propensity must have shape ({n_rows},); got {arr.shape}"
+        )
+
+    if not np.all(np.isfinite(arr)):
+        bad = int(np.flatnonzero(~np.isfinite(arr))[0])
+        raise DataValidationError(
+            "logged action propensity must contain only finite values; "
+            f"first invalid row is {bad}"
+        )
+
+    invalid = np.flatnonzero((arr <= 0.0) | (arr > 1.0))
+    if invalid.size:
+        row = int(invalid[0])
+        raise DataValidationError(
+            "logged action propensity must lie in (0, 1] for every evaluated "
+            f"decision; row {row} has {float(arr[row])}"
+        )
+
+    if field_name is not None and not str(field_name).strip():
+        raise DataValidationError("field_name must be non-empty when supplied")
+    if policy_id is not None and not str(policy_id).strip():
+        raise DataValidationError("policy_id must be non-empty when supplied")
+
+    # Copy so caller mutation cannot change an already-validated contract.
+    stable = arr.copy()
+    stable.setflags(write=False)
+    return LoggedActionPropensity(
+        values=stable,
+        field_name=None if field_name is None else str(field_name),
+        policy_id=None if policy_id is None else str(policy_id),
+    )
+
+
+def observed_importance_ratio(
+    target_action_probability: np.ndarray,
+    behavior: LoggedActionPropensity,
+) -> np.ndarray:
+    """Compute the unclipped observed-action ratio ``pi(A|x) / e(A|x)``.
+
+    This small helper makes the validated quantity explicit without requiring a
+    dense behavior-policy matrix. Target probabilities are still validated at
+    the policy boundary (#279); here we only enforce row alignment and finite
+    ``[0, 1]`` values defensively.
+    """
+
+    target = np.asarray(target_action_probability, dtype=np.float64)
+    if target.shape != behavior.values.shape:
+        raise DataValidationError(
+            "target observed-action probabilities and logged behavior "
+            f"propensities must have identical shape; got {target.shape} and "
+            f"{behavior.values.shape}"
+        )
+    if not np.all(np.isfinite(target)):
+        raise DataValidationError(
+            "target observed-action probabilities must be finite"
+        )
+    if np.any((target < 0.0) | (target > 1.0)):
+        raise DataValidationError(
+            "target observed-action probabilities must lie in [0, 1]"
+        )
+    return target / behavior.values
+
+
+__all__ = [
+    "LoggedActionPropensity",
+    "observed_importance_ratio",
+    "validate_logged_action_propensity",
+]

--- a/src/skdr_eval/propensity_contract.py
+++ b/src/skdr_eval/propensity_contract.py
@@ -12,7 +12,7 @@ Estimated behavior propensities remain a separate, validation-pending workflow.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 import numpy as np
 
@@ -26,21 +26,6 @@ class LoggedActionPropensity:
     Construction itself is fail-closed: callers cannot bypass validation by
     instantiating this dataclass directly instead of using
     :func:`validate_logged_action_propensity`.
-
-    Parameters
-    ----------
-    values:
-        Probability assigned by the behavior/logging policy to the action that
-        was actually taken on each row. Shape ``(n_rows,)`` with values in
-        ``(0, 1]``.
-    source:
-        Provenance category. Only ``"logged"`` is accepted by this class. An
-        estimated propensity needs a separate contract and validation status.
-    field_name:
-        Optional column/input identifier such as ``"propensity"``. This is
-        metadata only; raw data are not stored here.
-    policy_id:
-        Optional safe identifier for the logging-policy version/configuration.
     """
 
     values: np.ndarray
@@ -92,7 +77,6 @@ class LoggedActionPropensity:
             if not policy_id:
                 raise DataValidationError("policy_id must be non-empty when supplied")
 
-        # Copy so caller mutation cannot alter an already-validated contract.
         stable = arr.copy()
         stable.setflags(write=False)
         object.__setattr__(self, "values", stable)
@@ -105,7 +89,7 @@ class LoggedActionPropensity:
 
 
 def validate_logged_action_propensity(
-    values: np.ndarray,
+    values: Any,
     *,
     n_rows: int | None = None,
     field_name: str | None = None,
@@ -123,8 +107,11 @@ def validate_logged_action_propensity(
             f"n_rows must be a non-negative integer or None; got {n_rows!r}"
         )
 
+    # Let the self-validating value object perform numeric coercion so malformed
+    # ragged/non-numeric inputs always surface as DataValidationError rather
+    # than leaking a raw numpy ValueError from this convenience wrapper.
     result = LoggedActionPropensity(
-        values=np.asarray(values),
+        values=values,
         field_name=field_name,
         policy_id=policy_id,
     )
@@ -137,18 +124,18 @@ def validate_logged_action_propensity(
 
 
 def observed_importance_ratio(
-    target_action_probability: np.ndarray,
+    target_action_probability: Any,
     behavior: LoggedActionPropensity,
 ) -> np.ndarray:
-    """Compute the unclipped observed-action ratio ``pi(A|x) / e(A|x)``.
+    """Compute the unclipped observed-action ratio ``pi(A|x) / e(A|x)``."""
 
-    This small helper makes the validated quantity explicit without requiring a
-    dense behavior-policy matrix. Target probabilities are still validated at
-    the policy boundary (#279); here we only enforce row alignment and finite
-    ``[0, 1]`` values defensively.
-    """
+    try:
+        target = np.asarray(target_action_probability, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        raise DataValidationError(
+            "target observed-action probabilities must be numeric"
+        ) from exc
 
-    target = np.asarray(target_action_probability, dtype=np.float64)
     if target.shape != behavior.values.shape:
         raise DataValidationError(
             "target observed-action probabilities and logged behavior "

--- a/src/skdr_eval/propensity_contract.py
+++ b/src/skdr_eval/propensity_contract.py
@@ -23,6 +23,10 @@ from .exceptions import DataValidationError
 class LoggedActionPropensity:
     """Validated logged probability of the observed action.
 
+    Construction itself is fail-closed: callers cannot bypass validation by
+    instantiating this dataclass directly instead of using
+    :func:`validate_logged_action_propensity`.
+
     Parameters
     ----------
     values:
@@ -30,8 +34,8 @@ class LoggedActionPropensity:
         was actually taken on each row. Shape ``(n_rows,)`` with values in
         ``(0, 1]``.
     source:
-        Provenance category. ``"logged"`` means captured at decision time and
-        is the only source eligible for the initial validated-v1 path.
+        Provenance category. Only ``"logged"`` is accepted by this class. An
+        estimated propensity needs a separate contract and validation status.
     field_name:
         Optional column/input identifier such as ``"propensity"``. This is
         metadata only; raw data are not stored here.
@@ -43,6 +47,57 @@ class LoggedActionPropensity:
     source: Literal["logged"] = "logged"
     field_name: str | None = None
     policy_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.source != "logged":
+            raise DataValidationError(
+                "LoggedActionPropensity.source must be exactly 'logged'; "
+                "estimated propensities require a separate contract"
+            )
+
+        try:
+            arr = np.asarray(self.values, dtype=np.float64)
+        except (TypeError, ValueError) as exc:
+            raise DataValidationError(
+                "logged action propensity must be numeric"
+            ) from exc
+
+        if arr.ndim != 1:
+            raise DataValidationError(
+                "logged action propensity must be a one-dimensional vector with "
+                f"one value per decision; got shape {arr.shape}"
+            )
+        if not np.all(np.isfinite(arr)):
+            bad = int(np.flatnonzero(~np.isfinite(arr))[0])
+            raise DataValidationError(
+                "logged action propensity must contain only finite values; "
+                f"first invalid row is {bad}"
+            )
+        invalid = np.flatnonzero((arr <= 0.0) | (arr > 1.0))
+        if invalid.size:
+            row = int(invalid[0])
+            raise DataValidationError(
+                "logged action propensity must lie in (0, 1] for every evaluated "
+                f"decision; row {row} has {float(arr[row])}"
+            )
+
+        field_name = self.field_name
+        policy_id = self.policy_id
+        if field_name is not None:
+            field_name = str(field_name).strip()
+            if not field_name:
+                raise DataValidationError("field_name must be non-empty when supplied")
+        if policy_id is not None:
+            policy_id = str(policy_id).strip()
+            if not policy_id:
+                raise DataValidationError("policy_id must be non-empty when supplied")
+
+        # Copy so caller mutation cannot alter an already-validated contract.
+        stable = arr.copy()
+        stable.setflags(write=False)
+        object.__setattr__(self, "values", stable)
+        object.__setattr__(self, "field_name", field_name)
+        object.__setattr__(self, "policy_id", policy_id)
 
     @property
     def n_rows(self) -> int:
@@ -61,29 +116,6 @@ def validate_logged_action_propensity(
     This function performs **no clipping, filling, smoothing, estimation, or
     renormalization**. Missing or invalid behavior probabilities are a data
     contract failure for the validated path.
-
-    Parameters
-    ----------
-    values:
-        One probability per evaluated decision: ``P_behavior(A_i | X_i)``.
-    n_rows:
-        Optional expected row count. When supplied, shape must be exactly
-        ``(n_rows,)``.
-    field_name:
-        Optional source column/input name for provenance.
-    policy_id:
-        Optional safe logging-policy version identifier.
-
-    Returns
-    -------
-    LoggedActionPropensity
-        Immutable validated propensity object.
-
-    Raises
-    ------
-    DataValidationError
-        If dimensionality, row count, finiteness, missingness, or probability
-        bounds violate the logged-propensity contract.
     """
 
     if n_rows is not None and (not isinstance(n_rows, int) or n_rows < 0):
@@ -91,45 +123,17 @@ def validate_logged_action_propensity(
             f"n_rows must be a non-negative integer or None; got {n_rows!r}"
         )
 
-    arr = np.asarray(values, dtype=np.float64)
-    if arr.ndim != 1:
-        raise DataValidationError(
-            "logged action propensity must be a one-dimensional vector with "
-            f"one value per decision; got shape {arr.shape}"
-        )
-    if n_rows is not None and arr.shape != (n_rows,):
-        raise DataValidationError(
-            f"logged action propensity must have shape ({n_rows},); got {arr.shape}"
-        )
-
-    if not np.all(np.isfinite(arr)):
-        bad = int(np.flatnonzero(~np.isfinite(arr))[0])
-        raise DataValidationError(
-            "logged action propensity must contain only finite values; "
-            f"first invalid row is {bad}"
-        )
-
-    invalid = np.flatnonzero((arr <= 0.0) | (arr > 1.0))
-    if invalid.size:
-        row = int(invalid[0])
-        raise DataValidationError(
-            "logged action propensity must lie in (0, 1] for every evaluated "
-            f"decision; row {row} has {float(arr[row])}"
-        )
-
-    if field_name is not None and not str(field_name).strip():
-        raise DataValidationError("field_name must be non-empty when supplied")
-    if policy_id is not None and not str(policy_id).strip():
-        raise DataValidationError("policy_id must be non-empty when supplied")
-
-    # Copy so caller mutation cannot change an already-validated contract.
-    stable = arr.copy()
-    stable.setflags(write=False)
-    return LoggedActionPropensity(
-        values=stable,
-        field_name=None if field_name is None else str(field_name),
-        policy_id=None if policy_id is None else str(policy_id),
+    result = LoggedActionPropensity(
+        values=np.asarray(values),
+        field_name=field_name,
+        policy_id=policy_id,
     )
+    if n_rows is not None and result.values.shape != (n_rows,):
+        raise DataValidationError(
+            f"logged action propensity must have shape ({n_rows},); "
+            f"got {result.values.shape}"
+        )
+    return result
 
 
 def observed_importance_ratio(

--- a/tests/test_logged_propensity_contract.py
+++ b/tests/test_logged_propensity_contract.py
@@ -71,6 +71,13 @@ def test_non_finite_values_fail_closed(bad: float) -> None:
         validate_logged_action_propensity(np.array([0.5, bad]))
 
 
+def test_malformed_or_non_numeric_propensity_is_data_validation_error() -> None:
+    with pytest.raises(DataValidationError, match="numeric"):
+        validate_logged_action_propensity([[0.5], [0.2, 0.8]])
+    with pytest.raises(DataValidationError, match="numeric"):
+        validate_logged_action_propensity([0.5, "not-a-number"])
+
+
 def test_dense_matrix_is_rejected_instead_of_reinterpreted() -> None:
     with pytest.raises(DataValidationError, match="one-dimensional"):
         validate_logged_action_propensity(np.array([[0.4, 0.6], [0.7, 0.3]]))
@@ -99,6 +106,12 @@ def test_importance_ratio_requires_row_alignment() -> None:
     behavior = validate_logged_action_propensity(np.array([0.5, 0.5]))
     with pytest.raises(DataValidationError, match="identical shape"):
         observed_importance_ratio(np.array([0.5]), behavior)
+
+
+def test_importance_ratio_normalizes_non_numeric_errors() -> None:
+    behavior = validate_logged_action_propensity(np.array([0.5, 0.5]))
+    with pytest.raises(DataValidationError, match="numeric"):
+        observed_importance_ratio(["bad", "input"], behavior)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_logged_propensity_contract.py
+++ b/tests/test_logged_propensity_contract.py
@@ -1,0 +1,96 @@
+"""Tests for the validated logged-behavior-propensity contract (#167)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from skdr_eval.exceptions import DataValidationError
+from skdr_eval.propensity_contract import (
+    LoggedActionPropensity,
+    observed_importance_ratio,
+    validate_logged_action_propensity,
+)
+
+
+def test_valid_logged_propensity_records_provenance() -> None:
+    raw = np.array([0.2, 0.5, 1.0])
+    result = validate_logged_action_propensity(
+        raw,
+        n_rows=3,
+        field_name="propensity",
+        policy_id="epsilon-greedy-v7",
+    )
+    assert isinstance(result, LoggedActionPropensity)
+    assert result.source == "logged"
+    assert result.field_name == "propensity"
+    assert result.policy_id == "epsilon-greedy-v7"
+    np.testing.assert_array_equal(result.values, raw)
+    assert result.n_rows == 3
+
+
+def test_validated_values_are_immutable_copy() -> None:
+    raw = np.array([0.25, 0.75])
+    result = validate_logged_action_propensity(raw)
+    raw[0] = 0.9
+    assert result.values[0] == 0.25
+    with pytest.raises(ValueError):
+        result.values[0] = 0.3
+
+
+@pytest.mark.parametrize("bad", [0.0, -0.1, 1.000001])
+def test_probability_bounds_fail_closed(bad: float) -> None:
+    with pytest.raises(DataValidationError, match=r"\(0, 1\]"):
+        validate_logged_action_propensity(np.array([0.5, bad]))
+
+
+@pytest.mark.parametrize("bad", [np.nan, np.inf, -np.inf])
+def test_non_finite_values_fail_closed(bad: float) -> None:
+    with pytest.raises(DataValidationError, match="finite"):
+        validate_logged_action_propensity(np.array([0.5, bad]))
+
+
+def test_dense_matrix_is_rejected_instead_of_reinterpreted() -> None:
+    with pytest.raises(DataValidationError, match="one-dimensional"):
+        validate_logged_action_propensity(np.array([[0.4, 0.6], [0.7, 0.3]]))
+
+
+def test_expected_row_count_is_enforced() -> None:
+    with pytest.raises(DataValidationError, match="shape"):
+        validate_logged_action_propensity(np.array([0.5, 0.5]), n_rows=3)
+
+
+def test_blank_provenance_fields_are_rejected() -> None:
+    with pytest.raises(DataValidationError, match="field_name"):
+        validate_logged_action_propensity(np.array([0.5]), field_name="   ")
+    with pytest.raises(DataValidationError, match="policy_id"):
+        validate_logged_action_propensity(np.array([0.5]), policy_id="")
+
+
+def test_observed_importance_ratio_uses_exact_logged_probability() -> None:
+    behavior = validate_logged_action_propensity(np.array([0.25, 0.5, 1.0]))
+    target = np.array([0.5, 0.25, 0.0])
+    ratio = observed_importance_ratio(target, behavior)
+    np.testing.assert_allclose(ratio, np.array([2.0, 0.5, 0.0]))
+
+
+def test_importance_ratio_requires_row_alignment() -> None:
+    behavior = validate_logged_action_propensity(np.array([0.5, 0.5]))
+    with pytest.raises(DataValidationError, match="identical shape"):
+        observed_importance_ratio(np.array([0.5]), behavior)
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        np.array([np.nan, 0.5]),
+        np.array([-0.1, 0.5]),
+        np.array([1.1, 0.5]),
+    ],
+)
+def test_importance_ratio_defensively_validates_target_probability(
+    target: np.ndarray,
+) -> None:
+    behavior = validate_logged_action_propensity(np.array([0.5, 0.5]))
+    with pytest.raises(DataValidationError):
+        observed_importance_ratio(target, behavior)

--- a/tests/test_logged_propensity_contract.py
+++ b/tests/test_logged_propensity_contract.py
@@ -29,6 +29,27 @@ def test_valid_logged_propensity_records_provenance() -> None:
     assert result.n_rows == 3
 
 
+def test_direct_construction_enforces_the_same_contract() -> None:
+    direct = LoggedActionPropensity(
+        values=np.array([0.25, 0.75]),
+        field_name=" propensity ",
+        policy_id=" logger-v1 ",
+    )
+    np.testing.assert_array_equal(direct.values, np.array([0.25, 0.75]))
+    assert direct.field_name == "propensity"
+    assert direct.policy_id == "logger-v1"
+
+    with pytest.raises(DataValidationError, match=r"\(0, 1\]"):
+        LoggedActionPropensity(values=np.array([0.0]))
+    with pytest.raises(DataValidationError, match="finite"):
+        LoggedActionPropensity(values=np.array([np.nan]))
+    with pytest.raises(DataValidationError, match="source"):
+        LoggedActionPropensity(
+            values=np.array([0.5]),
+            source="estimated",  # type: ignore[arg-type]
+        )
+
+
 def test_validated_values_are_immutable_copy() -> None:
     raw = np.array([0.25, 0.75])
     result = validate_logged_action_propensity(raw)


### PR DESCRIPTION
## What

Adds the validated-v1 behavior-propensity seam without changing current evaluator numerics:

- `LoggedActionPropensity` models the probability the logging policy assigned to the **observed** action on each row;
- `validate_logged_action_propensity(...)` requires exact 1-D row alignment, finite values in `(0, 1]`, and optional safe provenance (`field_name`, `policy_id`);
- validation performs no clipping, filling, smoothing, estimation or renormalization;
- validated values are copied and made read-only so caller mutation cannot alter an already-validated contract;
- `observed_importance_ratio(...)` computes `pi(A|x) / e(A|x)` directly from the target observed-action probability and the exact logged behavior probability—without fabricating a dense behavior-policy matrix.

Tests cover valid provenance, immutability, shape/bounds/finiteness failures, and exact observed-action importance ratios.

## Why this representation

The first validated path requires the probability actually logged at decision time. The logs generally contain `P_behavior(A_i | X_i)`, not a full counterfactual probability vector over every action. Representing the observed-action probability directly avoids turning unavailable behavior-policy information into invented data.

## Why #167 remains open

This PR establishes the contract only. `evaluate_sklearn_models` still estimates propensities internally and has not yet been migrated to consume this object or record it in the evidence artifact. End-to-end integration is intentionally coordinated with #279, #280 and #58.

## Statistical behavior

None on existing APIs; this new module is not yet consumed by an evaluator.