### PR TITLE
docs: expose explicit policy contract in public navigation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
       - Quickstart: getting-started/quickstart.md
   - Concepts:
       - Estimands & assumptions: concepts/estimands-and-assumptions.md
+      - Target policy contract: concepts/policy-contract.md
       - Methods (DR / SNDR): methods.md
       - Choosing an estimator: choosing-an-estimator.md
       - Metrics glossary: metrics-glossary.md


### PR DESCRIPTION
## Why

PR #307 added `docs/concepts/policy-contract.md`, but MkDocs uses an explicit navigation tree. This makes the new target-policy contract discoverable alongside estimands and methods.

## Change

Add **Target policy contract** to the Concepts navigation.

No runtime or statistical behavior changes.