### PR TITLE
ci: restore main lint baseline

### DIFF
--- a/src/skdr_eval/policy.py
+++ b/src/skdr_eval/policy.py
@@ -18,6 +18,8 @@ import numpy as np
 
 from .exceptions import DataValidationError
 
+_POLICY_PROBABILITY_NDIM = 2
+
 
 @runtime_checkable
 class Policy(Protocol):
@@ -93,7 +95,7 @@ def validate_action_distribution(
     except (TypeError, ValueError) as exc:
         raise DataValidationError("policy probabilities must be numeric") from exc
 
-    if probs.ndim != 2:
+    if probs.ndim != _POLICY_PROBABILITY_NDIM:
         raise DataValidationError(
             "policy probabilities must be a 2D (n_rows, n_actions) matrix"
         )

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from skdr_eval.exceptions import DataValidationError
 from skdr_eval.policy import (
     ExplicitPolicy,
     Policy,
     resolve_action_distribution,
     validate_action_distribution,
 )
+from skdr_eval.exceptions import DataValidationError
 
 
 ACTIONS = ("a", "b", "c")

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from skdr_eval.exceptions import DataValidationError
 from skdr_eval.policy import (
     ExplicitPolicy,
     Policy,
     resolve_action_distribution,
     validate_action_distribution,
 )
-from skdr_eval.exceptions import DataValidationError
 
 
 ACTIONS = ("a", "b", "c")

--- a/tests/test_trackers.py
+++ b/tests/test_trackers.py
@@ -227,12 +227,14 @@ class TestDeprecatedTrackerPlaceholders:
     def test_placeholder_is_explicitly_deprecated_and_unusable(
         self, tracker_cls, package
     ):
-        with pytest.warns(DeprecationWarning, match="deprecated compatibility"):
-            with pytest.raises(
+        with (
+            pytest.warns(DeprecationWarning, match="deprecated compatibility"),
+            pytest.raises(
                 NotImplementedError,
                 match=rf"does not provide a working {package} tracker integration",
-            ):
-                tracker_cls()
+            ),
+        ):
+            tracker_cls()
 
 
 class TestFileTrackerEdgeCases:


### PR DESCRIPTION
Repairs the three Ruff failures currently present on `main` without changing behavior: names the policy matrix dimension constant, normalizes policy-test imports, and combines nested pytest contexts. This is a prerequisite cleanup so active correctness PRs can be evaluated against a healthy baseline.