### PR TITLE
[Duplicate of merged #305] chore: stop advertising unimplemented tracker integrations

### DIFF
--- a/changelog.d/217.deprecated.md
+++ b/changelog.d/217.deprecated.md
@@ -1,0 +1,1 @@
+Stopped advertising MLflow, W&B, and Aim compatibility stubs as working runtime capabilities. The historical stub modules remain temporarily importable but now explain that installing their legacy extras does not enable an integration; use `NullTracker`, `FileTracker`, or a custom `Tracker` implementation instead.

--- a/src/skdr_eval/capabilities.py
+++ b/src/skdr_eval/capabilities.py
@@ -1,14 +1,13 @@
 """Runtime capability detection for skdr-eval optional extras.
 
-Provides a side-effect-free way to discover which optional dependency
-groups (``[viz]``, ``[speed]``) are installed, so callers and CI smoke
-checks can short-circuit gracefully when a feature requires an extra
-that was not installed.
+Provides a side-effect-free way to discover which optional dependency groups
+are installed, so callers and CI smoke checks can short-circuit gracefully
+when a *working* feature requires an extra that was not installed.
 
-The set of detected capabilities tracks the *truly* optional extras in
-``pyproject.toml``: ``viz`` (``matplotlib``) and ``speed`` (``pyarrow``
-+ ``polars``). ``scipy`` is a mandatory dependency, so condlogit
-propensity estimation is always available and is not listed here.
+Only implemented user-facing extras belong in the capability matrix. Historical
+MLflow / W&B / Aim extras exposed importable stubs that always raised
+``NotImplementedError``; they are deliberately no longer advertised as
+capabilities (#217).
 """
 
 from __future__ import annotations
@@ -17,31 +16,26 @@ import importlib.util
 from dataclasses import asdict, dataclass
 from typing import Any
 
-# Map of capability name -> list of module names whose presence enables it.
-# Capability is True iff *all* listed modules can be located.
+# Map of lightweight capability name -> modules whose presence enables it.
+# ``get_capabilities`` intentionally remains the small preflight surface used by
+# the core evaluator.
 _CAPABILITY_SPECS: dict[str, tuple[str, ...]] = {
     "viz": ("matplotlib",),
     "speed": ("pyarrow", "polars"),
 }
 
-# Reverse map for missing-extras reporting.
 _EXTRA_BY_CAPABILITY = {
     "viz": "viz",
     "speed": "speed",
 }
 
-# Full capability matrix (#215): every optional ``[extra]`` declared in
-# ``pyproject.toml``, the modules that enable it, and the user-facing feature it
-# unlocks. ``scipy`` is a mandatory dependency (conditional-logit propensities
-# are always available), so it is intentionally absent here.
+# Full matrix of *implemented* user-facing optional extras. Maintainer/dev/docs
+# extras are not runtime capabilities, and retired tracker stubs are excluded.
 _EXTRA_MODULES: dict[str, tuple[str, ...]] = {
     "viz": ("matplotlib",),
     "speed": ("pyarrow", "polars"),
     "cli": ("typer", "joblib", "pyarrow"),
     "boosting": ("xgboost", "lightgbm", "catboost"),
-    "mlflow": ("mlflow",),
-    "wandb": ("wandb",),
-    "aim": ("aim",),
 }
 
 _EXTRA_FEATURES: dict[str, str] = {
@@ -49,29 +43,26 @@ _EXTRA_FEATURES: dict[str, str] = {
     "speed": "Accelerated parquet/feather I/O via pyarrow + polars.",
     "cli": "The 'skdr-eval' command-line interface.",
     "boosting": "XGBoost / LightGBM / CatBoost model adapters.",
-    "mlflow": "MLflow experiment-tracker integration.",
-    "wandb": "Weights & Biases experiment-tracker integration.",
-    "aim": "Aim experiment-tracker integration.",
 }
 
 
 @dataclass(frozen=True)
 class Capability:
-    """One row of the optional-dependency capability matrix (#215).
+    """One implemented optional-dependency capability.
 
     Attributes
     ----------
     extra : str
-        The pip extra name (e.g. ``"viz"``), installable via
+        The pip extra name, installable via
         ``pip install 'skdr-eval[<extra>]'``.
     installed : bool
-        ``True`` iff *all* modules backing the extra can be located.
+        ``True`` iff all modules backing the implemented extra can be located.
     feature : str
         Human-readable description of what the extra unlocks.
     install_hint : str
         Copy-pasteable ``pip install`` command that enables the extra.
     modules : tuple[str, ...]
-        The import names probed to decide ``installed``.
+        Import names probed to decide ``installed``.
     """
 
     extra: str
@@ -92,23 +83,18 @@ def _module_available(name: str) -> bool:
 
 
 def get_capability_matrix() -> list[Capability]:
-    """Return the full optional-dependency capability matrix (#215).
+    """Return the implemented optional-dependency capability matrix.
 
-    Unlike :func:`get_capabilities` (which reports only the *truly optional*
-    feature toggles ``viz`` / ``speed``), this covers every pip extra declared
-    in ``pyproject.toml`` — including ``cli``, ``boosting`` and the experiment
-    trackers — so ``doctor`` and the ``skdr-eval capabilities`` command can show
-    users which features are available and how to unlock the rest.
+    Unlike :func:`get_capabilities` (which reports only the lightweight
+    ``viz`` / ``speed`` toggles used by evaluator preflight), this also covers
+    implemented CLI and boosting extras. It intentionally does **not** advertise
+    optional packages whose skdr-eval adapters are only non-working compatibility
+    stubs.
 
-    Detection is import-light: it only probes :func:`importlib.util.find_spec`
-    and never imports the heavy extras themselves.
-
-    Returns
-    -------
-    list[Capability]
-        One :class:`Capability` per extra, ordered as declared in
-        :data:`_EXTRA_MODULES`.
+    Detection is import-light: it probes :func:`importlib.util.find_spec` and
+    never imports heavy extras themselves.
     """
+
     matrix: list[Capability] = []
     for extra, modules in _EXTRA_MODULES.items():
         installed = all(_module_available(m) for m in modules)
@@ -125,32 +111,8 @@ def get_capability_matrix() -> list[Capability]:
 
 
 def get_capabilities() -> dict[str, bool | list[str]]:
-    """Return the set of optional capabilities available in this environment.
+    """Return lightweight optional capabilities available in this environment."""
 
-    The returned dict is suitable for preflight checks: a missing capability
-    means the matching ``pip install 'skdr-eval[<extra>]'`` invocation will
-    enable it.
-
-    Returns
-    -------
-    dict[str, bool | list[str]]
-        Keys:
-
-        - ``"viz"`` (bool): plotting helpers under ``skdr_eval.visualization``
-          (requires ``matplotlib``; install via ``pip install 'skdr-eval[viz]'``).
-        - ``"speed"`` (bool): accelerated I/O paths (requires ``pyarrow``
-          and ``polars``; install via ``pip install 'skdr-eval[speed]'``).
-        - ``"missing_extras"`` (list[str]): pip extras that, if installed,
-          would enable currently-disabled capabilities. Stable, sorted.
-
-    Examples
-    --------
-    >>> caps = get_capabilities()  # doctest: +SKIP
-    >>> caps["viz"]                 # doctest: +SKIP
-    True
-    >>> caps["missing_extras"]      # doctest: +SKIP
-    ['speed']
-    """
     result: dict[str, bool | list[str]] = {}
     missing: list[str] = []
 

--- a/src/skdr_eval/trackers/__init__.py
+++ b/src/skdr_eval/trackers/__init__.py
@@ -1,23 +1,21 @@
-"""Tracker protocol and built-in trackers (#93).
+"""Tracker protocol and working built-in trackers (#93 / #217).
 
-The :class:`Tracker` protocol defines the minimum surface
-(``log_metric`` / ``log_artifact`` / ``log_card`` / ``set_tag`` plus context
-management) that evaluators use to push results to disk or an external
-experiment tracker. The core ships:
+The :class:`Tracker` protocol defines the minimum surface evaluators use for
+optional result logging. The core-supported implementations are deliberately
+small:
 
 - :class:`NullTracker` — no-op default; used when ``tracker=None``.
 - :class:`FileTracker` — writes JSONL metrics and artifact files to a run
   directory.
 
-External adapters (MLflow / W&B / Aim) live in this package as separate
-modules gated behind their own optional extras (``[mlflow]``, ``[wandb]``,
-``[aim]``). They currently raise :class:`NotImplementedError` on
-construction — the umbrella issue #73 tracks each adapter's full
-implementation as a follow-up PR.
+Historical MLflow / W&B / Aim modules exposed importable classes that always
+raised ``NotImplementedError``. They are not working integrations and are no
+longer advertised as capabilities. Their compatibility modules are being retired
+under #217; users can implement the protocol directly if an external tracker is
+needed before real demand justifies an official adapter.
 
-This module has zero new mandatory dependencies. The ``FileTracker`` uses
-only the standard library and the existing ``pyyaml`` dep already shipped
-in core.
+This module has zero new mandatory dependencies. ``FileTracker`` uses only the
+standard library and the existing ``pyyaml`` dependency already shipped in core.
 """
 
 from __future__ import annotations
@@ -38,12 +36,11 @@ logger = logging.getLogger("skdr_eval")
 
 @runtime_checkable
 class Tracker(Protocol):
-    """Minimum surface for experiment trackers used by ``evaluate_*_models``.
+    """Minimum result-logging surface used by ``evaluate_*_models``.
 
-    Implementations must be safe to use as context managers. The
-    :class:`NullTracker` and :class:`FileTracker` ship in core; external
-    adapters (MLflow / W&B / Aim) live in sibling modules behind optional
-    extras.
+    Implementations must be safe to use as context managers. ``NullTracker``
+    and ``FileTracker`` are the supported built-ins; callers may provide their
+    own implementation for third-party systems.
     """
 
     def log_metric(self, name: str, value: float, step: int | None = None) -> None: ...
@@ -70,11 +67,7 @@ class NullTracker:
     Every method is a true no-op — calling any method (in any order) is
     guaranteed to have zero observable side effects on the filesystem or
     process state. The class is included in the public API so callers can
-    spell their intent explicitly:
-
-    >>> from skdr_eval.trackers import NullTracker
-    >>> tracker = NullTracker()
-    >>> tracker.log_metric("V_hat", 1.23)  # no-op
+    spell their intent explicitly.
     """
 
     def log_metric(self, name: str, value: float, step: int | None = None) -> None:
@@ -106,20 +99,15 @@ class FileTracker:
 
     Writes a run directory containing:
 
-    - ``metrics.jsonl`` — one JSON object per ``log_metric`` call,
-      append-only (includes a wall-clock timestamp per record).
-    - ``tags.json`` — flat dict of tags (written on every ``set_tag`` call).
-    - ``artifacts/`` — files copied from ``log_artifact`` (or sub-paths
-      under it when ``artifact_path`` is provided).
-    - ``cards/<model_name>_<estimator>.card.yaml`` — YAML dump of each
-      ``log_card`` payload.
+    - ``metrics.jsonl`` — one JSON object per ``log_metric`` call;
+    - ``tags.json`` — flat dict of tags;
+    - ``artifacts/`` — files copied from ``log_artifact``;
+    - ``cards/<model_name>_<estimator>.card.yaml`` — YAML evaluation cards.
 
     Parameters
     ----------
     root : str or Path
-        Output directory. Created if it does not exist. Each instance writes
-        all its records into this single directory; reuse a path across runs
-        only if you want the metrics to be concatenated.
+        Output directory. Created if it does not exist.
     """
 
     def __init__(self, root: str | Path) -> None:
@@ -159,8 +147,8 @@ class FileTracker:
         except ValueError:
             raise ValueError(
                 f"artifact_path {artifact_path!r} resolves outside the "
-                f"artifacts directory. Only relative, non-traversing paths "
-                f"are allowed."
+                "artifacts directory. Only relative, non-traversing paths "
+                "are allowed."
             ) from None
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(src.read_bytes())
@@ -189,8 +177,4 @@ class FileTracker:
         del exc_type, exc, tb
 
 
-__all__ = [
-    "FileTracker",
-    "NullTracker",
-    "Tracker",
-]
+__all__ = ["FileTracker", "NullTracker", "Tracker"]

--- a/src/skdr_eval/trackers/_stub.py
+++ b/src/skdr_eval/trackers/_stub.py
@@ -1,8 +1,9 @@
-"""Shared stub-class builder for external tracker adapters.
+"""Retired compatibility stubs for historical external tracker adapters.
 
-Used by :mod:`mlflow`, :mod:`wandb`, and :mod:`aim` adapter modules to expose
-importable classes that raise :class:`NotImplementedError` on construction
-until their full implementations land under umbrella issue #73.
+MLflow, W&B, and Aim classes were publicly importable but never implemented:
+construction always raised ``NotImplementedError``.  They remain temporarily
+importable only so old imports fail with an accurate migration message while
+#217 removes the misleading optional-integration surface.
 """
 
 from __future__ import annotations
@@ -11,13 +12,7 @@ from typing import Any
 
 
 def build_stub(package: str) -> type:
-    """Construct a stub tracker class that errors on instantiation.
-
-    The class name is ``<Package>Tracker`` (capitalized). The error message
-    references the matching ``pip install 'skdr-eval[<package>]'`` extra and
-    points at the umbrella issue.
-    """
-    install_hint = f"pip install 'skdr-eval[{package}]'"
+    """Construct a retired compatibility stub for an unimplemented adapter."""
 
     class _Stub:
         __slots__ = ()
@@ -25,16 +20,17 @@ def build_stub(package: str) -> type:
         def __init__(self, *args: Any, **kwargs: Any) -> None:
             del args, kwargs
             raise NotImplementedError(
-                f"The {package} tracker adapter is a stub. Install the optional "
-                f"extra ({install_hint}) and wait for the full adapter to ship "
-                f"under issue #73."
+                f"The {package} tracker adapter is not implemented and is no longer "
+                "advertised as a skdr-eval capability. The historical optional "
+                f"extra '[{package}]' does not enable a working adapter. Use "
+                "NullTracker/FileTracker or provide your own Tracker implementation. "
+                "See issue #217 for the compatibility cleanup."
             )
 
     _Stub.__name__ = f"{package.capitalize()}Tracker"
     _Stub.__qualname__ = _Stub.__name__
     _Stub.__doc__ = (
-        f"Stub for the {package} tracker adapter. "
-        f"Raises NotImplementedError on construction. "
-        f"Full implementation tracked by issue #73."
+        f"Retired compatibility stub for the unimplemented {package} adapter. "
+        "Use NullTracker/FileTracker or a custom Tracker implementation."
     )
     return _Stub

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -16,11 +16,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_documented_extras_are_declared_in_pyproject():
-    """#107: every 'pip install skdr-eval[<extra>]' in the README is a real extra.
-
-    Guards against doc/packaging drift such as the removed ``[choice]`` extra,
-    where the README advertised an install target that pip could not satisfy.
-    """
+    """#107: every 'pip install skdr-eval[<extra>]' in the README is a real extra."""
     readme = (_REPO_ROOT / "README.md").read_text(encoding="utf-8")
     pyproject = tomllib.loads(
         (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
@@ -43,7 +39,6 @@ def test_get_capabilities_schema():
     for key in ("viz", "speed"):
         assert key in caps
         assert isinstance(caps[key], bool)
-    # 'choice' is intentionally absent: scipy is a mandatory dep.
     assert "choice" not in caps
     assert "missing_extras" in caps
     assert isinstance(caps["missing_extras"], list)
@@ -96,29 +91,21 @@ def test_find_spec_value_error_treated_as_missing(monkeypatch):
 
 
 class TestCapabilityMatrix:
-    """#215: the full optional-dependency capability matrix."""
+    """The matrix lists implemented runtime features, not compatibility stubs."""
 
-    def test_matrix_covers_every_declared_extra(self):
+    def test_matrix_covers_implemented_feature_extras(self):
         pyproject = tomllib.loads(
             (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
         )
         declared = set(pyproject["project"]["optional-dependencies"])
-        # The matrix intentionally omits dev-only / docs / notebooks extras,
-        # but must cover every *runtime feature* extra.
-        feature_extras = {
-            "viz",
-            "speed",
-            "cli",
-            "boosting",
-            "mlflow",
-            "wandb",
-            "aim",
-        }
-        assert feature_extras <= declared, (
-            "matrix references extras not declared in pyproject.toml"
-        )
+        implemented_feature_extras = {"viz", "speed", "cli", "boosting"}
+        assert implemented_feature_extras <= declared
         matrix = skdr_eval.get_capability_matrix()
-        assert {c.extra for c in matrix} == feature_extras
+        assert {c.extra for c in matrix} == implemented_feature_extras
+
+    def test_retired_tracker_stubs_are_not_advertised_as_capabilities(self):
+        extras = {c.extra for c in skdr_eval.get_capability_matrix()}
+        assert extras.isdisjoint({"mlflow", "wandb", "aim"})
 
     def test_matrix_entries_are_well_formed(self):
         for cap in skdr_eval.get_capability_matrix():
@@ -129,7 +116,6 @@ class TestCapabilityMatrix:
             assert cap.to_dict()["extra"] == cap.extra
 
     def test_installed_reflects_module_presence(self, monkeypatch):
-        # Simulate an environment where only matplotlib (viz) is importable.
         def only_matplotlib(name):
             class _Spec:
                 pass
@@ -139,7 +125,5 @@ class TestCapabilityMatrix:
         monkeypatch.setattr(cap_module.importlib.util, "find_spec", only_matplotlib)
         by_extra = {c.extra: c for c in cap_module.get_capability_matrix()}
         assert by_extra["viz"].installed is True
-        # boosting needs all three of xgboost/lightgbm/catboost → absent.
         assert by_extra["boosting"].installed is False
-        # speed needs pyarrow AND polars → absent.
         assert by_extra["speed"].installed is False


### PR DESCRIPTION
## Closed as duplicate of merged PR #305

While this focused cleanup was being prepared, PR #305 landed a more complete implementation of #217 on `main`:

- retired MLflow/W&B/Aim as advertised capabilities;
- kept explicit deprecated compatibility shims;
- preserved the working Tracker/FileTracker/NullTracker surface;
- updated install/public docs;
- added focused tests;
- closed #217.

Keeping this branch open would create competing implementations and documentation drift. The branch is intentionally closed; #305 is canonical.