### PR TITLE
fix: add explicit OOF evaluation-population contract (#280)

### DIFF
--- a/changelog.d/280.fixed.md
+++ b/changelog.d/280.fixed.md
@@ -1,0 +1,1 @@
+Added an explicit `EvaluationPopulation` contract that intersects required OOF-coverage masks, preserves per-row exclusion reasons, and fails closed when too few evaluated rows remain. The existing evaluator still needs to consume this contract and remove its historical statistical fallbacks, so #280 remains open.

--- a/src/skdr_eval/population.py
+++ b/src/skdr_eval/population.py
@@ -1,0 +1,189 @@
+"""Explicit evaluated-population contracts for cross-fitted OPE.
+
+Time-forward cross-fitting can leave warm-up/training-only rows without a genuine
+out-of-fold prediction.  The validated path must exclude those rows explicitly
+(or fail), never populate statistical defaults merely to keep the evaluation
+rectangular (#280 / #297).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+import numpy as np
+
+from .exceptions import DataValidationError, InsufficientDataError
+
+
+@dataclass(frozen=True)
+class EvaluationPopulation:
+    """Immutable description of the rows that contribute to an evaluation."""
+
+    input_rows: int
+    evaluated_mask: np.ndarray
+    exclusion_reasons: tuple[tuple[str, ...], ...]
+
+    @property
+    def evaluated_rows(self) -> int:
+        return int(self.evaluated_mask.sum())
+
+    @property
+    def excluded_rows(self) -> int:
+        return self.input_rows - self.evaluated_rows
+
+    @property
+    def evaluated_indices(self) -> np.ndarray:
+        out = np.flatnonzero(self.evaluated_mask)
+        out.setflags(write=False)
+        return out
+
+    def exclusion_counts(self) -> dict[str, int]:
+        """Count each exclusion reason independently across rows."""
+
+        counts: dict[str, int] = {}
+        for reasons in self.exclusion_reasons:
+            for reason in reasons:
+                counts[reason] = counts.get(reason, 0) + 1
+        return counts
+
+    def apply(self, values: np.ndarray, *, name: str = "values") -> np.ndarray:
+        """Return only evaluated rows from a row-aligned array."""
+
+        array = np.asarray(values)
+        if array.ndim == 0 or array.shape[0] != self.input_rows:
+            raise DataValidationError(
+                f"{name} must have {self.input_rows} rows; got shape {array.shape}"
+            )
+        return array[self.evaluated_mask]
+
+
+def coverage_from_fold_assignments(
+    fold_indices: np.ndarray,
+    *,
+    n_rows: int | None = None,
+) -> np.ndarray:
+    """Convert fold provenance into a boolean OOF-coverage mask.
+
+    A row is covered iff its fold assignment is a non-negative integer.  The
+    function does not invent a fold for uncovered rows.
+    """
+
+    folds = np.asarray(fold_indices)
+    if folds.ndim != 1:
+        raise DataValidationError(
+            f"fold_indices must be one-dimensional; got shape {folds.shape}"
+        )
+    if n_rows is not None and folds.shape != (n_rows,):
+        raise DataValidationError(
+            f"fold_indices must have shape ({n_rows},); got {folds.shape}"
+        )
+    if not np.issubdtype(folds.dtype, np.integer):
+        raise DataValidationError("fold_indices must contain integer fold identifiers")
+    return folds >= 0
+
+
+def build_evaluation_population(
+    n_rows: int,
+    required_coverage: Mapping[str, np.ndarray],
+    *,
+    minimum_evaluated_rows: int = 1,
+) -> EvaluationPopulation:
+    """Intersect required prediction-coverage masks and record exclusions.
+
+    Parameters
+    ----------
+    n_rows:
+        Number of input rows before cross-fitting exclusions.
+    required_coverage:
+        Mapping from a stable reason/source name (for example ``"outcome_oof"``)
+        to a boolean mask where ``True`` means that row has valid evidence from
+        that source.  All required masks must be true for a row to contribute.
+    minimum_evaluated_rows:
+        Minimum number of rows required after intersection.  The default of one
+        merely prevents an empty estimand; higher statistical support thresholds
+        belong to the evidence/diagnostic layer.
+
+    Returns
+    -------
+    EvaluationPopulation
+        Explicit row mask plus per-row exclusion reasons.
+
+    Raises
+    ------
+    DataValidationError
+        For malformed/ambiguous coverage inputs.
+    InsufficientDataError
+        When fewer than ``minimum_evaluated_rows`` remain.
+    """
+
+    if not isinstance(n_rows, int) or n_rows < 0:
+        raise DataValidationError(f"n_rows must be a non-negative integer; got {n_rows!r}")
+    if not isinstance(minimum_evaluated_rows, int) or minimum_evaluated_rows < 1:
+        raise DataValidationError(
+            "minimum_evaluated_rows must be a positive integer; "
+            f"got {minimum_evaluated_rows!r}"
+        )
+    if not required_coverage:
+        raise DataValidationError(
+            "required_coverage must name at least one coverage requirement"
+        )
+
+    normalized: dict[str, np.ndarray] = {}
+    for raw_name, raw_mask in required_coverage.items():
+        name = str(raw_name).strip()
+        if not name:
+            raise DataValidationError("coverage requirement names must be non-empty")
+        if name in normalized:
+            raise DataValidationError(f"duplicate coverage requirement name: {name!r}")
+
+        mask = np.asarray(raw_mask)
+        if mask.shape != (n_rows,):
+            raise DataValidationError(
+                f"coverage mask {name!r} must have shape ({n_rows},); got {mask.shape}"
+            )
+        if mask.dtype != np.bool_:
+            if not np.all(np.isin(mask, (0, 1))):
+                raise DataValidationError(
+                    f"coverage mask {name!r} must contain only booleans or 0/1 values"
+                )
+            mask = mask.astype(bool)
+        else:
+            mask = mask.astype(bool, copy=False)
+        normalized[name] = mask
+
+    evaluated = np.ones(n_rows, dtype=bool)
+    for mask in normalized.values():
+        evaluated &= mask
+
+    reasons: list[tuple[str, ...]] = []
+    for row in range(n_rows):
+        row_reasons = tuple(name for name, mask in normalized.items() if not mask[row])
+        reasons.append(row_reasons)
+
+    n_evaluated = int(evaluated.sum())
+    if n_evaluated < minimum_evaluated_rows:
+        counts: dict[str, int] = {}
+        for row_reasons in reasons:
+            for reason in row_reasons:
+                counts[reason] = counts.get(reason, 0) + 1
+        raise InsufficientDataError(
+            "Explicit OOF population left too few evaluated rows: "
+            f"{n_evaluated}/{n_rows} < minimum_evaluated_rows="
+            f"{minimum_evaluated_rows}; exclusion counts={counts}"
+        )
+
+    stable_mask = evaluated.copy()
+    stable_mask.setflags(write=False)
+    return EvaluationPopulation(
+        input_rows=n_rows,
+        evaluated_mask=stable_mask,
+        exclusion_reasons=tuple(reasons),
+    )
+
+
+__all__ = [
+    "EvaluationPopulation",
+    "build_evaluation_population",
+    "coverage_from_fold_assignments",
+]

--- a/src/skdr_eval/population.py
+++ b/src/skdr_eval/population.py
@@ -1,7 +1,7 @@
 """Explicit evaluated-population contracts for cross-fitted OPE.
 
 Time-forward cross-fitting can leave warm-up/training-only rows without a genuine
-out-of-fold prediction.  The validated path must exclude those rows explicitly
+out-of-fold prediction. The validated path must exclude those rows explicitly
 (or fail), never populate statistical defaults merely to keep the evaluation
 rectangular (#280 / #297).
 """
@@ -18,11 +18,71 @@ from .exceptions import DataValidationError, InsufficientDataError
 
 @dataclass(frozen=True)
 class EvaluationPopulation:
-    """Immutable description of the rows that contribute to an evaluation."""
+    """Immutable, self-validating description of rows that contribute.
+
+    Direct construction enforces the same invariants as
+    :func:`build_evaluation_population`; callers cannot manufacture an
+    inconsistent evaluated mask and exclusion record after validation.
+    """
 
     input_rows: int
     evaluated_mask: np.ndarray
     exclusion_reasons: tuple[tuple[str, ...], ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.input_rows, int) or self.input_rows < 0:
+            raise DataValidationError(
+                f"input_rows must be a non-negative integer; got {self.input_rows!r}"
+            )
+
+        raw_mask = np.asarray(self.evaluated_mask)
+        if raw_mask.shape != (self.input_rows,):
+            raise DataValidationError(
+                "evaluated_mask must have shape "
+                f"({self.input_rows},); got {raw_mask.shape}"
+            )
+        if raw_mask.dtype != np.bool_:
+            if not np.all(np.isin(raw_mask, (0, 1))):
+                raise DataValidationError(
+                    "evaluated_mask must contain only booleans or 0/1 values"
+                )
+            raw_mask = raw_mask.astype(bool)
+        else:
+            raw_mask = raw_mask.astype(bool, copy=False)
+
+        if len(self.exclusion_reasons) != self.input_rows:
+            raise DataValidationError(
+                "exclusion_reasons must contain one tuple per input row; "
+                f"got {len(self.exclusion_reasons)} for {self.input_rows} rows"
+            )
+
+        normalized_reasons: list[tuple[str, ...]] = []
+        for row, raw_reasons in enumerate(self.exclusion_reasons):
+            reasons = tuple(str(reason).strip() for reason in raw_reasons)
+            if any(not reason for reason in reasons):
+                raise DataValidationError(
+                    f"exclusion reasons must be non-empty strings; row {row} is invalid"
+                )
+            if len(set(reasons)) != len(reasons):
+                raise DataValidationError(
+                    f"exclusion reasons must be unique per row; row {row} has duplicates"
+                )
+            if raw_mask[row] and reasons:
+                raise DataValidationError(
+                    "evaluated rows cannot carry exclusion reasons; "
+                    f"row {row} has {reasons}"
+                )
+            if not raw_mask[row] and not reasons:
+                raise DataValidationError(
+                    "excluded rows must record at least one exclusion reason; "
+                    f"row {row} has none"
+                )
+            normalized_reasons.append(reasons)
+
+        stable_mask = raw_mask.copy()
+        stable_mask.setflags(write=False)
+        object.__setattr__(self, "evaluated_mask", stable_mask)
+        object.__setattr__(self, "exclusion_reasons", tuple(normalized_reasons))
 
     @property
     def evaluated_rows(self) -> int:
@@ -65,7 +125,7 @@ def coverage_from_fold_assignments(
 ) -> np.ndarray:
     """Convert fold provenance into a boolean OOF-coverage mask.
 
-    A row is covered iff its fold assignment is a non-negative integer.  The
+    A row is covered iff its fold assignment is a non-negative integer. The
     function does not invent a fold for uncovered rows.
     """
 
@@ -98,23 +158,11 @@ def build_evaluation_population(
     required_coverage:
         Mapping from a stable reason/source name (for example ``"outcome_oof"``)
         to a boolean mask where ``True`` means that row has valid evidence from
-        that source.  All required masks must be true for a row to contribute.
+        that source. All required masks must be true for a row to contribute.
     minimum_evaluated_rows:
-        Minimum number of rows required after intersection.  The default of one
+        Minimum number of rows required after intersection. The default of one
         merely prevents an empty estimand; higher statistical support thresholds
         belong to the evidence/diagnostic layer.
-
-    Returns
-    -------
-    EvaluationPopulation
-        Explicit row mask plus per-row exclusion reasons.
-
-    Raises
-    ------
-    DataValidationError
-        For malformed/ambiguous coverage inputs.
-    InsufficientDataError
-        When fewer than ``minimum_evaluated_rows`` remain.
     """
 
     if not isinstance(n_rows, int) or n_rows < 0:
@@ -173,11 +221,9 @@ def build_evaluation_population(
             f"{minimum_evaluated_rows}; exclusion counts={counts}"
         )
 
-    stable_mask = evaluated.copy()
-    stable_mask.setflags(write=False)
     return EvaluationPopulation(
         input_rows=n_rows,
-        evaluated_mask=stable_mask,
+        evaluated_mask=evaluated,
         exclusion_reasons=tuple(reasons),
     )
 

--- a/tests/test_evaluation_population.py
+++ b/tests/test_evaluation_population.py
@@ -48,6 +48,34 @@ def test_population_intersects_all_required_coverage() -> None:
     }
 
 
+def test_direct_population_construction_enforces_consistency() -> None:
+    direct = EvaluationPopulation(
+        input_rows=2,
+        evaluated_mask=np.array([1, 0]),
+        exclusion_reasons=((), ("warmup",)),
+    )
+    np.testing.assert_array_equal(direct.evaluated_mask, np.array([True, False]))
+
+    with pytest.raises(DataValidationError, match="evaluated rows cannot"):
+        EvaluationPopulation(
+            input_rows=1,
+            evaluated_mask=np.array([True]),
+            exclusion_reasons=(("impossible",),),
+        )
+    with pytest.raises(DataValidationError, match="excluded rows must"):
+        EvaluationPopulation(
+            input_rows=1,
+            evaluated_mask=np.array([False]),
+            exclusion_reasons=((),),
+        )
+    with pytest.raises(DataValidationError, match="one tuple per input row"):
+        EvaluationPopulation(
+            input_rows=2,
+            evaluated_mask=np.array([True, False]),
+            exclusion_reasons=((),),
+        )
+
+
 def test_multiple_exclusion_reasons_are_preserved_per_row() -> None:
     population = build_evaluation_population(
         3,

--- a/tests/test_evaluation_population.py
+++ b/tests/test_evaluation_population.py
@@ -1,0 +1,149 @@
+"""Tests for the explicit OOF evaluation-population contract (#280)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from skdr_eval.exceptions import DataValidationError, InsufficientDataError
+from skdr_eval.population import (
+    EvaluationPopulation,
+    build_evaluation_population,
+    coverage_from_fold_assignments,
+)
+
+
+def test_fold_assignments_preserve_uncovered_prefix() -> None:
+    folds = np.array([-1, -1, 0, 0, 1, 1], dtype=np.int64)
+    covered = coverage_from_fold_assignments(folds)
+    np.testing.assert_array_equal(
+        covered,
+        np.array([False, False, True, True, True, True]),
+    )
+    # The contract explicitly does not replace -1 with a synthetic fold.
+    np.testing.assert_array_equal(folds[:2], np.array([-1, -1]))
+
+
+def test_population_intersects_all_required_coverage() -> None:
+    population = build_evaluation_population(
+        5,
+        {
+            "outcome_oof": np.array([0, 1, 1, 1, 1]),
+            "policy_holdout": np.array([1, 1, 1, 0, 1]),
+        },
+    )
+    assert isinstance(population, EvaluationPopulation)
+    np.testing.assert_array_equal(
+        population.evaluated_mask,
+        np.array([False, True, True, False, True]),
+    )
+    assert population.input_rows == 5
+    assert population.evaluated_rows == 3
+    assert population.excluded_rows == 2
+    assert population.exclusion_reasons[0] == ("outcome_oof",)
+    assert population.exclusion_reasons[3] == ("policy_holdout",)
+    assert population.exclusion_counts() == {
+        "outcome_oof": 1,
+        "policy_holdout": 1,
+    }
+
+
+def test_multiple_exclusion_reasons_are_preserved_per_row() -> None:
+    population = build_evaluation_population(
+        3,
+        {
+            "outcome_oof": np.array([0, 1, 1]),
+            "propensity_oof": np.array([0, 1, 1]),
+        },
+    )
+    assert population.exclusion_reasons[0] == (
+        "outcome_oof",
+        "propensity_oof",
+    )
+    assert population.exclusion_counts() == {
+        "outcome_oof": 1,
+        "propensity_oof": 1,
+    }
+
+
+def test_apply_filters_row_aligned_arrays() -> None:
+    population = build_evaluation_population(
+        4,
+        {"outcome_oof": np.array([0, 1, 0, 1])},
+    )
+    one_d = np.array([10, 20, 30, 40])
+    two_d = np.arange(8).reshape(4, 2)
+    np.testing.assert_array_equal(population.apply(one_d), np.array([20, 40]))
+    np.testing.assert_array_equal(
+        population.apply(two_d),
+        np.array([[2, 3], [6, 7]]),
+    )
+
+
+def test_apply_rejects_non_aligned_array() -> None:
+    population = build_evaluation_population(
+        3,
+        {"outcome_oof": np.array([1, 1, 1])},
+    )
+    with pytest.raises(DataValidationError, match="3 rows"):
+        population.apply(np.array([1, 2]), name="q_hat")
+
+
+def test_empty_or_too_small_population_fails_closed() -> None:
+    with pytest.raises(InsufficientDataError, match="0/3"):
+        build_evaluation_population(
+            3,
+            {"outcome_oof": np.array([0, 0, 0])},
+        )
+    with pytest.raises(InsufficientDataError, match="minimum_evaluated_rows=3"):
+        build_evaluation_population(
+            4,
+            {"outcome_oof": np.array([0, 1, 0, 1])},
+            minimum_evaluated_rows=3,
+        )
+
+
+def test_missing_coverage_contract_is_rejected() -> None:
+    with pytest.raises(DataValidationError, match="at least one"):
+        build_evaluation_population(3, {})
+
+
+def test_coverage_mask_shape_and_values_are_validated() -> None:
+    with pytest.raises(DataValidationError, match="shape"):
+        build_evaluation_population(
+            3,
+            {"outcome_oof": np.array([1, 1])},
+        )
+    with pytest.raises(DataValidationError, match="0/1"):
+        build_evaluation_population(
+            2,
+            {"outcome_oof": np.array([1.0, 0.5])},
+        )
+
+
+def test_evaluated_mask_is_immutable_copy() -> None:
+    source = np.array([1, 0, 1])
+    population = build_evaluation_population(3, {"outcome_oof": source})
+    source[:] = 0
+    np.testing.assert_array_equal(
+        population.evaluated_mask,
+        np.array([True, False, True]),
+    )
+    with pytest.raises(ValueError):
+        population.evaluated_mask[0] = False
+
+
+def test_evaluated_indices_are_explicit() -> None:
+    population = build_evaluation_population(
+        5,
+        {"outcome_oof": np.array([0, 1, 0, 1, 1])},
+    )
+    indices = population.evaluated_indices
+    np.testing.assert_array_equal(indices, np.array([1, 3, 4]))
+    with pytest.raises(ValueError):
+        indices[0] = 99
+
+
+def test_non_integer_fold_assignments_rejected() -> None:
+    with pytest.raises(DataValidationError, match="integer"):
+        coverage_from_fold_assignments(np.array([-1.0, 0.0, 1.0]))


### PR DESCRIPTION
## What

Adds the explicit population/provenance seam required by #280 without changing current evaluator numerics yet:

- `EvaluationPopulation` records input rows, immutable evaluated mask, explicit evaluated indices, and per-row exclusion reasons;
- `coverage_from_fold_assignments(...)` treats negative fold IDs as genuinely uncovered rather than assigning them to a synthetic fold;
- `build_evaluation_population(...)` intersects all required coverage masks, preserves multiple exclusion reasons on the same row, and fails closed when too few rows remain;
- `apply(...)` filters any row-aligned array through the exact same evaluated mask;
- no statistical values are filled or imputed merely to keep a rectangular result.

Tests explicitly reproduce a TimeSeriesSplit-style uncovered prefix and prove it remains excluded rather than being reassigned.

## Why this is only part of #280

The current propensity/outcome helpers and high-level evaluator still have historical fallback behavior. This PR establishes the reusable population contract first; #280 remains open until:

- `fit_outcome_crossfit`/the validated path expose genuine prediction provenance rather than relying on zero initialization;
- internally estimated propensity workflows preserve uncovered rows rather than filling uniform probabilities;
- the standard validated evaluator applies one shared population mask to point estimation, diagnostics, uncertainty, reference comparison and artifact provenance;
- historical impact is covered by #300.

For validated-v1, logged behavior propensities (#167) do not require OOF estimation; their provenance remains a separate contract.

## Statistical behavior

None on existing APIs yet; this module is additive and not consumed by current evaluators.