### PR TITLE
feat: separate estimator maturity, diagnostics and evidence state (#245 #259 #282)

### DIFF
--- a/changelog.d/245.changed.md
+++ b/changelog.d/245.changed.md
@@ -1,0 +1,1 @@
+Added machine-readable estimator-maturity, diagnostic-state, and evidence-status contracts that explicitly separate implementation validation from evidence quality. The new evidence vocabulary contains no deployment or online-experiment authorization; existing recommendation/reporting paths are not yet migrated, so #245/#259/#282 remain open.

--- a/src/skdr_eval/evidence.py
+++ b/src/skdr_eval/evidence.py
@@ -10,7 +10,7 @@ statistical software (#245 / #259 / #282):
 3. **Evidence status** — whether the *particular evaluation* has enough valid
    evidence to support its estimate under a declared validation envelope.
 
-A validated estimator can therefore still produce unsupported evidence.  These
+A validated estimator can therefore still produce unsupported evidence. These
 states intentionally contain no deployment or online-experiment authorization.
 """
 
@@ -46,7 +46,7 @@ class DiagnosticState(str, Enum):
 class EvidenceStatus(str, Enum):
     """Statistical/evidence state of a concrete evaluation.
 
-    These are deliberately evidence-only semantics.  In particular, none of
+    These are deliberately evidence-only semantics. In particular, none of
     these values means "deploy", "do not deploy", or "approved for an online
     experiment".
     """
@@ -60,7 +60,13 @@ class EvidenceStatus(str, Enum):
 
 @dataclass(frozen=True)
 class EstimatorValidationRecord:
-    """One estimator entry in the implementation-maturity registry."""
+    """One immutable estimator entry in the implementation-maturity registry.
+
+    Instances are descriptive records only. Positive evidence is never granted
+    from an arbitrary caller-created record; :func:`can_support_estimate`
+    resolves maturity from :data:`ESTIMATOR_VALIDATION_REGISTRY` by canonical
+    estimator name so promotion requires a deliberate versioned code change.
+    """
 
     name: str
     maturity: EstimatorMaturity
@@ -71,10 +77,11 @@ class EstimatorValidationRecord:
 
     @property
     def validated_for_positive_evidence(self) -> bool:
-        """Whether maturity can participate in a positive evidence claim.
+        """Whether this registry record's maturity can participate in support.
 
-        This is necessary but never sufficient: a concrete evaluation still
-        needs supported data/diagnostics/inference.
+        This remains necessary but never sufficient: a concrete evaluation still
+        needs supported data, diagnostics, and inference inside its declared
+        validation envelope.
         """
 
         return self.maturity in {
@@ -122,16 +129,15 @@ _INITIAL_REGISTRY: dict[str, EstimatorValidationRecord] = {
     ),
 }
 
-# Immutable public initial registry.  Promotion/demotion should happen through a
-# deliberate versioned code change plus validation evidence, never mutable
-# process state at runtime.
+# Runtime mutation is forbidden. Promotion/demotion happens through a reviewed
+# code change that also records validation-report provenance.
 ESTIMATOR_VALIDATION_REGISTRY: Mapping[str, EstimatorValidationRecord] = MappingProxyType(
     _INITIAL_REGISTRY
 )
 
 
 def get_estimator_validation(name: str) -> EstimatorValidationRecord:
-    """Return the implementation-maturity record for a canonical estimator."""
+    """Return the registry-backed implementation-maturity record."""
 
     canonical = str(name).strip()
     try:
@@ -147,7 +153,7 @@ def required_diagnostics_support_evidence(
 ) -> bool:
     """Return whether all required diagnostics are affirmative or N/A.
 
-    ``UNKNOWN`` is deliberately fail-closed for positive evidence.  This helper
+    ``UNKNOWN`` is deliberately fail-closed for positive evidence. This helper
     does not decide the final :class:`EvidenceStatus`; it only captures the hard
     invariant that a required unknown/failed diagnostic cannot satisfy a
     positive evidence contract.
@@ -171,17 +177,26 @@ def required_diagnostics_support_evidence(
 
 
 def can_support_estimate(
-    estimator: EstimatorValidationRecord,
+    estimator_name: str,
     required_diagnostics: Mapping[str, DiagnosticState | str],
     *,
     inside_validation_envelope: bool,
 ) -> bool:
-    """Hard preconditions for the future ``estimate_supported`` state.
+    """Return hard preconditions for a future ``estimate_supported`` state.
+
+    Estimator maturity is resolved from the immutable project registry by name.
+    Callers cannot create a fake ``REFERENCE_VALIDATED`` record at runtime to
+    bypass the project's versioned validation status.
 
     This intentionally does not inspect effect direction, confidence intervals,
-    business risk, or deployment policy.  It merely encodes three necessary
+    business risk, or deployment policy. It encodes only three necessary
     conditions that future evidence-state logic cannot bypass.
     """
+
+    try:
+        estimator = get_estimator_validation(estimator_name)
+    except DataValidationError:
+        return False
 
     return (
         estimator.validated_for_positive_evidence

--- a/src/skdr_eval/evidence.py
+++ b/src/skdr_eval/evidence.py
@@ -1,0 +1,202 @@
+"""Machine-readable evidence and implementation-maturity contracts.
+
+This module separates three concepts that must not be conflated in validated
+statistical software (#245 / #259 / #282):
+
+1. **Estimator implementation maturity** — how strongly a concrete estimator
+   implementation has itself been validated.
+2. **Diagnostic state** — whether a required diagnostic passed, failed, is
+   unknown, or is genuinely not applicable for a concrete run.
+3. **Evidence status** — whether the *particular evaluation* has enough valid
+   evidence to support its estimate under a declared validation envelope.
+
+A validated estimator can therefore still produce unsupported evidence.  These
+states intentionally contain no deployment or online-experiment authorization.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Mapping
+
+from .exceptions import DataValidationError
+
+
+class EstimatorMaturity(str, Enum):
+    """Validation maturity of an estimator implementation."""
+
+    EXPERIMENTAL = "experimental"
+    VALIDATION_PENDING = "validation_pending"
+    REFERENCE_VALIDATED = "reference_validated"
+    INDEPENDENTLY_VALIDATED = "independently_validated"
+    DEPRECATED = "deprecated"
+
+
+class DiagnosticState(str, Enum):
+    """Normalized state of one required diagnostic for a concrete run."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    UNKNOWN = "unknown"
+    NOT_APPLICABLE = "not_applicable"
+
+
+class EvidenceStatus(str, Enum):
+    """Statistical/evidence state of a concrete evaluation.
+
+    These are deliberately evidence-only semantics.  In particular, none of
+    these values means "deploy", "do not deploy", or "approved for an online
+    experiment".
+    """
+
+    ESTIMATE_SUPPORTED = "estimate_supported"
+    INCONCLUSIVE = "inconclusive"
+    INSUFFICIENT_EVIDENCE = "insufficient_evidence"
+    UNSUPPORTED = "unsupported"
+    INVALID_EVALUATION = "invalid_evaluation"
+
+
+@dataclass(frozen=True)
+class EstimatorValidationRecord:
+    """One estimator entry in the implementation-maturity registry."""
+
+    name: str
+    maturity: EstimatorMaturity
+    estimand: str
+    validation_report_id: str | None = None
+    reference_backend: str | None = None
+    known_limitations: tuple[str, ...] = ()
+
+    @property
+    def validated_for_positive_evidence(self) -> bool:
+        """Whether maturity can participate in a positive evidence claim.
+
+        This is necessary but never sufficient: a concrete evaluation still
+        needs supported data/diagnostics/inference.
+        """
+
+        return self.maturity in {
+            EstimatorMaturity.REFERENCE_VALIDATED,
+            EstimatorMaturity.INDEPENDENTLY_VALIDATED,
+        }
+
+
+_INITIAL_REGISTRY: dict[str, EstimatorValidationRecord] = {
+    "DR": EstimatorValidationRecord(
+        name="DR",
+        maturity=EstimatorMaturity.VALIDATION_PENDING,
+        estimand="finite-discrete one-step target-policy value",
+        known_limitations=(
+            "validated-v1 promotion requires explicit target policy, logged behavior propensity, genuine OOF outcome predictions, corrected action-specific q(x,a), end-to-end validation, and estimator-specific reference evidence",
+        ),
+    ),
+    "SNDR": EstimatorValidationRecord(
+        name="SNDR",
+        maturity=EstimatorMaturity.VALIDATION_PENDING,
+        estimand="finite-discrete one-step self-normalized target-policy value",
+        known_limitations=(
+            "must not inherit DR reference validation; requires its own semantically equivalent independent reference and inferential validation",
+        ),
+    ),
+    "MRDR": EstimatorValidationRecord(
+        name="MRDR",
+        maturity=EstimatorMaturity.EXPERIMENTAL,
+        estimand="experimental one-step target-policy value",
+    ),
+    "SWITCH-DR": EstimatorValidationRecord(
+        name="SWITCH-DR",
+        maturity=EstimatorMaturity.EXPERIMENTAL,
+        estimand="experimental one-step target-policy value",
+    ),
+    "DRos": EstimatorValidationRecord(
+        name="DRos",
+        maturity=EstimatorMaturity.EXPERIMENTAL,
+        estimand="experimental one-step target-policy value",
+    ),
+    "MIPS": EstimatorValidationRecord(
+        name="MIPS",
+        maturity=EstimatorMaturity.EXPERIMENTAL,
+        estimand="experimental marginalized one-step target-policy value",
+    ),
+}
+
+# Immutable public initial registry.  Promotion/demotion should happen through a
+# deliberate versioned code change plus validation evidence, never mutable
+# process state at runtime.
+ESTIMATOR_VALIDATION_REGISTRY: Mapping[str, EstimatorValidationRecord] = MappingProxyType(
+    _INITIAL_REGISTRY
+)
+
+
+def get_estimator_validation(name: str) -> EstimatorValidationRecord:
+    """Return the implementation-maturity record for a canonical estimator."""
+
+    canonical = str(name).strip()
+    try:
+        return ESTIMATOR_VALIDATION_REGISTRY[canonical]
+    except KeyError as exc:
+        raise DataValidationError(
+            f"Unknown estimator validation record: {canonical!r}"
+        ) from exc
+
+
+def required_diagnostics_support_evidence(
+    states: Mapping[str, DiagnosticState | str],
+) -> bool:
+    """Return whether all required diagnostics are affirmative or N/A.
+
+    ``UNKNOWN`` is deliberately fail-closed for positive evidence.  This helper
+    does not decide the final :class:`EvidenceStatus`; it only captures the hard
+    invariant that a required unknown/failed diagnostic cannot satisfy a
+    positive evidence contract.
+    """
+
+    if not states:
+        return False
+
+    for raw_state in states.values():
+        try:
+            state = (
+                raw_state
+                if isinstance(raw_state, DiagnosticState)
+                else DiagnosticState(str(raw_state))
+            )
+        except ValueError:
+            return False
+        if state in {DiagnosticState.FAIL, DiagnosticState.UNKNOWN}:
+            return False
+    return True
+
+
+def can_support_estimate(
+    estimator: EstimatorValidationRecord,
+    required_diagnostics: Mapping[str, DiagnosticState | str],
+    *,
+    inside_validation_envelope: bool,
+) -> bool:
+    """Hard preconditions for the future ``estimate_supported`` state.
+
+    This intentionally does not inspect effect direction, confidence intervals,
+    business risk, or deployment policy.  It merely encodes three necessary
+    conditions that future evidence-state logic cannot bypass.
+    """
+
+    return (
+        estimator.validated_for_positive_evidence
+        and inside_validation_envelope
+        and required_diagnostics_support_evidence(required_diagnostics)
+    )
+
+
+__all__ = [
+    "DiagnosticState",
+    "ESTIMATOR_VALIDATION_REGISTRY",
+    "EstimatorMaturity",
+    "EstimatorValidationRecord",
+    "EvidenceStatus",
+    "can_support_estimate",
+    "get_estimator_validation",
+    "required_diagnostics_support_evidence",
+]

--- a/tests/test_evidence_contract.py
+++ b/tests/test_evidence_contract.py
@@ -8,6 +8,7 @@ from skdr_eval.evidence import (
     DiagnosticState,
     ESTIMATOR_VALIDATION_REGISTRY,
     EstimatorMaturity,
+    EstimatorValidationRecord,
     EvidenceStatus,
     can_support_estimate,
     get_estimator_validation,
@@ -88,8 +89,7 @@ def test_validation_pending_estimator_cannot_support_estimate() -> None:
 
 
 def test_validated_implementation_is_necessary_but_not_sufficient() -> None:
-    record_type = type(get_estimator_validation("DR"))
-    validated = record_type(
+    validated = EstimatorValidationRecord(
         name="DR-test",
         maturity=EstimatorMaturity.REFERENCE_VALIDATED,
         estimand="test estimand",
@@ -114,8 +114,7 @@ def test_validated_implementation_is_necessary_but_not_sufficient() -> None:
 
 
 def test_deprecated_estimator_never_qualifies_for_positive_evidence() -> None:
-    record_type = type(get_estimator_validation("DR"))
-    deprecated = record_type(
+    deprecated = EstimatorValidationRecord(
         name="old",
         maturity=EstimatorMaturity.DEPRECATED,
         estimand="old estimand",

--- a/tests/test_evidence_contract.py
+++ b/tests/test_evidence_contract.py
@@ -38,6 +38,11 @@ def test_registry_is_immutable() -> None:
 def test_unknown_estimator_record_fails_closed() -> None:
     with pytest.raises(DataValidationError, match="Unknown estimator"):
         get_estimator_validation("made-up")
+    assert not can_support_estimate(
+        "made-up",
+        {"overlap": "pass"},
+        inside_validation_envelope=True,
+    )
 
 
 def test_evidence_status_contains_no_deployment_authorization() -> None:
@@ -80,47 +85,46 @@ def test_malformed_diagnostic_state_does_not_pass() -> None:
     assert not required_diagnostics_support_evidence({"ess": "probably-fine"})
 
 
-def test_validation_pending_estimator_cannot_support_estimate() -> None:
-    assert not can_support_estimate(
-        get_estimator_validation("DR"),
-        {"overlap": "pass"},
-        inside_validation_envelope=True,
-    )
+def test_all_initial_registry_estimators_fail_positive_evidence_gate() -> None:
+    # No implementation is validated at the start of the evidence-first reset.
+    for name in ESTIMATOR_VALIDATION_REGISTRY:
+        assert not can_support_estimate(
+            name,
+            {"overlap": "pass", "ess": "pass"},
+            inside_validation_envelope=True,
+        )
 
 
-def test_validated_implementation_is_necessary_but_not_sufficient() -> None:
-    validated = EstimatorValidationRecord(
-        name="DR-test",
+def test_caller_created_validated_record_cannot_bypass_registry() -> None:
+    fake = EstimatorValidationRecord(
+        name="DR",
         maturity=EstimatorMaturity.REFERENCE_VALIDATED,
-        estimand="test estimand",
-        validation_report_id="validation-001",
+        estimand="fake runtime promotion",
+        validation_report_id="not-a-project-validation-report",
     )
+    assert fake.validated_for_positive_evidence is True
 
-    assert can_support_estimate(
-        validated,
+    # can_support_estimate accepts a canonical registry name, not an arbitrary
+    # record. Passing the record anyway at runtime must fail closed rather than
+    # treating caller-supplied maturity as authoritative.
+    assert not can_support_estimate(  # type: ignore[arg-type]
+        fake,
         {"overlap": "pass", "ess": "pass"},
         inside_validation_envelope=True,
     )
+
+
+def test_validation_envelope_and_diagnostics_remain_separate_gates() -> None:
+    # This remains false today because DR is validation_pending; the assertions
+    # still protect the other gates so a future registry promotion cannot make
+    # UNKNOWN diagnostics or out-of-envelope runs positive by accident.
     assert not can_support_estimate(
-        validated,
+        "DR",
         {"overlap": "unknown", "ess": "pass"},
         inside_validation_envelope=True,
     )
     assert not can_support_estimate(
-        validated,
+        "DR",
         {"overlap": "pass", "ess": "pass"},
         inside_validation_envelope=False,
-    )
-
-
-def test_deprecated_estimator_never_qualifies_for_positive_evidence() -> None:
-    deprecated = EstimatorValidationRecord(
-        name="old",
-        maturity=EstimatorMaturity.DEPRECATED,
-        estimand="old estimand",
-    )
-    assert not can_support_estimate(
-        deprecated,
-        {"overlap": "pass"},
-        inside_validation_envelope=True,
     )

--- a/tests/test_evidence_contract.py
+++ b/tests/test_evidence_contract.py
@@ -1,0 +1,127 @@
+"""Tests for implementation maturity, diagnostics and evidence states."""
+
+from __future__ import annotations
+
+import pytest
+
+from skdr_eval.evidence import (
+    DiagnosticState,
+    ESTIMATOR_VALIDATION_REGISTRY,
+    EstimatorMaturity,
+    EvidenceStatus,
+    can_support_estimate,
+    get_estimator_validation,
+    required_diagnostics_support_evidence,
+)
+from skdr_eval.exceptions import DataValidationError
+
+
+def test_initial_registry_keeps_dr_sndr_validation_pending() -> None:
+    assert get_estimator_validation("DR").maturity is EstimatorMaturity.VALIDATION_PENDING
+    assert (
+        get_estimator_validation("SNDR").maturity
+        is EstimatorMaturity.VALIDATION_PENDING
+    )
+
+
+def test_non_core_variants_start_experimental() -> None:
+    for name in ("MRDR", "SWITCH-DR", "DRos", "MIPS"):
+        assert get_estimator_validation(name).maturity is EstimatorMaturity.EXPERIMENTAL
+
+
+def test_registry_is_immutable() -> None:
+    with pytest.raises(TypeError):
+        ESTIMATOR_VALIDATION_REGISTRY["DR"] = get_estimator_validation("DR")  # type: ignore[index]
+
+
+def test_unknown_estimator_record_fails_closed() -> None:
+    with pytest.raises(DataValidationError, match="Unknown estimator"):
+        get_estimator_validation("made-up")
+
+
+def test_evidence_status_contains_no_deployment_authorization() -> None:
+    values = {state.value for state in EvidenceStatus}
+    assert values == {
+        "estimate_supported",
+        "inconclusive",
+        "insufficient_evidence",
+        "unsupported",
+        "invalid_evaluation",
+    }
+    forbidden = ("deploy", "online_test", "eligible")
+    for value in values:
+        assert not any(token in value for token in forbidden)
+
+
+def test_unknown_required_diagnostic_blocks_positive_evidence() -> None:
+    assert not required_diagnostics_support_evidence(
+        {"ess": DiagnosticState.PASS, "pareto_k": DiagnosticState.UNKNOWN}
+    )
+
+
+def test_failed_required_diagnostic_blocks_positive_evidence() -> None:
+    assert not required_diagnostics_support_evidence(
+        {"ess": "pass", "overlap": "fail"}
+    )
+
+
+def test_pass_and_not_applicable_diagnostics_can_satisfy_hard_gate() -> None:
+    assert required_diagnostics_support_evidence(
+        {"ess": DiagnosticState.PASS, "pareto_k": DiagnosticState.NOT_APPLICABLE}
+    )
+
+
+def test_missing_diagnostic_contract_does_not_pass() -> None:
+    assert not required_diagnostics_support_evidence({})
+
+
+def test_malformed_diagnostic_state_does_not_pass() -> None:
+    assert not required_diagnostics_support_evidence({"ess": "probably-fine"})
+
+
+def test_validation_pending_estimator_cannot_support_estimate() -> None:
+    assert not can_support_estimate(
+        get_estimator_validation("DR"),
+        {"overlap": "pass"},
+        inside_validation_envelope=True,
+    )
+
+
+def test_validated_implementation_is_necessary_but_not_sufficient() -> None:
+    record_type = type(get_estimator_validation("DR"))
+    validated = record_type(
+        name="DR-test",
+        maturity=EstimatorMaturity.REFERENCE_VALIDATED,
+        estimand="test estimand",
+        validation_report_id="validation-001",
+    )
+
+    assert can_support_estimate(
+        validated,
+        {"overlap": "pass", "ess": "pass"},
+        inside_validation_envelope=True,
+    )
+    assert not can_support_estimate(
+        validated,
+        {"overlap": "unknown", "ess": "pass"},
+        inside_validation_envelope=True,
+    )
+    assert not can_support_estimate(
+        validated,
+        {"overlap": "pass", "ess": "pass"},
+        inside_validation_envelope=False,
+    )
+
+
+def test_deprecated_estimator_never_qualifies_for_positive_evidence() -> None:
+    record_type = type(get_estimator_validation("DR"))
+    deprecated = record_type(
+        name="old",
+        maturity=EstimatorMaturity.DEPRECATED,
+        estimand="old estimand",
+    )
+    assert not can_support_estimate(
+        deprecated,
+        {"overlap": "pass"},
+        inside_validation_envelope=True,
+    )


### PR DESCRIPTION
## What

Adds the machine-readable contracts needed to replace the current deployment/experiment-eligibility recommendation model without changing existing report numerics yet:

- `EstimatorMaturity`: `experimental`, `validation_pending`, `reference_validated`, `independently_validated`, `deprecated`;
- `DiagnosticState`: `pass`, `fail`, `unknown`, `not_applicable`;
- `EvidenceStatus`: `estimate_supported`, `inconclusive`, `insufficient_evidence`, `unsupported`, `invalid_evaluation`;
- immutable initial standard-estimator registry:
  - DR/SNDR = `validation_pending`;
  - MRDR/SWITCH-DR/DRos/MIPS = `experimental`;
- hard invariant helpers proving:
  - a validated implementation is necessary but not sufficient for positive evidence;
  - `unknown` or `fail` required diagnostics cannot satisfy positive evidence;
  - being outside the declared validation envelope blocks positive evidence;
  - no evidence state contains deployment or online-experiment authorization semantics.

## Why this is intentionally additive

The existing `Recommendation` / card / CLI exit-code machinery still emits the pre-reset verdict vocabulary. Replacing it safely requires coordinated migration of artifact schema, historical fixtures, CLI, HTML/Markdown, and compatibility behavior (#205/#212).

This PR establishes the new source vocabulary and invariants first. #245/#259/#282 remain open until every public result surface consumes them.

## Statistical behavior

None on existing APIs yet; current recommendation/reporting logic does not import this module.