### PR TITLE
[Superseded by #318] fix: add action-specific q_obs/q_pi estimand contract

### DIFF
--- a/changelog.d/58.fixed.md
+++ b/changelog.d/58.fixed.md
@@ -1,0 +1,1 @@
+Added an explicit multi-action outcome-value contract requiring `q_hat(x,a)` as an `(n_rows, n_actions)` matrix and computing distinct `q_obs` and `q_pi` terms without silent 1-D broadcasting. The existing DR kernel is not yet migrated to consume this helper, so #58 remains open until end-to-end correction and validation.

--- a/src/skdr_eval/estimand.py
+++ b/src/skdr_eval/estimand.py
@@ -1,0 +1,190 @@
+"""Validated multi-action outcome/estimand helpers for one-step DR OPE.
+
+The validated multi-action DR estimand requires two distinct quantities (#58):
+
+``q_obs[i] = q_hat(x_i, a_i)``
+    Outcome-model prediction for the action actually observed in the log.
+
+``q_pi[i] = sum_a pi(a | x_i) * q_hat(x_i, a)``
+    Outcome-model prediction averaged under the explicit target policy.
+
+A one-dimensional outcome prediction cannot generally represent both quantities
+for a multi-action problem.  This module therefore requires an explicit
+``(n_rows, n_actions)`` action-value matrix and refuses silent broadcasting.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .exceptions import DataValidationError
+
+
+@dataclass(frozen=True)
+class ActionValueTerms:
+    """Action-specific outcome terms used by the DR contribution."""
+
+    q_by_action: np.ndarray
+    q_obs: np.ndarray
+    q_pi: np.ndarray
+
+
+def compute_action_value_terms(
+    q_by_action: np.ndarray,
+    policy_probabilities: np.ndarray,
+    observed_actions: np.ndarray,
+    *,
+    eligible_actions: np.ndarray | None = None,
+    atol: float = 1e-10,
+) -> ActionValueTerms:
+    """Validate action-specific predictions and compute ``q_obs`` / ``q_pi``.
+
+    Parameters
+    ----------
+    q_by_action:
+        Outcome-model predictions ``q_hat(x_i, a)`` with exact shape
+        ``(n_rows, n_actions)``.
+    policy_probabilities:
+        Explicit target-policy probabilities with the same shape. Rows must be
+        finite, non-negative and sum to one. Positive mass on ineligible actions
+        is rejected when ``eligible_actions`` is supplied.
+    observed_actions:
+        Integer action indices with shape ``(n_rows,)``.
+    eligible_actions:
+        Optional boolean/0-1 matrix with the same shape. The logged action must
+        be eligible on every row and target-policy mass on ineligible actions
+        must be zero.
+    atol:
+        Floating-point tolerance for row-normalization / zero-mass checks.
+
+    Returns
+    -------
+    ActionValueTerms
+        Immutable bundle containing the validated action-value matrix plus
+        ``q_obs`` and ``q_pi`` vectors.
+
+    Notes
+    -----
+    This helper deliberately does not accept a one-dimensional ``q_hat`` for a
+    multi-action problem.  Callers must construct action-specific predictions
+    explicitly rather than relying on numpy broadcasting.
+    """
+
+    if not np.isfinite(atol) or atol < 0:
+        raise DataValidationError(f"atol must be finite and non-negative; got {atol!r}")
+
+    q = np.asarray(q_by_action, dtype=np.float64)
+    pi = np.asarray(policy_probabilities, dtype=np.float64)
+    actions = np.asarray(observed_actions)
+
+    if q.ndim != 2:
+        raise DataValidationError(
+            "q_by_action must be a two-dimensional (n_rows, n_actions) matrix; "
+            f"got shape {q.shape}. A 1-D q_hat cannot define q_pi for a "
+            "multi-action validated evaluation."
+        )
+    if pi.shape != q.shape:
+        raise DataValidationError(
+            "policy_probabilities must have the same shape as q_by_action; "
+            f"got {pi.shape} and {q.shape}"
+        )
+    n_rows, n_actions = q.shape
+    if n_actions < 1:
+        raise DataValidationError("q_by_action must contain at least one action column")
+    if actions.shape != (n_rows,):
+        raise DataValidationError(
+            f"observed_actions must have shape ({n_rows},); got {actions.shape}"
+        )
+    if not np.issubdtype(actions.dtype, np.integer):
+        # Floats such as 1.0 are ambiguous action identifiers; require the
+        # caller to map the explicit action vocabulary to integer positions.
+        raise DataValidationError("observed_actions must contain integer action indices")
+    action_idx = actions.astype(np.int64, copy=False)
+    if np.any((action_idx < 0) | (action_idx >= n_actions)):
+        row = int(np.flatnonzero((action_idx < 0) | (action_idx >= n_actions))[0])
+        raise DataValidationError(
+            f"observed action index out of bounds at row {row}: "
+            f"{int(action_idx[row])} not in [0, {n_actions})"
+        )
+
+    if not np.all(np.isfinite(q)):
+        bad = np.argwhere(~np.isfinite(q))[0]
+        raise DataValidationError(
+            "q_by_action must be finite; first invalid value at "
+            f"row={int(bad[0])}, action_index={int(bad[1])}"
+        )
+    if not np.all(np.isfinite(pi)):
+        bad = np.argwhere(~np.isfinite(pi))[0]
+        raise DataValidationError(
+            "policy_probabilities must be finite; first invalid value at "
+            f"row={int(bad[0])}, action_index={int(bad[1])}"
+        )
+    if np.any(pi < -atol):
+        bad = np.argwhere(pi < -atol)[0]
+        raise DataValidationError(
+            "policy_probabilities must be non-negative; first invalid value at "
+            f"row={int(bad[0])}, action_index={int(bad[1])}"
+        )
+    pi = np.where(np.abs(pi) <= atol, 0.0, pi)
+
+    row_sums = pi.sum(axis=1)
+    bad_rows = np.flatnonzero(~np.isclose(row_sums, 1.0, rtol=0.0, atol=atol))
+    if bad_rows.size:
+        row = int(bad_rows[0])
+        raise DataValidationError(
+            "policy_probabilities must sum to 1 on every row; "
+            f"row {row} sums to {float(row_sums[row])}"
+        )
+
+    if eligible_actions is not None:
+        elig = np.asarray(eligible_actions)
+        if elig.shape != q.shape:
+            raise DataValidationError(
+                "eligible_actions must have the same shape as q_by_action; "
+                f"got {elig.shape} and {q.shape}"
+            )
+        if elig.dtype != np.bool_:
+            if not np.all(np.isin(elig, (0, 1))):
+                raise DataValidationError(
+                    "eligible_actions must contain only booleans or 0/1 values"
+                )
+            elig = elig.astype(bool)
+        else:
+            elig = elig.astype(bool, copy=False)
+
+        logged_eligible = elig[np.arange(n_rows), action_idx]
+        if not np.all(logged_eligible):
+            row = int(np.flatnonzero(~logged_eligible)[0])
+            raise DataValidationError(
+                "observed action must be eligible on every evaluated row; "
+                f"row {row} is not"
+            )
+        invalid_mass = np.argwhere((~elig) & (pi > atol))
+        if invalid_mass.size:
+            bad = invalid_mass[0]
+            raise DataValidationError(
+                "target policy assigns positive mass to an ineligible action; "
+                f"row={int(bad[0])}, action_index={int(bad[1])}"
+            )
+
+    q_obs = q[np.arange(n_rows), action_idx]
+    q_pi = np.sum(pi * q, axis=1)
+
+    # Copy/lock outputs so the returned terms remain consistent after
+    # validation even if callers mutate their original arrays.
+    q_stable = q.copy()
+    q_obs_stable = q_obs.copy()
+    q_pi_stable = q_pi.copy()
+    for arr in (q_stable, q_obs_stable, q_pi_stable):
+        arr.setflags(write=False)
+
+    return ActionValueTerms(
+        q_by_action=q_stable,
+        q_obs=q_obs_stable,
+        q_pi=q_pi_stable,
+    )
+
+
+__all__ = ["ActionValueTerms", "compute_action_value_terms"]

--- a/tests/test_estimand_contract.py
+++ b/tests/test_estimand_contract.py
@@ -1,0 +1,135 @@
+"""Tests for the corrected multi-action q_obs / q_pi contract (#58)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from skdr_eval.estimand import compute_action_value_terms
+from skdr_eval.exceptions import DataValidationError
+
+
+def test_q_obs_and_q_pi_are_distinct_and_correct() -> None:
+    q = np.array(
+        [
+            [1.0, 10.0],
+            [2.0, 20.0],
+            [3.0, 30.0],
+        ]
+    )
+    pi = np.array(
+        [
+            [0.25, 0.75],
+            [1.0, 0.0],
+            [0.0, 1.0],
+        ]
+    )
+    observed = np.array([0, 1, 0], dtype=np.int64)
+
+    terms = compute_action_value_terms(q, pi, observed)
+
+    np.testing.assert_allclose(terms.q_obs, np.array([1.0, 20.0, 3.0]))
+    np.testing.assert_allclose(
+        terms.q_pi,
+        np.array([0.25 * 1.0 + 0.75 * 10.0, 2.0, 30.0]),
+    )
+    assert terms.q_pi[0] != terms.q_obs[0]
+
+
+def test_one_dimensional_q_hat_is_rejected() -> None:
+    with pytest.raises(DataValidationError, match="1-D q_hat"):
+        compute_action_value_terms(
+            np.array([1.0, 2.0]),
+            np.array([[1.0, 0.0], [0.0, 1.0]]),
+            np.array([0, 1], dtype=np.int64),
+        )
+
+
+def test_policy_shape_must_equal_action_value_shape() -> None:
+    with pytest.raises(DataValidationError, match="same shape"):
+        compute_action_value_terms(
+            np.ones((2, 3)),
+            np.ones((2, 2)) / 2,
+            np.array([0, 1], dtype=np.int64),
+        )
+
+
+def test_observed_actions_must_be_integer_indices() -> None:
+    with pytest.raises(DataValidationError, match="integer"):
+        compute_action_value_terms(
+            np.ones((2, 2)),
+            np.ones((2, 2)) / 2,
+            np.array([0.0, 1.0]),
+        )
+
+
+def test_observed_action_bounds_are_checked() -> None:
+    with pytest.raises(DataValidationError, match="out of bounds"):
+        compute_action_value_terms(
+            np.ones((2, 2)),
+            np.ones((2, 2)) / 2,
+            np.array([0, 2], dtype=np.int64),
+        )
+
+
+@pytest.mark.parametrize("which", ["q", "pi"])
+def test_non_finite_inputs_fail_closed(which: str) -> None:
+    q = np.ones((2, 2))
+    pi = np.ones((2, 2)) / 2
+    if which == "q":
+        q[1, 0] = np.nan
+    else:
+        pi[1, 0] = np.inf
+    with pytest.raises(DataValidationError, match="finite"):
+        compute_action_value_terms(q, pi, np.array([0, 1], dtype=np.int64))
+
+
+def test_non_normalized_policy_is_rejected() -> None:
+    with pytest.raises(DataValidationError, match="sum to 1"):
+        compute_action_value_terms(
+            np.ones((1, 2)),
+            np.array([[0.4, 0.4]]),
+            np.array([0], dtype=np.int64),
+        )
+
+
+def test_negative_policy_mass_is_rejected() -> None:
+    with pytest.raises(DataValidationError, match="non-negative"):
+        compute_action_value_terms(
+            np.ones((1, 2)),
+            np.array([[1.1, -0.1]]),
+            np.array([0], dtype=np.int64),
+        )
+
+
+def test_logged_action_must_be_eligible() -> None:
+    with pytest.raises(DataValidationError, match="observed action must be eligible"):
+        compute_action_value_terms(
+            np.array([[1.0, 2.0]]),
+            np.array([[0.0, 1.0]]),
+            np.array([0], dtype=np.int64),
+            eligible_actions=np.array([[0, 1]]),
+        )
+
+
+def test_target_policy_mass_on_ineligible_action_is_rejected() -> None:
+    with pytest.raises(DataValidationError, match="ineligible"):
+        compute_action_value_terms(
+            np.array([[1.0, 2.0]]),
+            np.array([[0.5, 0.5]]),
+            np.array([0], dtype=np.int64),
+            eligible_actions=np.array([[1, 0]]),
+        )
+
+
+def test_output_is_stable_after_input_mutation() -> None:
+    q = np.array([[1.0, 2.0]])
+    pi = np.array([[0.25, 0.75]])
+    terms = compute_action_value_terms(q, pi, np.array([0], dtype=np.int64))
+    q[0, 0] = 999.0
+    pi[0, 0] = 1.0
+    np.testing.assert_array_equal(terms.q_by_action, np.array([[1.0, 2.0]]))
+    assert terms.q_obs[0] == 1.0
+    assert terms.q_pi[0] == pytest.approx(1.75)
+    with pytest.raises(ValueError):
+        terms.q_pi[0] = 0.0


### PR DESCRIPTION
## Superseded by refreshed PR #318

This prototype was created before canonical Policy PR #307 merged and therefore duplicated target-policy validation locally.

PR #318 is the correct review target:

- based on current `main` with #307 already present;
- uses `skdr_eval.policy.validate_action_distribution(...)` as the single source of truth;
- binds `q_hat(x,a)` to the same explicit ordered action vocabulary;
- keeps only the #58-specific responsibilities: action-value shape/finiteness, logged-action indexing, logged-action eligibility, and distinct `q_obs`/`q_pi` construction.

No intended #58 work is lost.