### PR TITLE
fix: add canonical action-specific q_obs/q_pi contract (#58)

### DIFF
--- a/changelog.d/58.fixed.md
+++ b/changelog.d/58.fixed.md
@@ -1,0 +1,1 @@
+Added the corrected multi-action outcome-value contract requiring explicit `q_hat(x,a)` with distinct `q_obs` and `q_pi`, consuming target-policy probabilities through the canonical #279 policy validator rather than maintaining a second probability interpretation. The existing DR kernel is not yet migrated, so #58 remains open pending end-to-end correction and validation.

--- a/src/skdr_eval/estimand.py
+++ b/src/skdr_eval/estimand.py
@@ -24,6 +24,8 @@ import numpy as np
 from .exceptions import DataValidationError
 from .policy import validate_action_distribution
 
+_ACTION_VALUE_NDIM = 2
+
 
 @dataclass(frozen=True)
 class ActionValueTerms:
@@ -69,6 +71,11 @@ def compute_action_value_terms(
     This helper deliberately rejects one-dimensional outcome predictions. The
     corrected kernel must construct action-specific ``q_hat(x,a)`` explicitly
     rather than relying on numpy broadcasting.
+
+    Returned arrays are independent copies with NumPy's write flag disabled to
+    guard against accidental mutation. This is not a hard immutability or
+    security boundary: a caller holding an array can deliberately re-enable its
+    write flag.
     """
 
     action_tuple = tuple(actions)
@@ -80,7 +87,7 @@ def compute_action_value_terms(
     except (TypeError, ValueError) as exc:
         raise DataValidationError("q_by_action must be numeric") from exc
 
-    if q.ndim != 2:
+    if q.ndim != _ACTION_VALUE_NDIM:
         raise DataValidationError(
             "q_by_action must be a 2D (n_rows, n_actions) matrix; a 1-D q_hat "
             "cannot define q_pi for a multi-action validated evaluation"
@@ -135,7 +142,7 @@ def compute_action_value_terms(
             )
 
     q_obs = q[np.arange(n_rows), action_idx]
-    q_pi = np.sum(pi * q, axis=1)
+    q_pi = np.einsum("ij,ij->i", pi, q)
 
     q_stable = q.copy()
     q_obs_stable = q_obs.copy()

--- a/src/skdr_eval/estimand.py
+++ b/src/skdr_eval/estimand.py
@@ -1,0 +1,154 @@
+"""Action-specific outcome terms for the corrected multi-action DR estimand.
+
+For a finite-discrete target policy, doubly robust evaluation needs two distinct
+outcome-model quantities (#58):
+
+``q_obs[i] = q_hat(x_i, a_i)``
+    Prediction for the action actually observed in the log.
+
+``q_pi[i] = sum_a pi(a | x_i) * q_hat(x_i, a)``
+    Prediction averaged under the explicit target action distribution.
+
+A one-dimensional ``q_hat`` cannot generally represent both quantities. This
+module therefore requires an explicit ``(n_rows, n_actions)`` action-value
+matrix and consumes target probabilities through the canonical policy validator
+introduced by #279.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .exceptions import DataValidationError
+from .policy import validate_action_distribution
+
+
+@dataclass(frozen=True)
+class ActionValueTerms:
+    """Computed action-specific outcome terms for a validated action vocabulary."""
+
+    actions: tuple[str, ...]
+    q_by_action: np.ndarray
+    q_obs: np.ndarray
+    q_pi: np.ndarray
+
+
+def compute_action_value_terms(
+    q_by_action: np.ndarray,
+    policy_probabilities: np.ndarray,
+    observed_actions: np.ndarray,
+    *,
+    actions: list[str] | tuple[str, ...],
+    eligible_actions: np.ndarray | None = None,
+) -> ActionValueTerms:
+    """Compute ``q_obs`` and ``q_pi`` from action-specific predictions.
+
+    Parameters
+    ----------
+    q_by_action:
+        Outcome predictions ``q_hat(x_i, a)`` with exact shape
+        ``(n_rows, n_actions)``.
+    policy_probabilities:
+        Explicit target-policy probabilities. Validation is delegated to
+        :func:`skdr_eval.policy.validate_action_distribution`, keeping one
+        source of truth for action vocabulary, normalization, finiteness, and
+        eligibility semantics.
+    observed_actions:
+        Integer column indices into ``actions`` with shape ``(n_rows,)``.
+    actions:
+        Ordered action vocabulary shared by ``q_by_action`` and the target
+        policy matrix.
+    eligible_actions:
+        Optional boolean/0-1 eligibility matrix. In addition to the canonical
+        policy checks, the logged action itself must be eligible on every row.
+
+    Notes
+    -----
+    This helper deliberately rejects one-dimensional outcome predictions. The
+    corrected kernel must construct action-specific ``q_hat(x,a)`` explicitly
+    rather than relying on numpy broadcasting.
+    """
+
+    action_tuple = tuple(actions)
+    if not action_tuple:
+        raise DataValidationError("actions must contain at least one action")
+
+    try:
+        q = np.asarray(q_by_action, dtype=np.float64)
+    except (TypeError, ValueError) as exc:
+        raise DataValidationError("q_by_action must be numeric") from exc
+
+    if q.ndim != 2:
+        raise DataValidationError(
+            "q_by_action must be a 2D (n_rows, n_actions) matrix; a 1-D q_hat "
+            "cannot define q_pi for a multi-action validated evaluation"
+        )
+    n_rows, n_actions = q.shape
+    if n_actions != len(action_tuple):
+        raise DataValidationError(
+            "q_by_action columns must match the explicit action vocabulary: "
+            f"got {n_actions} columns for {len(action_tuple)} actions"
+        )
+    if not np.all(np.isfinite(q)):
+        bad = np.argwhere(~np.isfinite(q))[0]
+        raise DataValidationError(
+            "q_by_action must be finite; first invalid value at "
+            f"row={int(bad[0])}, action={action_tuple[int(bad[1])]!r}"
+        )
+
+    pi = validate_action_distribution(
+        policy_probabilities,
+        actions=action_tuple,
+        n_rows=n_rows,
+        eligible_actions=eligible_actions,
+    )
+
+    observed = np.asarray(observed_actions)
+    if observed.shape != (n_rows,):
+        raise DataValidationError(
+            f"observed_actions must have shape ({n_rows},); got {observed.shape}"
+        )
+    if not np.issubdtype(observed.dtype, np.integer):
+        raise DataValidationError("observed_actions must contain integer action indices")
+    action_idx = observed.astype(np.int64, copy=False)
+    invalid = (action_idx < 0) | (action_idx >= n_actions)
+    if np.any(invalid):
+        row = int(np.flatnonzero(invalid)[0])
+        raise DataValidationError(
+            f"observed action index out of bounds at row {row}: "
+            f"{int(action_idx[row])} not in [0, {n_actions})"
+        )
+
+    if eligible_actions is not None:
+        # ``validate_action_distribution`` has already validated shape and
+        # boolean/0-1 semantics, so this cast only supports the additional
+        # logged-action eligibility invariant.
+        elig = np.asarray(eligible_actions, dtype=bool)
+        logged_eligible = elig[np.arange(n_rows), action_idx]
+        if not np.all(logged_eligible):
+            row = int(np.flatnonzero(~logged_eligible)[0])
+            raise DataValidationError(
+                "observed action must be eligible on every evaluated row; "
+                f"row {row} action {action_tuple[int(action_idx[row])]!r} is not"
+            )
+
+    q_obs = q[np.arange(n_rows), action_idx]
+    q_pi = np.sum(pi * q, axis=1)
+
+    q_stable = q.copy()
+    q_obs_stable = q_obs.copy()
+    q_pi_stable = q_pi.copy()
+    for array in (q_stable, q_obs_stable, q_pi_stable):
+        array.setflags(write=False)
+
+    return ActionValueTerms(
+        actions=action_tuple,
+        q_by_action=q_stable,
+        q_obs=q_obs_stable,
+        q_pi=q_pi_stable,
+    )
+
+
+__all__ = ["ActionValueTerms", "compute_action_value_terms"]

--- a/src/skdr_eval/policy.py
+++ b/src/skdr_eval/policy.py
@@ -18,6 +18,8 @@ import numpy as np
 
 from .exceptions import DataValidationError
 
+_POLICY_PROBABILITY_NDIM = 2
+
 
 @runtime_checkable
 class Policy(Protocol):
@@ -93,7 +95,7 @@ def validate_action_distribution(
     except (TypeError, ValueError) as exc:
         raise DataValidationError("policy probabilities must be numeric") from exc
 
-    if probs.ndim != 2:
+    if probs.ndim != _POLICY_PROBABILITY_NDIM:
         raise DataValidationError(
             "policy probabilities must be a 2D (n_rows, n_actions) matrix"
         )

--- a/tests/test_estimand_contract.py
+++ b/tests/test_estimand_contract.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from skdr_eval.estimand import compute_action_value_terms
 from skdr_eval.exceptions import DataValidationError
+from skdr_eval.estimand import compute_action_value_terms
 
 
 ACTIONS = ("left", "right")

--- a/tests/test_estimand_contract.py
+++ b/tests/test_estimand_contract.py
@@ -1,0 +1,154 @@
+"""Tests for corrected multi-action q_obs / q_pi construction (#58)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from skdr_eval.estimand import compute_action_value_terms
+from skdr_eval.exceptions import DataValidationError
+
+
+ACTIONS = ("left", "right")
+
+
+def test_q_obs_and_q_pi_are_distinct_and_correct() -> None:
+    q = np.array(
+        [
+            [1.0, 10.0],
+            [2.0, 20.0],
+            [3.0, 30.0],
+        ]
+    )
+    pi = np.array(
+        [
+            [0.25, 0.75],
+            [1.0, 0.0],
+            [0.0, 1.0],
+        ]
+    )
+    observed = np.array([0, 1, 0], dtype=np.int64)
+
+    terms = compute_action_value_terms(
+        q,
+        pi,
+        observed,
+        actions=ACTIONS,
+    )
+
+    assert terms.actions == ACTIONS
+    np.testing.assert_allclose(terms.q_obs, np.array([1.0, 20.0, 3.0]))
+    np.testing.assert_allclose(
+        terms.q_pi,
+        np.array([0.25 * 1.0 + 0.75 * 10.0, 2.0, 30.0]),
+    )
+    assert terms.q_pi[0] != terms.q_obs[0]
+
+
+def test_one_dimensional_q_hat_is_rejected() -> None:
+    with pytest.raises(DataValidationError, match="1-D q_hat"):
+        compute_action_value_terms(
+            np.array([1.0, 2.0]),
+            np.array([[1.0, 0.0], [0.0, 1.0]]),
+            np.array([0, 1], dtype=np.int64),
+            actions=ACTIONS,
+        )
+
+
+def test_q_columns_must_match_explicit_action_vocabulary() -> None:
+    with pytest.raises(DataValidationError, match="action vocabulary"):
+        compute_action_value_terms(
+            np.ones((2, 3)),
+            np.ones((2, 3)) / 3,
+            np.array([0, 1], dtype=np.int64),
+            actions=ACTIONS,
+        )
+
+
+def test_policy_validation_uses_canonical_contract() -> None:
+    with pytest.raises(DataValidationError, match="sum to 1"):
+        compute_action_value_terms(
+            np.ones((1, 2)),
+            np.array([[0.4, 0.4]]),
+            np.array([0], dtype=np.int64),
+            actions=ACTIONS,
+        )
+    with pytest.raises(DataValidationError, match="non-negative"):
+        compute_action_value_terms(
+            np.ones((1, 2)),
+            np.array([[1.1, -0.1]]),
+            np.array([0], dtype=np.int64),
+            actions=ACTIONS,
+        )
+
+
+def test_observed_actions_must_be_integer_indices() -> None:
+    with pytest.raises(DataValidationError, match="integer"):
+        compute_action_value_terms(
+            np.ones((2, 2)),
+            np.ones((2, 2)) / 2,
+            np.array([0.0, 1.0]),
+            actions=ACTIONS,
+        )
+
+
+def test_observed_action_bounds_are_checked() -> None:
+    with pytest.raises(DataValidationError, match="out of bounds"):
+        compute_action_value_terms(
+            np.ones((2, 2)),
+            np.ones((2, 2)) / 2,
+            np.array([0, 2], dtype=np.int64),
+            actions=ACTIONS,
+        )
+
+
+def test_non_finite_action_values_fail_closed() -> None:
+    q = np.ones((2, 2))
+    q[1, 0] = np.nan
+    with pytest.raises(DataValidationError, match="finite"):
+        compute_action_value_terms(
+            q,
+            np.ones((2, 2)) / 2,
+            np.array([0, 1], dtype=np.int64),
+            actions=ACTIONS,
+        )
+
+
+def test_logged_action_must_be_eligible() -> None:
+    with pytest.raises(DataValidationError, match="observed action must be eligible"):
+        compute_action_value_terms(
+            np.array([[1.0, 2.0]]),
+            np.array([[0.0, 1.0]]),
+            np.array([0], dtype=np.int64),
+            actions=ACTIONS,
+            eligible_actions=np.array([[0, 1]]),
+        )
+
+
+def test_target_policy_mass_on_ineligible_action_is_rejected_by_policy_contract() -> None:
+    with pytest.raises(DataValidationError, match="ineligible"):
+        compute_action_value_terms(
+            np.array([[1.0, 2.0]]),
+            np.array([[0.5, 0.5]]),
+            np.array([0], dtype=np.int64),
+            actions=ACTIONS,
+            eligible_actions=np.array([[1, 0]]),
+        )
+
+
+def test_output_is_stable_after_input_mutation() -> None:
+    q = np.array([[1.0, 2.0]])
+    pi = np.array([[0.25, 0.75]])
+    terms = compute_action_value_terms(
+        q,
+        pi,
+        np.array([0], dtype=np.int64),
+        actions=ACTIONS,
+    )
+    q[0, 0] = 999.0
+    pi[0, 0] = 1.0
+    np.testing.assert_array_equal(terms.q_by_action, np.array([[1.0, 2.0]]))
+    assert terms.q_obs[0] == 1.0
+    assert terms.q_pi[0] == pytest.approx(1.75)
+    with pytest.raises(ValueError):
+        terms.q_pi[0] = 0.0

--- a/tests/test_estimand_contract.py
+++ b/tests/test_estimand_contract.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from skdr_eval.exceptions import DataValidationError
 from skdr_eval.estimand import compute_action_value_terms
+from skdr_eval.exceptions import DataValidationError
 
 
 ACTIONS = ("left", "right")

--- a/tests/test_estimand_contract.py
+++ b/tests/test_estimand_contract.py
@@ -45,6 +45,30 @@ def test_q_obs_and_q_pi_are_distinct_and_correct() -> None:
     assert terms.q_pi[0] != terms.q_obs[0]
 
 
+def test_two_action_dgp_recovers_known_target_value_and_rejects_old_broadcast_value() -> None:
+    """Simulation proof for the corrected target-policy outcome term (#58)."""
+    rng = np.random.default_rng(58)
+    n_rows = 50_000
+    context = rng.integers(0, 2, size=n_rows)
+
+    # Heterogeneous action values with E[q_left]=2 and E[q_right]=3.5.
+    q = np.column_stack((1.0 + 2.0 * context, 4.0 - context))
+
+    # Behavior strongly favors left; target strongly favors right.
+    observed = (rng.random(n_rows) < 0.15).astype(np.int64)
+    pi = np.tile(np.array([0.2, 0.8]), (n_rows, 1))
+
+    terms = compute_action_value_terms(q, pi, observed, actions=ACTIONS)
+
+    # V(pi) = 0.2 * 2 + 0.8 * 3.5 = 3.2.
+    assert float(np.mean(terms.q_pi)) == pytest.approx(3.2, abs=0.01)
+
+    # The old 1-D broadcast construction collapses q_pi to q_obs and therefore
+    # tracks the behavior-policy value instead of the target-policy value.
+    old_broadcast_value = float(np.mean(terms.q_obs))
+    assert abs(old_broadcast_value - 3.2) > 0.5
+
+
 def test_one_dimensional_q_hat_is_rejected() -> None:
     with pytest.raises(DataValidationError, match="1-D q_hat"):
         compute_action_value_terms(

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -227,12 +227,14 @@ class TestDeprecatedTrackerPlaceholders:
     def test_placeholder_is_explicitly_deprecated_and_unusable(
         self, tracker_cls, package
     ):
-        with pytest.warns(DeprecationWarning, match="deprecated compatibility"):
-            with pytest.raises(
+        with (
+            pytest.warns(DeprecationWarning, match="deprecated compatibility"),
+            pytest.raises(
                 NotImplementedError,
                 match=rf"does not provide a working {package} tracker integration",
-            ):
-                tracker_cls()
+            ),
+        ):
+            tracker_cls()
 
 
 class TestFileTrackerEdgeCases:


### PR DESCRIPTION
## What

Refreshes the #58 mathematical seam on current `main`, after canonical target-policy PR #307 merged.

- requires explicit `(n_rows, n_actions)` `q_hat(x,a)`;
- records the ordered action vocabulary used by both outcome and policy matrices;
- delegates target-policy shape/finiteness/non-negativity/normalization/eligibility validation to `skdr_eval.policy.validate_action_distribution(...)` — one semantic source of truth;
- computes `q_obs[i] = q_hat(x_i, A_i)` by logged-action indexing;
- computes `q_pi[i] = sum_a pi(a|x_i) q_hat(x_i,a)`;
- rejects 1-D `q_hat` instead of broadcasting it;
- additionally requires the observed/logged action itself to be eligible;
- copies/freezes computed arrays so validated terms do not drift after caller mutation.

Tests include a controlled case with `q_pi != q_obs`, action-vocabulary mismatch, canonical policy-validation failures, observed-action bounds/eligibility, non-finite q values, and immutability.

## Why #58 remains open

This PR establishes the corrected mathematical representation only. The historical DR/SNDR point-estimate and bootstrap/contribution paths still need to migrate from the 1-D `q_hat` shortcut, use the explicit target policy/logged propensity/evaluated-population contracts, and pass the known-ground-truth/reference/inferential validation gates.

## Statistical behavior

No existing evaluator changes yet; additive contract only.